### PR TITLE
spice survey inventory: usage disappears in wrapper?

### DIFF
--- a/src/test/java/io/spicelabs/cli/SpiceLabsCLITest.java
+++ b/src/test/java/io/spicelabs/cli/SpiceLabsCLITest.java
@@ -54,6 +54,16 @@ class SpiceLabsCLITest {
   }
 
   @Test
+  void surveyInventory_noargs_help() {
+    CommandLine cmd = new CommandLine(new SpiceLabsCLI());
+    int rc = cmd.execute("survey", "inventory");
+    // The PicoCLI test log shows a Usage message for spice survey inventory (yay!)
+    // but the spice command line does not (boo!)
+    // Is the wrapper swallowing extra output after the first error line?
+    assertEquals(2, rc);
+  }
+
+  @Test
   void surveyInventory_help() {
     CommandLine cmd = new CommandLine(new SpiceLabsCLI());
     int rc = cmd.execute("survey", "inventory", "--help");


### PR DESCRIPTION
Not for merging: this is "I see the usage message in the CLI tests, but I don't see it in the CLI."

Re: https://github.com/spice-labs-inc/internal-docs/issues/531 (better CLI help for spice survey inventory).

What do I see in the CLI? (Linux, version as shown)


---

The version of the CLI I have locally is:

```
$ spice -V
📦 Checking for updates to Spice Labs Surveyor CLI...
script version 4d0940431b7b229c20aff7942e01405f26e477c41ee91c1611b4f0e1993645a6
1.2.5
https://github.com/spice-labs-inc/spice-labs-cli git commit: 6e0a6cb36b84c9621702de1fd6aaff2560deb2cc
```

When I run "spice survey inventory", it gives an error message for missing arguments but omits the specific usage help. That's issue https://github.com/spice-labs-inc/internal-docs/issues/531 .

```
$ spice survey inventory
📦 Checking for updates to Spice Labs Surveyor CLI...
ERROR ❌ Missing required parameters: '<subject>', '<input>'
INFO  Use --help for usage information.
```

When I run "spice survey inventory" in the PicoCLI tests in the spice-lab-cli project, I see the same error message as the first line of the output, and a return code of "2", and also, logged to the test console, I see the specific usage help that internal-docs#531 is asking for, and which shows up when running "spice survey inventory --help".

```
$ spice survey inventory --help
📦 Checking for updates to Spice Labs Surveyor CLI...
Usage: spice survey inventory [-hV] [--no-upload] [--upload-only]
(...super detailed usage message follows)
```

The test in the draft PR demonstrates in the logged output that "spice survey inventory" produces a detailed usage message.

The PicoCLI code logging the usage message is the default parameter error handler.
(decompiled)
```
static void internalHandleParseException(ParameterException ex, PrintWriter writer, Help.ColorScheme colorScheme) {  
    writer.println(colorScheme.errorText(ex.getMessage()));  
    if (!CommandLine.UnmatchedArgumentException.printSuggestions(ex, writer)) {  
        ex.getCommandLine().usage(writer, colorScheme);  // HERE
    }  
```

However, that message does not reach the console when using the "spice" wrapper. Is the wrapper removing the usage message?

### Summary
- The CLI should give better help when run with "spice survey inventory"
- The Java CLI tests already log the better help with detailed usage (run the test-only PR code for an example)
- The Spice Labs CLI when run through the wrapper does not give the specific usage message.

Are we losing the detailed usage when there's an error code returned?