### PR TITLE
Fix macOS install issues: bash 3.2 unbound arrays + zsh completion errors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,20 +25,31 @@ fi
 
 # ── Tab completion ───────────────────────────────────────────────────────────
 
-SOURCE_LINE="[ -f \"$COMPLETION_DIR/spice.bash\" ] && source \"$COMPLETION_DIR/spice.bash\""
+BASH_SOURCE_LINE="[ -f \"$COMPLETION_DIR/spice.bash\" ] && source \"$COMPLETION_DIR/spice.bash\""
+ZSH_SOURCE_BLOCK="autoload -U +X bashcompinit 2>/dev/null && bashcompinit 2>/dev/null
+[ -f \"$COMPLETION_DIR/spice.bash\" ] && source \"$COMPLETION_DIR/spice.bash\""
 COMPLETION_INSTALLED=0
 for rc in "${HOME}/.bashrc" "${HOME}/.zshrc"; do
   [ -f "$rc" ] || continue
-  if ! grep -qF "$COMPLETION_DIR/spice.bash" "$rc" 2>/dev/null; then
-    printf '\n# Spice CLI tab completion\n%s\n' "$SOURCE_LINE" >> "$rc"
-  fi
+  case "$rc" in
+    *.zshrc)
+      if ! grep -qF "bashcompinit" "$rc" 2>/dev/null || ! grep -qF "$COMPLETION_DIR/spice.bash" "$rc" 2>/dev/null; then
+        printf '\n# Spice CLI tab completion\n%s\n' "$ZSH_SOURCE_BLOCK" >> "$rc"
+      fi
+      ;;
+    *)
+      if ! grep -qF "$COMPLETION_DIR/spice.bash" "$rc" 2>/dev/null; then
+        printf '\n# Spice CLI tab completion\n%s\n' "$BASH_SOURCE_LINE" >> "$rc"
+      fi
+      ;;
+  esac
   COMPLETION_INSTALLED=1
 done
 if [ "$COMPLETION_INSTALLED" = "1" ]; then
   echo "✅ Tab completion installed (restart your shell or source your profile to activate)"
 else
   echo "💡 To enable tab completion, add this to your shell profile:"
-  echo "  $SOURCE_LINE"
+  echo "  $BASH_SOURCE_LINE"
 fi
 
 if [[ -z "${SPICE_PASS:-}" ]]; then

--- a/spice
+++ b/spice
@@ -100,7 +100,7 @@ if [ "${SPICE_LABS_CLI_USE_JVM:-0}" = "1" ]; then
     else FILTERED+=("$arg"); prev=""; fi
   done
   # shellcheck disable=SC2086
-  exec java $JVM_ARGS -jar "$SPICE_LABS_CLI_JAR" "${FILTERED[@]}"
+  exec java $JVM_ARGS -jar "$SPICE_LABS_CLI_JAR" ${FILTERED[@]+"${FILTERED[@]}"}
 fi
 
 # ── Docker checks ────────────────────────────────────────────────────────────
@@ -450,4 +450,4 @@ exec docker run --rm \
   -e SPICE_PASS \
   ${SPICE_LABS_JVM_ARGS:+-e SPICE_LABS_JVM_ARGS} \
   "${IMAGE}:${TAG}" \
-  "${DOCKER_ARGS[@]}"
+  ${DOCKER_ARGS[@]+"${DOCKER_ARGS[@]}"}


### PR DESCRIPTION
 ## Summary

Two unrelated macOS install bugs, both small and local:

  - **`spice`**: guard `"${DOCKER_ARGS[@]}"` and `"${FILTERED[@]}"` with `${ARR[@]+"${ARR[@]}"}`. Under `set -u`, stock macOS
  `/bin/bash` 3.2 treats an empty declared array as unbound and aborts every subcommand with `line 444: DOCKER_ARGS[@]: unbound
  variable`. Bash 4+ fixed this, so Linux/WSL/Homebrew-bash users never saw it. Matches the existing guard already used on `VOLUMES`
  two lines up.
  - **`install.sh`**: stop appending a raw `source .../spice.bash` line to `.zshrc`. The completion file uses
  `complete`/`compgen`/`COMPREPLY`, none of which exist in vanilla zsh, so every new zsh session printed `command not found:
  complete`. The installer now writes a zsh-specific block that runs `autoload -U +X bashcompinit && bashcompinit` before sourcing.
  `.bashrc` still gets the plain source line. The zsh idempotency check requires both `bashcompinit` and the completion path to be
  present, so re-running the installer repairs existing broken `.zshrc` files.

  `_init_completion` and `_filedir` still come from the bash-completion package, so zsh users without it will get partial completion.
   A native `_spice` zsh completion is the ideal follow-up but is out of scope here — this PR stops the shell-startup error and
  enables the completions that do work.