### PR TITLE
trim SPICE_PASS before passing to Docker

### DIFF
--- a/spice.ps1
+++ b/spice.ps1
@@ -207,6 +207,12 @@ if ($env:SPICE_LABS_CLI_USE_JVM -eq "1") {
     }
   }
 
+  # Trim SPICE_PASS to remove any invisible characters (e.g. CRLF, BOM, trailing
+  # whitespace) that Windows may introduce when the value is stored via the
+  # Environment Variables GUI or registry. These are invisible in the UI but
+  # corrupt the Authorization header sent to the upload server.
+  $spicePass = if ($env:SPICE_PASS) { $env:SPICE_PASS.Trim() } else { "" }
+
   $envArgs = @()
   if ($env:SPICE_LABS_JVM_ARGS) {
     $envArgs += "-e"
@@ -230,7 +236,7 @@ if ($env:SPICE_LABS_CLI_USE_JVM -eq "1") {
     @dockerFlags `
     --network host `
     @volumes `
-    -e SPICE_PASS `
+    -e "SPICE_PASS=$spicePass" `
     @envArgs `
     "${img}:${tag}" `
     @modifiedArgs


### PR DESCRIPTION
# fix(spice.ps1): trim SPICE_PASS before passing to Docker

### Summary
Fixes a Windows-specific 401 upload failure caused by invisible characters in `SPICE_PASS`. When the token is stored via the Windows Environment Variables GUI or registry, it may contain trailing `\r\n`, BOM, or whitespace characters that are invisible in the UI. These survive local JWT decoding but corrupt the HTTP `Authorization` header sent to the upload server, resulting in a 401 response. The same token used on Linux uploads successfully. `SPICE_PASS` is now trimmed before being passed to the Docker container.

### Changes
- Added `.Trim()` on `$env:SPICE_PASS` before the Docker call, stored in `$spicePass`
- Changed `-e SPICE_PASS` (environment passthrough) to `-e "SPICE_PASS=$spicePass"` (explicit trimmed value)

### Tests
- Set `SPICE_PASS` permanently via `[System.Environment]::SetEnvironmentVariable("SPICE_PASS", "<token>", "User")`, closed and reopened PowerShell, ran full survey + upload — ✅ `status=queued`, `bundleId=31e82cc6-a6ff-4481-b595-c86a52ac81ce`, no 401
- Confirmed via direct Docker `upload-adgs` call with session-set `SPICE_PASS` — ✅ upload successful
- Debian 13 bash and PowerShell runs unaffected — ✅ continue to upload successfully
- Watch CI: `buildAndTest`

> **Note:** Root cause confirmed. The Windows registry stores the token with invisible trailing characters. `.Trim()` sanitises the value before it reaches the Docker `-e` flag, resolving the 401. Previously failing tests without a permanent variable were not a valid reproduction of the original bug condition.

### Impact
No breaking changes. Behaviour is identical when `SPICE_PASS` contains no trailing characters, which is the case for all Linux environments and Windows users who set the token programmatically without invisible padding.

### Ticket
https://github.com/spice-labs-inc/internal-docs/issues/502