### PR TITLE
Dockerfile update to unlink ghcr.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ghcr.io/spice-labs-inc/goatrodeo:latest
 
 # Copy ginger binary directly from ginger image
-COPY --from=ghcr.io/spice-labs-inc/ginger:latest /usr/bin/ginger /usr/bin/ginger
+COPY --from=spicelabs/ginger:latest /usr/bin/ginger /usr/bin/ginger
 
 # Copy spicelabs.sh into the final image
 COPY ./spice-labs.sh /opt/spice-labs-cli/spice-labs.sh


### PR DESCRIPTION
Changed image location in Dockerfile for https://github.com/spice-labs-inc/internal-docs/issues/154

From: COPY --from=ghcr.io/spice-labs-inc/ginger:latest /usr/bin/ginger /usr/bin/ginger
To: COPY --from=spicelabs/ginger:latest /usr/bin/ginger /usr/bin/ginger