### PR TITLE
Add chunk-size to Runtime table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ spice pass decode
 | `--keep-recording` | Don't delete JFR recordings after upload | `false` |
 | `--output` | Directory for temporary files | `~/.spicelabs/runtime-survey/` |
 | `--log-level` | `debug` \| `info` \| `warn` \| `error` | `info` |
+| `--log-file` | Path to log file (output appended to both console and file) | _(none)_ |
 | `--chunk-size` | Target chunk size in MB for uploads | `64` |
 
 Flags can appear anywhere before the `--` separator.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ spice pass decode
 | `--keep-recording` | Don't delete JFR recordings after upload | `false` |
 | `--output` | Directory for temporary files | `~/.spicelabs/runtime-survey/` |
 | `--log-level` | `debug` \| `info` \| `warn` \| `error` | `info` |
-| `--log-file` | Path to log file | _(none)_ |
+| `--chunk-size` | Target chunk size in MB for uploads | `64` |
 
 Flags can appear anywhere before the `--` separator.
 


### PR DESCRIPTION
### Summary
Two changes were made, both in the Runtime Survey options table

### Changes
Added: `--chunk-size` this option is present in `SurveyRuntimeCommand` with an identical signature to the inventory command (Integer chunkSizeMB, default 64), but was missing from the table.

