### PR TITLE
link probe events to loadedClasses by class gitoid

### DIFF
--- a/src/main/java/io/spicelabs/cli/JfrEventExtractor.java
+++ b/src/main/java/io/spicelabs/cli/JfrEventExtractor.java
@@ -67,7 +67,9 @@ public class JfrEventExtractor {
             String methodName,
             String probeLabel,
             long count,
-            List<CallSite> callSites
+            List<CallSite> callSites,
+            Integer classId,
+            List<Integer> callerClassIds
     ) {}
 
     public record SecurityProviderEvent(
@@ -101,7 +103,7 @@ public class JfrEventExtractor {
             boolean modified
     ) {}
 
-    public record CallSite(String location, String thread) {}
+    public record CallSite(String className, String location, String thread) {}
 
     /**
      * A class loaded at runtime, hashed identically to goatrodeo's inventory hashes so the two
@@ -138,6 +140,9 @@ public class JfrEventExtractor {
         long count;
         final List<CallSite> callSites = new ArrayList<>();
         final Set<String> seenSites = new LinkedHashSet<>();
+        // Phase 2 class linking: declaring-class gitoid (constant per probe) + caller-class gitoids.
+        String classGitoid;
+        final Set<String> callerGitoids = new LinkedHashSet<>();
 
         ProbeAccumulator(String eventType, String classFqn, String methodName, String probeLabel) {
             this.eventType = eventType;
@@ -146,10 +151,10 @@ public class JfrEventExtractor {
             this.probeLabel = probeLabel;
         }
 
-        void addCallSite(String location, String thread) {
+        void addCallSite(String className, String location, String thread) {
             String key = location + "|" + (thread != null ? thread : "");
             if (seenSites.add(key)) {
-                callSites.add(new CallSite(location, thread));
+                callSites.add(new CallSite(className, location, thread));
             }
         }
     }
@@ -166,10 +171,10 @@ public class JfrEventExtractor {
             this.serviceType = serviceType;
         }
 
-        void addCallSite(String location, String thread) {
+        void addCallSite(String className, String location, String thread) {
             String key = location + "|" + (thread != null ? thread : "");
             if (seenSites.add(key)) {
-                callSites.add(new CallSite(location, thread));
+                callSites.add(new CallSite(className, location, thread));
             }
         }
     }
@@ -341,8 +346,22 @@ public class JfrEventExtractor {
         RuntimeInfo runtime = new RuntimeInfo(
                 jvmVersion[0], jvmName[0], jvmVendor[0], javaVersion[0], os[0], pid[0]);
 
+        // Build loadedClasses first (with stable ids) + a gitoid -> id index for event linking.
+        List<LoadedClass> loadedClasses = new ArrayList<>(classLoadMap.size());
+        Map<String, Integer> gitoidToId = new LinkedHashMap<>();
+        int loadedClassId = 0;
+        for (LoadedClass lc : classLoadMap.values()) {
+            loadedClasses.add(new LoadedClass(loadedClassId, lc.className(), lc.classGitoid(),
+                    lc.classSha256(), lc.codeSource(), lc.jarGitoid(), lc.jarSha256()));
+            gitoidToId.put(lc.classGitoid(), loadedClassId);
+            loadedClassId++;
+        }
+
         List<ProbeEvent> probeEvents = probeMap.values().stream()
-                .map(a -> new ProbeEvent(a.eventType, a.classFqn, a.methodName, a.probeLabel, a.count, a.callSites))
+                .map(a -> new ProbeEvent(a.eventType, a.classFqn, a.methodName, a.probeLabel, a.count,
+                        a.callSites,
+                        gitoidToId.get(a.classGitoid),
+                        resolveClassIds(a.callerGitoids, gitoidToId)))
                 .toList();
 
         List<SecurityProviderEvent> secProvEvents = secProvMap.values().stream()
@@ -356,14 +375,6 @@ public class JfrEventExtractor {
 
         List<CertificateRecord> certificates = new ArrayList<>(certMap.values());
         List<SecurityProperty> securityProperties = new ArrayList<>(secPropMap.values());
-
-        // Assign stable per-survey ids at materialization (records are immutable, so rebuild).
-        List<LoadedClass> loadedClasses = new ArrayList<>(classLoadMap.size());
-        int loadedClassId = 0;
-        for (LoadedClass lc : classLoadMap.values()) {
-            loadedClasses.add(new LoadedClass(loadedClassId++, lc.className(), lc.classGitoid(),
-                    lc.classSha256(), lc.codeSource(), lc.jarGitoid(), lc.jarSha256()));
-        }
 
         log.info("Extracted: {} probe events, {} security provider events, {} TLS handshakes, {} certs, {} security properties, {} loaded classes from {} recording(s)",
                 probeEvents.size(), secProvEvents.size(), tlsHandshakes.size(),
@@ -427,6 +438,24 @@ public class JfrEventExtractor {
                 k -> new ProbeAccumulator(eventType, finalClassFqn, finalMethodName, label));
         acc.count++;
 
+        // Phase 2: declaring-class + caller gitoids stamped by the agent (absent on older agents).
+        if (event.hasField("classGitoid")) {
+            String classGitoid = event.getString("classGitoid");
+            if (classGitoid != null) {
+                acc.classGitoid = classGitoid;
+            }
+        }
+        if (event.hasField("callerGitoids")) {
+            String callers = event.getString("callerGitoids");
+            if (callers != null && !callers.isEmpty()) {
+                for (String g : callers.split("\n")) {
+                    if (!g.isEmpty()) {
+                        acc.callerGitoids.add(g);
+                    }
+                }
+            }
+        }
+
         // Add application-level call site (skip JDK/agent frames)
         if (st != null) {
             String thread = event.getThread() != null ? event.getThread().getJavaName() : null;
@@ -434,7 +463,7 @@ public class JfrEventExtractor {
                 String cn = frame.getMethod().getType().getName();
                 if (isApplicationCode(cn)) {
                     String site = cn + "." + frame.getMethod().getName() + "() line " + frame.getLineNumber();
-                    acc.addCallSite(site, thread);
+                    acc.addCallSite(cn, site, thread);
                     break;
                 }
             }
@@ -451,10 +480,25 @@ public class JfrEventExtractor {
             String cn = frame.getMethod().getType().getName();
             if (isApplicationCode(cn)) {
                 String site = cn + "." + frame.getMethod().getName() + "() line " + frame.getLineNumber();
-                acc.addCallSite(site, thread);
+                acc.addCallSite(cn, site, thread);
                 break;
             }
         }
+    }
+
+    /** Resolve a set of caller gitoids to compact loadedClasses ids, dropping any not present. */
+    private static List<Integer> resolveClassIds(Set<String> gitoids, Map<String, Integer> gitoidToId) {
+        if (gitoids == null || gitoids.isEmpty()) {
+            return List.of();
+        }
+        List<Integer> ids = new ArrayList<>();
+        for (String gitoid : gitoids) {
+            Integer id = gitoidToId.get(gitoid);
+            if (id != null) {
+                ids.add(id);
+            }
+        }
+        return ids;
     }
 
     static boolean isApplicationCode(String className) {

--- a/src/main/java/io/spicelabs/cli/JfrEventExtractor.java
+++ b/src/main/java/io/spicelabs/cli/JfrEventExtractor.java
@@ -140,7 +140,7 @@ public class JfrEventExtractor {
         long count;
         final List<CallSite> callSites = new ArrayList<>();
         final Set<String> seenSites = new LinkedHashSet<>();
-        // Phase 2 class linking: declaring-class gitoid (constant per probe) + caller-class gitoids.
+        // Class linking: declaring-class gitoid (constant per probe) + caller-class gitoids.
         String classGitoid;
         final Set<String> callerGitoids = new LinkedHashSet<>();
 
@@ -438,7 +438,7 @@ public class JfrEventExtractor {
                 k -> new ProbeAccumulator(eventType, finalClassFqn, finalMethodName, label));
         acc.count++;
 
-        // Phase 2: declaring-class + caller gitoids stamped by the agent (absent on older agents).
+        // Declaring-class + caller gitoids stamped by the agent (absent on older agents).
         if (event.hasField("classGitoid")) {
             String classGitoid = event.getString("classGitoid");
             if (classGitoid != null) {

--- a/src/test/java/io/spicelabs/cli/JfrEventExtractorTest.java
+++ b/src/test/java/io/spicelabs/cli/JfrEventExtractorTest.java
@@ -77,8 +77,8 @@ class JfrEventExtractorTest {
 
     @Test
     void callSite_deduplication() {
-        var cs1 = new JfrEventExtractor.CallSite("com.example.App.run() line 42", "main");
-        var cs2 = new JfrEventExtractor.CallSite("com.example.App.run() line 42", "main");
+        var cs1 = new JfrEventExtractor.CallSite("com.example.App", "com.example.App.run() line 42", "main");
+        var cs2 = new JfrEventExtractor.CallSite("com.example.App", "com.example.App.run() line 42", "main");
         assertEquals(cs1, cs2);
     }
 
@@ -330,6 +330,80 @@ class JfrEventExtractorTest {
             recording.stop();
             recording.dump(file);
         }
+    }
+
+    /** Mirrors a Phase 2 probe event: spice.probe.* with classGitoid + callerGitoids fields. */
+    @Name("spice.probe.testlink")
+    @Enabled(true)
+    @StackTrace(true)
+    static class SpiceProbeEvent extends Event {
+        String classGitoid;
+        String callerGitoids;
+    }
+
+    @Test
+    void extract_probeEvent_linksClassAndCallerToLoadedClasses() throws Exception {
+        Path jfrFile = tempDir.resolve("link.jfr");
+        try (Recording recording = new Recording()) {
+            recording.enable("spice.ClassLoaded");
+            recording.enable("spice.probe.testlink");
+            recording.start();
+
+            classLoaded(recording, "g-decl", "com.example.Probed");
+            classLoaded(recording, "g-caller", "com.example.Caller");
+
+            SpiceProbeEvent probe = new SpiceProbeEvent();
+            probe.classGitoid = "g-decl";
+            probe.callerGitoids = "g-caller";
+            probe.commit();
+
+            recording.stop();
+            recording.dump(jfrFile);
+        }
+
+        var data = JfrEventExtractor.extract("link-test", List.of(jfrFile));
+
+        int declId = idOf(data, "g-decl");
+        int callerId = idOf(data, "g-caller");
+        assertEquals(1, data.probeEvents().size());
+        var probe = data.probeEvents().get(0);
+        assertEquals(declId, probe.classId(), "classId must point to the declaring class");
+        assertTrue(probe.callerClassIds().contains(callerId),
+                "callerClassIds must include the caller's loadedClasses id");
+    }
+
+    @Test
+    void extract_probeEvent_withoutGitoids_hasNullClassIdAndEmptyCallers() throws Exception {
+        Path jfrFile = tempDir.resolve("nolink.jfr");
+        try (Recording recording = new Recording()) {
+            recording.enable("spice.probe.testlink");
+            recording.start();
+            SpiceProbeEvent probe = new SpiceProbeEvent(); // no gitoids set
+            probe.commit();
+            recording.stop();
+            recording.dump(jfrFile);
+        }
+
+        var data = JfrEventExtractor.extract("nolink-test", List.of(jfrFile));
+        assertEquals(1, data.probeEvents().size());
+        var probe = data.probeEvents().get(0);
+        assertNull(probe.classId(), "no classGitoid -> null classId");
+        assertTrue(probe.callerClassIds().isEmpty(), "no callerGitoids -> empty callerClassIds");
+    }
+
+    private static void classLoaded(Recording r, String gitoid, String className) {
+        SpiceClassLoadedEvent e = new SpiceClassLoadedEvent();
+        e.className = className;
+        e.classGitoid = gitoid;
+        e.classSha256 = "sha-" + gitoid;
+        e.codeSource = "file:/tmp/x.jar";
+        e.commit();
+    }
+
+    private static int idOf(JfrEventExtractor.RawSurveyData data, String gitoid) {
+        return data.loadedClasses().stream()
+                .filter(c -> gitoid.equals(c.classGitoid()))
+                .findFirst().orElseThrow().id();
     }
 
     @Test

--- a/src/test/java/io/spicelabs/cli/JfrEventExtractorTest.java
+++ b/src/test/java/io/spicelabs/cli/JfrEventExtractorTest.java
@@ -332,7 +332,7 @@ class JfrEventExtractorTest {
         }
     }
 
-    /** Mirrors a Phase 2 probe event: spice.probe.* with classGitoid + callerGitoids fields. */
+    /** Mirrors a probe event with class-linking fields: spice.probe.* with classGitoid + callerGitoids. */
     @Name("spice.probe.testlink")
     @Enabled(true)
     @StackTrace(true)


### PR DESCRIPTION
  Consume the declaring/caller class gitoids the agent now stamps on probe events and
  compact them to integer refs into loadedClasses, giving event -> class -> inventory
  linkage without a fragile class-name join.

  - ProbeEvent: add classId (declaring class) + callerClassIds; CallSite: add className.
  - processProbeEvent reads classGitoid/callerGitoids off the event via hasField, so recordings from older agents (without those fields) parse unchanged.
  - extract builds a gitoid -> loadedClasses-id index, then resolves each probe's declaring/caller gitoids to compact ids (dropping any not in loadedClasses).
