### PR TITLE
correct PATH check for Linux and add $IsWindows compatibility

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,10 @@
 # To install : `irm -UseBasicParsing -Uri https://install.spicelabs.io | iex`
 
+# Compatibility shim for Windows PowerShell 5.1 where $IsWindows is not defined
+if (-not (Test-Path variable:IsWindows)) {
+    $IsWindows = $true
+}
+
 # Ensure USERPROFILE is set (for Linux compatibility)
 if (-not $env:USERPROFILE) {
     $env:USERPROFILE = $env:HOME
@@ -21,7 +26,7 @@ Set-Content -Path $ShimPath -Value "@echo off`npowershell -ExecutionPolicy Bypas
 # Add to PATH if not present
 # On Linux/macOS the PATH delimiter is ":" and paths use "/", on Windows it is ";" and "\"
 $pathDelimiter = if ($IsWindows) { ";" } else { ":" }
-$normalizedTarget = $TargetDir -replace "\\", "/"
+$normalizedTarget = if ($IsWindows) { $TargetDir } else { $TargetDir -replace "\\", "/" }
 
 if (-not ($env:PATH -split $pathDelimiter | Where-Object { $_ -eq $normalizedTarget })) {
     Write-Host "⚠️  $normalizedTarget is not in your PATH. Add it to your user environment variables:"


### PR DESCRIPTION
# fix(install.ps1): correct PATH check for Linux and add $IsWindows compatibility shim

### Summary
Fixes a false positive PATH warning on Linux when running `install.ps1` via `pwsh`, and a related forward-slash conversion issue on Windows PowerShell 5.1. The installer was splitting `$env:PATH` on `";"` (Windows delimiter) and comparing against a backslash-formatted path — both wrong on Linux. Additionally, `$IsWindows` is undefined in Windows PowerShell 5.1, causing the platform branch to fall through to the Linux path and incorrectly convert backslashes to forward slashes on Windows.

### Changes
- Added `$IsWindows` compatibility shim matching the one already present in `spice.ps1`
- Added `$pathDelimiter` using `$IsWindows` to select `";"` on Windows and `":"` on Linux/macOS
- Added `$normalizedTarget` which normalises path separators to forward slashes on Linux/macOS only, leaving Windows paths unchanged
- Updated the PATH check, warning message, and success message to use both new variables

### Tests
- Debian 13 · `pwsh` · `.spice/bin` already in PATH: ran `./install.ps1` — ✅ `spice installed and ready to use`
- Windows 11 · PowerShell · `.spice\bin` in User PATH via Environment Variables GUI: ran `.\install.ps1` — ✅ `spice installed and ready to use`
- Watch CI: `buildAndTest`

### Impact
No breaking changes. Installation behaviour, file placement, and shim creation are unchanged on all platforms. Only the PATH check comparison and output message are affected.

### Ticket
- https://github.com/spice-labs-inc/internal-docs/issues/503
