### PR TITLE
Really fixed the script on Linux

### DIFF
--- a/spice
+++ b/spice
@@ -118,6 +118,7 @@ else
   fi
 
   exec docker run --rm \
+    --user $(id -u):$(id -g) \
     ${PULL_FLAG:+$PULL_FLAG} \
     ${VOLUMES+"${VOLUMES[@]}"} \
     -e SPICE_PASS \


### PR DESCRIPTION
Two changes:

* Catch the `exit` from awk in Linux so it doesn't propagate
* Added uid/gid to Docker invocation so root doesn't write
* 