### PR TITLE
fix issue where deploy events are unable to be uploaded #27

### DIFF
--- a/grind.sh
+++ b/grind.sh
@@ -159,10 +159,13 @@ upload_deployment_events() {
 
   temp_json="$(mktemp "/tmp/deploy_events_XXXXXX").json"
 
-  if jq -e type | grep -q array; then
-    cat > "$temp_json"
+  #pull the passed in info into a variable to allow multi-step processing
+  temp_cache=$(cat)
+
+  if jq -e type <<< "$temp_cache" | grep -q array; then    
+    echo $temp_cache > "$temp_json"
   else
-    if ! jq -s . > "$temp_json"; then
+    if ! jq -s <<< "$temp_cache" > "$temp_json"; then
       stop_spinner
       echo "❌ Failed to convert input to JSON"
       rm -f "$temp_json"


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)
What did you change, and what additional context do reviewers need?

See issue #27 for context and thought process.  Contents are passed into grinder.sh via command line, multi-step processing would clear the events.  I added in a temp variable to hold the contents and let multiple steps process.  Otherwise it just hung.

**WHILE I THINK WE MOVE FORWARD PROVIDING REVIEWERS AGREE, WE NEED TO THINK ABOUT IF THERE IS ANY OPPORTUNITY TO PASS IN COMMANDS OR DATA THAT COULD POISON UPSTREAM.  I DON'T THINK THERE IS BUT I'M NERVOUS GIVEN UNCHECKED DATA GOING INTO VARIABLE --> FILE --> WASABI SERVER**


### 🧠 Rationale Behind Change(s)
Why were these changes made? What tradeoffs were considered?

Multi-step processing is needed and we needed to be able to pass in context over the command line to support using in tool support.  

### 📝 Test Plan
Beyond unit tests, how did you make sure this code is ready for production?

Exercised on a handful of various deploy event types.  

### 📜 Documentation
What documentation did you add or update? 
Was the documentation appropriate for the scope of this change?

### 💣 Quality Control
(All items must be checked before a PR is merged)
Did you…
- [X ] Mention an issue number in the PR title?
- [N/A ] Update the version # in the build file?
- [N/A ] Create new and/or update relevant existing tests?
- [X ] Create or update relevant documentation and/or diagrams?
- [X ] Comment your code?
- [ X] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved
