### PR TITLE
Warn on conflicting spice binary and advise prepend on Linux

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -31,8 +31,19 @@ $normalizedTarget = if ($IsWindows) { $TargetDir } else { $TargetDir -replace "\
 if (-not ($env:PATH -split $pathDelimiter | Where-Object { $_ -eq $normalizedTarget })) {
     Write-Host "⚠️  $normalizedTarget is not in your PATH. Add it to your user environment variables:"
     Write-Host "    $normalizedTarget"
+    if (-not $IsWindows) {
+        Write-Host "💡 On Linux/macOS, prepend it so spice.ps1 takes precedence over any existing spice binary:"
+        Write-Host "    `$env:PATH = `"$normalizedTarget`:`$env:PATH`""
+    }
 } else {
-    Write-Host "✅ spice installed and ready to use"
+    # Warn if a conflicting spice binary exists earlier in PATH than spice.ps1
+    $spiceCmd = Get-Command spice -ErrorAction SilentlyContinue
+    if ($spiceCmd -and $spiceCmd.Source -ne "$normalizedTarget/spice.ps1" -and $spiceCmd.Source -ne "$normalizedTarget\spice.ps1") {
+        Write-Host "⚠️  Another 'spice' binary was found at $($spiceCmd.Source) which may shadow spice.ps1."
+        Write-Host "    Ensure $normalizedTarget appears before $([System.IO.Path]::GetDirectoryName($spiceCmd.Source)) in your PATH."
+    } else {
+        Write-Host "✅ spice installed and ready to use"
+    }
 }
 
 if (-not $env:SPICE_PASS) {


### PR DESCRIPTION
# fix(install.ps1): warn on conflicting spice binary and advise prepend on Linux

### Summary
When `spice` is called unqualified from `pwsh` on Linux and `.local/bin` appears before `.spice/bin` in PATH, the bash wrapper at `.local/bin/spice` silently shadows `spice.ps1`. The installer gave no indication this could happen and no guidance on how to avoid it. This change adds a prepend hint when PATH needs updating on Linux, and a warning when a conflicting `spice` binary is detected ahead of the installed `spice.ps1`.

### Changes
- When `.spice/bin` is not in PATH on Linux/macOS, an additional hint is shown advising the user to prepend rather than append, so `spice.ps1` takes precedence over any existing `spice` binary
- When `.spice/bin` is already in PATH but a different `spice` binary is resolved by `Get-Command`, a warning is shown identifying the conflicting binary and advising PATH order correction

### Tests
- Debian 13 · `pwsh` · `.local/bin/spice` present and `.spice/bin` not yet in PATH: run `./install.ps1` — confirm prepend hint is shown
- Debian 13 · `pwsh` · `.local/bin` before `.spice/bin` in PATH: run `./install.ps1` — confirm shadowing warning is shown with the conflicting binary path
- Debian 13 · `pwsh` · `.spice/bin` first in PATH, no conflicting binary: run `./install.ps1` — confirm `✅ spice installed and ready to use`
- Windows 11 · PowerShell · `.spice\bin` in PATH: run `.\install.ps1` — confirm `✅ spice installed and ready to use`, no Linux hint shown
- Watch CI: `buildAndTest`

### Impact
No breaking changes. Installation behaviour and file placement are unchanged. The prepend hint and conflict warning are informational only.


### Ticket
- https://github.com/spice-labs-inc/internal-docs/issues/504
