### PR TITLE
Added Syft to the CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ WORKDIR /opt/spice-labs-cli
 
 RUN mkdir -p /mnt/input /mnt/output
 
+COPY --from=anchore/syft:v1.30.0 /syft /usr/bin/local
 COPY ./target/spice-labs-cli-*-fat.jar ./spice-labs-cli.jar
 COPY spice ./spice
 COPY spice.ps1 ./spice.ps1
+
 
 ENTRYPOINT ["sh", "-c", "\
   JVM_ARGS=\"${SPICE_LABS_JVM_ARGS:--XX:MaxRAMPercentage=75}\" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /opt/spice-labs-cli
 
 RUN mkdir -p /mnt/input /mnt/output
 
-COPY --from=anchore/syft:v1.30.0 /syft /usr/bin/local
+COPY --from=anchore/syft:v1.30.0 /syft /usr/bin
 COPY ./target/spice-labs-cli-*-fat.jar ./spice-labs-cli.jar
 COPY spice ./spice
 COPY spice.ps1 ./spice.ps1

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.18</logback.version>
         <picocli.version>4.7.6</picocli.version>
-        <goatrodeo.version>0.8.12</goatrodeo.version>
+        <goatrodeo.version>0.9.0</goatrodeo.version>
         <ginger.version>0.1.4</ginger.version>
 <!--        Use these versions for local dev-->
 <!--        <goatrodeo.version>0.0.1-SNAPSHOT</goatrodeo.version>-->

--- a/src/main/java/io/spicelabs/cli/SpiceLabsCLI.java
+++ b/src/main/java/io/spicelabs/cli/SpiceLabsCLI.java
@@ -66,11 +66,17 @@ public class SpiceLabsCLI implements Callable<Integer> {
   @Option(names = "--threads", description = "Number of threads to use (default: 2)")
   int threads = 2;
 
+  @Option(names = "--use-syft", description = "Augment Goat Rodeo information with Syft")
+  boolean useSyft = true;
+
   @Option(names = "--max-records", description = "Max records to process per batch (default: 5000)")
   int maxRecords = 5000;
 
   @Option(names = "--tag", description = "Tag all top level artifacts (files) with the current date and the text of the tag")
   String tag;
+
+  @Option(names = "--tag-json", description = "Add JSON to any tags")
+  String tagJson;
 
   @Option(
       names = "--goat-rodeo-args",
@@ -221,10 +227,16 @@ public class SpiceLabsCLI implements Callable<Integer> {
           .withOutput(output.toString())
           .withThreads(threads)
           .withMaxRecords(maxRecords)
+          .withSyft(useSyft)
+         
           .withExtraArgs(goatRodeoArgs);
 
       if (tag != null && !tag.isBlank()) {
         builder.withTag(tag);
+      }
+
+      if (tagJson != null && !tagJson.isBlank()) {
+        builder.withTagJson(tagJson);
       }
 
       builder.run();


### PR DESCRIPTION
Added Syft support and a new version of Goat Rodeo to the CLI.

Syft augments the metadata for types that Syft knows about including Debian packages, Docker images, etc.

The new version of Goat Rodeo has support for JSON in tag data for arbitrary information about ADGed files.