### PR TITLE
move survey to its own workflow that runs after publish...

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -172,13 +172,6 @@ jobs:
             install.sh
             install.ps1
 
-      - name: Index and Upload ADG
-        uses: spice-labs-inc/action-spice-labs-surveyor@v4
-        with:
-          spice_pass: "${{ secrets.SPICE_PASS }}"
-          input: "./target"
-          tag: "${{ github.event.repository.name }}"
-
   docker_image:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest

--- a/.github/workflows/survey.yml
+++ b/.github/workflows/survey.yml
@@ -1,0 +1,152 @@
+name: Survey Published Release Artifacts
+
+on:
+  workflow_run:
+    workflows: ["Publish The Spice Labs Surveyor CLI Container Images"]
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to survey (e.g., v1.2.3 or 1.2.3)'
+        required: true
+        type: string
+
+jobs:
+  survey:
+    name: Survey Published Artifacts
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            INPUT_VERSION="${{ inputs.version }}"
+            if [[ "$INPUT_VERSION" =~ ^v?([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+              VERSION="${BASH_REMATCH[1]}"
+              TAG_NAME="v$VERSION"
+            else
+              echo "Invalid version format: $INPUT_VERSION"
+              exit 1
+            fi
+          else
+            TAG_NAME="${{ github.event.workflow_run.head_branch }}"
+            if [[ "$TAG_NAME" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+              VERSION="${BASH_REMATCH[1]}"
+            else
+              echo "Not a version tag, skipping survey"
+              exit 0
+            fi
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
+
+      - name: Create artifacts directory
+        run: mkdir -p artifacts/{maven,release,images}
+
+      - name: Download all Maven artifacts from GitHub Packages
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/packages/maven/io.spicelabs.spice-labs-cli/versions" \
+            --jq ".[] | select(.name == \"$VERSION\") | .id" > version_id.txt
+
+          if [ ! -s version_id.txt ]; then
+            echo "Version $VERSION not found in GitHub Packages"
+            exit 1
+          fi
+
+          VERSION_ID=$(cat version_id.txt)
+
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/packages/maven/io.spicelabs.spice-labs-cli/versions/$VERSION_ID" \
+            --jq '.metadata.container.tags[]' | while read -r file; do
+            echo "Downloading: $file"
+          done
+
+          BASE_URL="https://maven.pkg.github.com/${{ github.repository }}/io/spicelabs/spice-labs-cli/$VERSION"
+
+          for artifact in \
+            "spice-labs-cli-$VERSION.jar" \
+            "spice-labs-cli-$VERSION-fat.jar" \
+            "spice-labs-cli-$VERSION-sources.jar" \
+            "spice-labs-cli-$VERSION-javadoc.jar" \
+            "spice-labs-cli-$VERSION.pom" \
+            "spice-labs-cli-$VERSION.pom.asc" \
+            "spice-labs-cli-$VERSION.jar.asc" \
+            "spice-labs-cli-$VERSION-fat.jar.asc" \
+            "spice-labs-cli-$VERSION-sources.jar.asc" \
+            "spice-labs-cli-$VERSION-javadoc.jar.asc"
+          do
+            echo "Downloading $artifact..."
+            curl -fL -o "artifacts/maven/$artifact" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/octet-stream" \
+              "$BASE_URL/$artifact" || echo "  (not found, skipping)"
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download all files from GitHub Release
+        run: |
+          gh release download ${{ steps.version.outputs.tag }} \
+            --repo ${{ github.repository }} \
+            --dir artifacts/release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull and export all Docker image tags
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          for tag in $VERSION latest; do
+            echo "Pulling spicelabs/spice-labs-cli:$tag"
+            if docker pull spicelabs/spice-labs-cli:$tag 2>/dev/null; then
+              docker save spicelabs/spice-labs-cli:$tag -o artifacts/images/spice-labs-cli-$tag.tar
+            else
+              echo "  Tag $tag not found, skipping"
+            fi
+          done
+
+          MAJOR_MINOR=$(echo $VERSION | cut -d. -f1-2)
+          for tag in $MAJOR_MINOR; do
+            echo "Pulling spicelabs/spice-labs-cli:$tag"
+            if docker pull spicelabs/spice-labs-cli:$tag 2>/dev/null; then
+              docker save spicelabs/spice-labs-cli:$tag -o artifacts/images/spice-labs-cli-$tag.tar
+            else
+              echo "  Tag $tag not found, skipping"
+            fi
+          done
+
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          for tag in $MAJOR; do
+            echo "Pulling spicelabs/spice-labs-cli:$tag"
+            if docker pull spicelabs/spice-labs-cli:$tag 2>/dev/null; then
+              docker save spicelabs/spice-labs-cli:$tag -o artifacts/images/spice-labs-cli-$tag.tar
+            else
+              echo "  Tag $tag not found, skipping"
+            fi
+          done
+
+      - name: List all artifacts
+        run: |
+          echo "=== Artifacts to be surveyed ==="
+          find artifacts -type f -exec ls -lh {} \;
+          echo ""
+          echo "=== Total size ==="
+          du -sh artifacts
+
+      - name: Survey artifacts with Spice Labs Surveyor
+        uses: spice-labs-inc/action-spice-labs-surveyor@v4
+        with:
+          spice_pass: "${{ secrets.SPICE_PASS }}"
+          input: "./artifacts"
+          tag: "${{ github.event.repository.name }}"


### PR DESCRIPTION
and downloads the actual artifacts.  this decouples the survey from getting fixes to the cli released, which currently is a circular dependency

