### PR TITLE
publish ANALYZE progress during surveys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.18</logback.version>
         <picocli.version>4.7.6</picocli.version>
-        <goatrodeo.version>0.15.2</goatrodeo.version>
-        <ginger.version>0.3.1</ginger.version>
+        <goatrodeo.version>0.15.5</goatrodeo.version>
+        <ginger.version>0.3.3</ginger.version>
         <ancho.version>0.0.5</ancho.version>
         <!--        Use these versions for local dev-->
         <!--        <goatrodeo.version>0.0.1-SNAPSHOT</goatrodeo.version>-->

--- a/src/main/java/io/spicelabs/cli/AnalyzeProgressPublisher.java
+++ b/src/main/java/io/spicelabs/cli/AnalyzeProgressPublisher.java
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors */
+
+package io.spicelabs.cli;
+
+import java.util.UUID;
+
+import io.spicelabs.goatrodeo.ProgressListener;
+
+/**
+ * Translates goat-rodeo's {@code (current, total)} ticks into RUNNING progress publishes
+ * against the ANALYZE sub-job daikon minted at {@code initSurvey}, so the dashboard's
+ * phase strip moves during long surveys.
+ *
+ * <p>Layout of the 0..100 band:
+ * <ul>
+ *   <li>0% — {@link #start()} fires once before goat-rodeo begins.</li>
+ *   <li>5..95% — {@code onProgress(current, total)} maps linearly into this range.</li>
+ *   <li>95% — {@link #building()} fires after goat-rodeo returns, while ginger-j wraps
+ *       the bundle.</li>
+ *   <li>100% / COMPLETED — {@link #complete()} fires when the wrap is done and UPLOAD is
+ *       about to take over.</li>
+ * </ul>
+ *
+ * <p>Throttling: emits on the first call, then only when the percent moves by at least 1%
+ * or 2 seconds have passed since the last emit. Goat-rodeo's per-run Notifier serializes
+ * onProgress calls so no extra locking is required for the throttle state.
+ */
+final class AnalyzeProgressPublisher implements ProgressListener {
+
+    /** What this publisher knows how to invoke. Real code passes {@code ginger::publishStatus}. */
+    @FunctionalInterface
+    interface StatusPublisher {
+        void publish(UUID subJobId, String status, Integer progress, String message);
+    }
+
+    private static final long MIN_INTERVAL_MS = 2000L;
+    private static final int MIN_PERCENT_DELTA = 1;
+    private static final int START_PERCENT = 5;
+    private static final int BUILDING_PERCENT = 95;
+    private static final int COMPLETE_PERCENT = 100;
+
+    private final StatusPublisher publisher;
+    private final UUID subJobId;
+
+    private long lastEmitMillis = 0L;
+    private int lastEmitPercent = -1;
+    private boolean terminated = false;
+
+    AnalyzeProgressPublisher(StatusPublisher publisher, UUID subJobId) {
+        this.publisher = publisher;
+        this.subJobId = subJobId;
+    }
+
+    /** Opening tick: RUNNING / 0 / "Analyzing source". */
+    void start() {
+        publishRunning(0, "Analyzing source");
+    }
+
+    @Override
+    public void onProgress(long current, long total) {
+        int percent;
+        if (total <= 0) {
+            percent = START_PERCENT;
+        } else {
+            double fraction = Math.min(1.0, (double) current / (double) total);
+            percent = START_PERCENT
+                    + (int) Math.floor(fraction * (BUILDING_PERCENT - START_PERCENT));
+            if (percent < START_PERCENT) percent = START_PERCENT;
+            if (percent > BUILDING_PERCENT) percent = BUILDING_PERCENT;
+        }
+        long now = System.currentTimeMillis();
+        boolean firstCall = lastEmitPercent < 0;
+        boolean percentMoved = (percent - lastEmitPercent) >= MIN_PERCENT_DELTA;
+        boolean intervalElapsed = (now - lastEmitMillis) >= MIN_INTERVAL_MS;
+        if (!firstCall && !percentMoved && !intervalElapsed) {
+            return;
+        }
+        publishRunning(percent, "Processing artifacts (" + current + "/" + total + ")");
+    }
+
+    /** Goat-rodeo returned; ginger-j is about to wrap the bundle. */
+    void building() {
+        publishRunning(BUILDING_PERCENT, "Building bundle");
+    }
+
+    /**
+     * Wrap done; ANALYZE is fully complete. Idempotent — wired into ginger-j's
+     * {@code afterBundleWrapped} hook, so a subsequent {@link #fail(String)} from an upload
+     * exception silently no-ops instead of trying to drag a finished sub-job backwards.
+     */
+    void complete() {
+        publishTerminal(COMPLETE_PERCENT, "COMPLETED", "Analysis complete");
+    }
+
+    /**
+     * Something blew up during analyze. Reports the last known percent. No-op once the
+     * sub-job has already reached a terminal state.
+     */
+    void fail(String reason) {
+        int percent = Math.max(0, lastEmitPercent);
+        publishTerminal(percent, "FAILED", "Analysis failed: " + reason);
+    }
+
+    private void publishRunning(int percent, String message) {
+        if (terminated) {
+            return;
+        }
+        lastEmitMillis = System.currentTimeMillis();
+        lastEmitPercent = percent;
+        publisher.publish(subJobId, "RUNNING", percent, message);
+    }
+
+    private void publishTerminal(int percent, String status, String message) {
+        if (terminated) {
+            return;
+        }
+        terminated = true;
+        lastEmitMillis = System.currentTimeMillis();
+        lastEmitPercent = percent;
+        publisher.publish(subJobId, status, percent, message);
+    }
+}

--- a/src/main/java/io/spicelabs/cli/JfrEventExtractor.java
+++ b/src/main/java/io/spicelabs/cli/JfrEventExtractor.java
@@ -190,10 +190,15 @@ public class JfrEventExtractor {
      * @return raw survey data ready for JSON serialization and upload
      */
     public static RawSurveyData extract(String subject, List<Path> recordingPaths) throws Exception {
-        return extract(subject, recordingPaths, null);
+        return extract(subject, recordingPaths, null, null);
     }
 
     public static RawSurveyData extract(String subject, List<Path> recordingPaths, Map<String, ProbeDefinition> probeIndex) throws Exception {
+        return extract(subject, recordingPaths, probeIndex, null);
+    }
+
+    public static RawSurveyData extract(String subject, List<Path> recordingPaths, Map<String, ProbeDefinition> probeIndex,
+                                        JfrProgressCallback progress) throws Exception {
         if (recordingPaths == null || recordingPaths.isEmpty()) {
             throw new IllegalArgumentException("No recording files provided");
         }
@@ -217,13 +222,35 @@ public class JfrEventExtractor {
         long totalDistinctEvents = 0;
         boolean truncated = false;
 
+        int totalRecordings = recordingPaths.size();
+        int recordingIndex = 0;
+        // Liveness ticks within a single recording — same (current, total), updated_at advances.
+        // Goat-rodeo uses the same rule (every 1k items or 30s); we use 1s here because
+        // JFR events stream much faster than goat-rodeo's per-artifact processing.
+        long eventsSinceTick = 0L;
+        long lastTickMillis = System.currentTimeMillis();
+        final long EVENT_TICK_INTERVAL = 1000L;
+        final long TIME_TICK_INTERVAL_MS = 1000L;
+        if (progress != null) {
+            progress.onProgress(0, totalRecordings);
+        }
+
         for (Path recording : recordingPaths) {
             recordingNames.add(recording.getFileName().toString());
-            log.info("Parsing recording: {}", recording.getFileName());
+            log.info("Parsing recording {} of {}: {}", recordingIndex + 1, totalRecordings, recording.getFileName());
 
             try (RecordingFile rf = new RecordingFile(recording)) {
                 while (rf.hasMoreEvents()) {
                     RecordedEvent event = rf.readEvent();
+                    if (progress != null) {
+                        eventsSinceTick++;
+                        long now = System.currentTimeMillis();
+                        if (eventsSinceTick >= EVENT_TICK_INTERVAL || (now - lastTickMillis) >= TIME_TICK_INTERVAL_MS) {
+                            progress.onProgress(recordingIndex, totalRecordings);
+                            eventsSinceTick = 0;
+                            lastTickMillis = now;
+                        }
+                    }
                     String eventType = event.getEventType().getName();
 
                     switch (eventType) {
@@ -340,6 +367,13 @@ public class JfrEventExtractor {
                 log.warn("⚠️  {} distinct events exceed cap of {}. Results may be truncated.",
                         totalDistinctEvents, MAX_DISTINCT_EVENTS);
                 truncated = true;
+            }
+
+            recordingIndex++;
+            if (progress != null) {
+                progress.onProgress(recordingIndex, totalRecordings);
+                eventsSinceTick = 0L;
+                lastTickMillis = System.currentTimeMillis();
             }
         }
 

--- a/src/main/java/io/spicelabs/cli/JfrProgressCallback.java
+++ b/src/main/java/io/spicelabs/cli/JfrProgressCallback.java
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors */
+
+package io.spicelabs.cli;
+
+/**
+ * Progress sink for the JFR parse pass. Mirrors the shape of goat-rodeo's
+ * {@code ProgressListener} without dragging the goat-rodeo dependency into
+ * {@link JfrEventExtractor} — runtime surveys don't use goat-rodeo.
+ *
+ * <p>{@code current} is the number of JFR recordings whose parse has finished; {@code total}
+ * is the number of recordings handed to {@link JfrEventExtractor#extract}. Liveness ticks
+ * within a single long recording fire with the same {@code current/total}, so callers that
+ * just want a "still working" pulse get one.
+ */
+@FunctionalInterface
+interface JfrProgressCallback {
+
+    void onProgress(long current, long total);
+}

--- a/src/main/java/io/spicelabs/cli/RuntimeCollect.java
+++ b/src/main/java/io/spicelabs/cli/RuntimeCollect.java
@@ -94,32 +94,79 @@ public class RuntimeCollect {
             log.debug("Loaded {} probe definitions", probeIndex.size());
         }
 
+        // Register the survey with the server before parsing so the dashboard sees the
+        // row up front, daikon mints the parent + ANALYZE sub-job, and the upload that
+        // follows can present the idempotency key the new /bundle/upload/init requires.
+        SurveyRegistration.Context survey = null;
+        AnalyzeProgressPublisher analyzeProgress = null;
+        String spicePass = null;
+        if (!noUpload) {
+            spicePass = System.getenv("SPICE_PASS");
+            if (spicePass == null || spicePass.isBlank()) {
+                log.error("SPICE_PASS not set");
+                System.exit(1);
+            }
+            log.info("Registering survey with Spice Labs...");
+            survey = SurveyRegistration.register(spicePass, "RUNTIME_SURVEY", subject, null);
+            log.info("Survey registered (submission time {})", survey.submissionTimestamp());
+            if (survey.analyzeSubJobId() != null) {
+                Ginger statusPublisher = Ginger.builder()
+                        .jwt(spicePass)
+                        .parentId(survey.parentId())
+                        .idempotencyKey(survey.idempotencyKey())
+                        .userAgent(survey.userAgent());
+                analyzeProgress = new AnalyzeProgressPublisher(
+                        statusPublisher::publishStatus, survey.analyzeSubJobId());
+                analyzeProgress.start();
+            }
+        }
+
         // Parse
         log.debug("Parsing JFR recordings...");
-        JfrEventExtractor.RawSurveyData data = JfrEventExtractor.extract(subject, recordings, probeIndex);
+        JfrEventExtractor.RawSurveyData data;
+        try {
+            JfrProgressCallback parseCallback = analyzeProgress == null
+                    ? null
+                    : analyzeProgress::onProgress;
+            data = JfrEventExtractor.extract(subject, recordings, probeIndex, parseCallback);
+        } catch (Exception e) {
+            if (analyzeProgress != null) {
+                analyzeProgress.fail(e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+            }
+            throw e;
+        }
 
         // Print summary
         new SurveyRuntimeCommand().printSummary(data);
 
         // Upload
         if (!noUpload) {
-            String spicePass = System.getenv("SPICE_PASS");
-            if (spicePass == null || spicePass.isBlank()) {
-                log.error("SPICE_PASS not set");
-                System.exit(1);
-            }
-
             Path jsonPath = dir.resolve("survey-data.json");
             ObjectMapper mapper = new ObjectMapper();
             mapper.enable(SerializationFeature.INDENT_OUTPUT);
             mapper.writeValue(jsonPath.toFile(), data);
 
             log.debug("Uploading survey results...");
-            Ginger.builder()
+            Ginger ginger = Ginger.builder()
                     .jwt(spicePass)
                     .runtimeSurveyFile(jsonPath)
                     .runtimeSubject(subject)
-                    .run();
+                    .parentId(survey.parentId())
+                    .submissionTimestamp(survey.submissionTimestamp())
+                    .idempotencyKey(survey.idempotencyKey())
+                    .userAgent(survey.userAgent());
+            if (analyzeProgress != null) {
+                analyzeProgress.building();
+                ginger.afterBundleWrapped(analyzeProgress::complete);
+            }
+            try {
+                ginger.run();
+            } catch (Exception e) {
+                if (analyzeProgress != null) {
+                    analyzeProgress.fail(e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+                }
+                throw e;
+            }
             log.debug("Upload complete.");
         } else {
             log.debug("--no-upload: remove to send results to Spice Labs for full categorization.");

--- a/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
@@ -235,13 +235,26 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
       survey = initSurvey(spicePass);
     }
 
+    // Progress publisher for the ANALYZE sub-job. Only wired when we ran a real initSurvey
+    // and daikon minted an analyzeSubJobId; the upload-only / no-upload paths skip it
+    // because no local analyze runs (upload-only) or no survey was registered (no-upload).
+    AnalyzeProgressPublisher analyzeProgress = null;
+    if (survey != null && survey.analyzeSubJobId() != null) {
+      Ginger statusPublisher = Ginger.builder()
+          .jwt(spicePass)
+          .parentId(survey.parentId())
+          .idempotencyKey(survey.idempotencyKey())
+          .userAgent(survey.userAgent());
+      analyzeProgress = new AnalyzeProgressPublisher(statusPublisher::publishStatus, survey.analyzeSubJobId());
+    }
+
     if (uploadOnly) {
-      doUpload(spicePass, Optional.of(input), survey);
+      doUpload(spicePass, Optional.of(input), survey, null);
     } else if (noUpload) {
-      doSurvey(null);
+      doSurvey(null, null);
     } else {
-      doSurvey(survey);
-      doUpload(spicePass, Optional.of(output), survey);
+      doSurvey(survey, analyzeProgress);
+      doUpload(spicePass, Optional.of(output), survey, analyzeProgress);
     }
   }
 
@@ -261,7 +274,8 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
     return survey;
   }
 
-  protected void doSurvey(SurveyRegistration.Context survey) throws Exception {
+  protected void doSurvey(SurveyRegistration.Context survey, AnalyzeProgressPublisher analyzeProgress)
+      throws Exception {
     log.info("📦 Surveying artifacts with GoatRodeo...");
 
     String originalScalaLevel = System.getProperty("scala.logging.level");
@@ -313,7 +327,19 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
         builder.withTagDate(survey.submissionTimestamp().toString());
       }
 
-      builder.run();
+      if (analyzeProgress != null) {
+        builder.withProgressListener(analyzeProgress);
+        analyzeProgress.start();
+      }
+
+      try {
+        builder.run();
+      } catch (Exception e) {
+        if (analyzeProgress != null) {
+          analyzeProgress.fail(e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+        }
+        throw e;
+      }
     } finally {
       if (singleFileDir != null) {
         deleteRecursively(singleFileDir);
@@ -328,7 +354,8 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
     }
   }
 
-  private void doUpload(String spicePass, Optional<Path> gingerInputDir, SurveyRegistration.Context survey) throws Exception {
+  private void doUpload(String spicePass, Optional<Path> gingerInputDir, SurveyRegistration.Context survey,
+      AnalyzeProgressPublisher analyzeProgress) throws Exception {
     log.info("📦 Uploading ADGs...");
 
     Map<String, String> gingerArgsMap = new HashMap<>(gingerArgs);
@@ -352,7 +379,18 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
     if (output != null)
       ginger.outputDir(output);
 
-    ginger.run();
+    if (analyzeProgress != null) {
+      analyzeProgress.building();
+      ginger.afterBundleWrapped(analyzeProgress::complete);
+    }
+    try {
+      ginger.run();
+    } catch (Exception e) {
+      if (analyzeProgress != null) {
+        analyzeProgress.fail(e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+      }
+      throw e;
+    }
   }
 
   private String resolveSpicePass() {

--- a/src/main/java/io/spicelabs/cli/SurveyRegistration.java
+++ b/src/main/java/io/spicelabs/cli/SurveyRegistration.java
@@ -16,8 +16,14 @@ import io.spicelabs.ginger.DirectUploadService;
  */
 final class SurveyRegistration {
 
-  /** Server-supplied survey identity and timestamp, threaded through survey + upload. */
-  record Context(UUID parentId, Instant submissionTimestamp, UUID idempotencyKey, String userAgent) {}
+  /**
+   * Server-supplied survey identity and timestamp, threaded through survey + upload.
+   * {@code analyzeSubJobId} is the sub-job daikon mints at {@code initSurvey} for the
+   * local analyze pass — progress publishes during goat-rodeo / JFR parsing target it.
+   * It may be {@code null} when running against an older daikon that doesn't mint it.
+   */
+  record Context(UUID parentId, Instant submissionTimestamp, UUID idempotencyKey, String userAgent,
+                 UUID analyzeSubJobId) {}
 
   private SurveyRegistration() {}
 
@@ -41,6 +47,7 @@ final class SurveyRegistration {
     if (submissionTimestamp == null) {
       throw new IllegalStateException("initSurvey response missing submission_timestamp");
     }
-    return new Context(response.parentId(), submissionTimestamp, idempotencyKey, userAgent);
+    return new Context(response.parentId(), submissionTimestamp, idempotencyKey, userAgent,
+        response.analyzeSubJobId());
   }
 }

--- a/src/main/java/io/spicelabs/cli/SurveyRuntimeCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyRuntimeCommand.java
@@ -231,27 +231,62 @@ public class SurveyRuntimeCommand implements Callable<Integer> {
                 log.warn("\u26A0\uFE0F  Total recording size exceeds 1GB. This may indicate excessive instrumentation.");
             }
 
-            // 8. Parse recordings
-            log.debug("Parsing JFR recordings...");
-            JfrEventExtractor.RawSurveyData data = JfrEventExtractor.extract(subject, recordings);
+            // 8. Register the survey with the server (so the dashboard sees the row before we
+            // start parsing) and build a progress publisher for the ANALYZE sub-job.
+            SurveyRegistration.Context survey = null;
+            AnalyzeProgressPublisher analyzeProgress = null;
+            if (!noUpload) {
+                log.info("Registering survey with Spice Labs...");
+                survey = SurveyRegistration.register(spicePass, "RUNTIME_SURVEY", subject, null);
+                log.info("Survey registered (submission time {})", survey.submissionTimestamp());
+                if (survey.analyzeSubJobId() != null) {
+                    Ginger statusPublisher = Ginger.builder()
+                            .jwt(spicePass)
+                            .parentId(survey.parentId())
+                            .idempotencyKey(survey.idempotencyKey())
+                            .userAgent(survey.userAgent());
+                    analyzeProgress = new AnalyzeProgressPublisher(statusPublisher::publishStatus, survey.analyzeSubJobId());
+                    analyzeProgress.start();
+                }
+            }
 
-            // 9. Print summary
+            // 9. Parse recordings
+            log.debug("Parsing JFR recordings...");
+            JfrEventExtractor.RawSurveyData data;
+            try {
+                JfrProgressCallback parseCallback = analyzeProgress == null
+                        ? null
+                        : analyzeProgress::onProgress;
+                data = JfrEventExtractor.extract(subject, recordings, null, parseCallback);
+            } catch (Exception e) {
+                if (analyzeProgress != null) {
+                    analyzeProgress.fail(e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+                }
+                throw e;
+            }
+
+            // 10. Print summary
             printSummary(data);
 
-            // 10. Upload or save locally
+            // 11. Upload or save locally
             if (!noUpload) {
                 Path jsonPath = tempDir.resolve("survey-data.json");
                 ObjectMapper mapper = new ObjectMapper();
                 mapper.enable(SerializationFeature.INDENT_OUTPUT);
                 mapper.writeValue(jsonPath.toFile(), data);
 
-                log.info("Registering survey with Spice Labs...");
-                SurveyRegistration.Context survey =
-                        SurveyRegistration.register(spicePass, "RUNTIME_SURVEY", subject, null);
-                log.info("Survey registered (submission time {})", survey.submissionTimestamp());
-
                 log.debug("Uploading survey results...");
-                doUpload(spicePass, jsonPath, survey);
+                if (analyzeProgress != null) {
+                    analyzeProgress.building();
+                }
+                try {
+                    doUpload(spicePass, jsonPath, survey, analyzeProgress);
+                } catch (Exception e) {
+                    if (analyzeProgress != null) {
+                        analyzeProgress.fail(e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+                    }
+                    throw e;
+                }
                 log.info("\u2705 Upload complete.");
             } else {
                 log.debug("--no-upload specified. Remove --no-upload to send results to Spice Labs for full categorization.");
@@ -424,7 +459,8 @@ public class SurveyRuntimeCommand implements Callable<Integer> {
 
     // ── Upload ──────────────────────────────────────────────────────────
 
-    private void doUpload(String spicePass, Path rawEventsJson, SurveyRegistration.Context survey) throws Exception {
+    private void doUpload(String spicePass, Path rawEventsJson, SurveyRegistration.Context survey,
+            AnalyzeProgressPublisher analyzeProgress) throws Exception {
         Map<String, String> gingerArgsMap = new HashMap<>();
         if (chunkSizeMB != null) {
             gingerArgsMap.put("--target-chunk-size", chunkSizeMB.toString());
@@ -440,6 +476,10 @@ public class SurveyRuntimeCommand implements Callable<Integer> {
                     .submissionTimestamp(survey.submissionTimestamp())
                     .idempotencyKey(survey.idempotencyKey())
                     .userAgent(survey.userAgent());
+        }
+
+        if (analyzeProgress != null) {
+            ginger.afterBundleWrapped(analyzeProgress::complete);
         }
 
         ginger.run();

--- a/src/test/java/io/spicelabs/cli/AnalyzeProgressPublisherTest.java
+++ b/src/test/java/io/spicelabs/cli/AnalyzeProgressPublisherTest.java
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors */
+
+package io.spicelabs.cli;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AnalyzeProgressPublisherTest {
+
+    private record Call(UUID subJobId, String status, Integer percent, String message) {}
+
+    private List<Call> calls;
+    private UUID subJobId;
+    private AnalyzeProgressPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        calls = new ArrayList<>();
+        subJobId = UUID.randomUUID();
+        publisher = new AnalyzeProgressPublisher(
+                (sid, status, percent, message) -> calls.add(new Call(sid, status, percent, message)),
+                subJobId);
+    }
+
+    @Test
+    void start_emitsOpeningTickAtZero() {
+        publisher.start();
+        assertEquals(1, calls.size());
+        assertEquals(new Call(subJobId, "RUNNING", 0, "Analyzing source"), calls.get(0));
+    }
+
+    @Test
+    void onProgress_mapsLinearlyIntoFiveToNinetyFive() {
+        publisher.onProgress(0, 100);
+        publisher.onProgress(50, 100);
+        publisher.onProgress(100, 100);
+
+        assertEquals(3, calls.size());
+        assertEquals(5, calls.get(0).percent());
+        assertEquals(50, calls.get(1).percent());
+        assertEquals(95, calls.get(2).percent());
+    }
+
+    @Test
+    void onProgress_dropsTicksWithinOnePercentAndUnderTwoSeconds() {
+        publisher.onProgress(0, 1000);   // first call → 5%
+        publisher.onProgress(1, 1000);   // still 5% → throttled
+        publisher.onProgress(5, 1000);   // still 5% → throttled
+        publisher.onProgress(12, 1000);  // 6% → passes the 1% delta gate
+
+        assertEquals(2, calls.size());
+        assertEquals(5, calls.get(0).percent());
+        assertEquals(6, calls.get(1).percent());
+    }
+
+    @Test
+    void onProgress_messageIncludesCurrentAndTotal() {
+        publisher.onProgress(7, 42);
+        assertEquals("Processing artifacts (7/42)", calls.get(0).message());
+    }
+
+    @Test
+    void complete_emitsCompletedTerminalAtOneHundred() {
+        publisher.complete();
+        assertEquals(new Call(subJobId, "COMPLETED", 100, "Analysis complete"), calls.get(0));
+    }
+
+    @Test
+    void fail_emitsFailedAtLastSeenPercent() {
+        publisher.onProgress(50, 100); // pushes lastPercent to 50%
+        publisher.fail("boom");
+
+        assertEquals(2, calls.size());
+        assertEquals(new Call(subJobId, "FAILED", 50, "Analysis failed: boom"), calls.get(1));
+    }
+
+    @Test
+    void fail_emitsZeroWhenNothingPublishedYet() {
+        publisher.fail("never started");
+        assertEquals(new Call(subJobId, "FAILED", 0, "Analysis failed: never started"), calls.get(0));
+    }
+
+    @Test
+    void building_pinsAtNinetyFive() {
+        publisher.building();
+        assertEquals(new Call(subJobId, "RUNNING", 95, "Building bundle"), calls.get(0));
+    }
+
+    @Test
+    void terminalCallsAreIdempotent() {
+        publisher.complete();
+        publisher.fail("late upload failure");
+        publisher.onProgress(50, 100);
+        publisher.complete();
+
+        assertEquals(1, calls.size(), "only the first terminal call should publish");
+        assertEquals("COMPLETED", calls.get(0).status());
+    }
+
+    @Test
+    void onProgress_handlesZeroTotalAsBaseline() {
+        // total=0 happens at the very start of a goat-rodeo run, before the filesystem walk
+        // completes.
+        publisher.onProgress(0, 0);
+        assertTrue(calls.size() >= 1);
+        assertEquals(5, calls.get(0).percent());
+    }
+}

--- a/src/test/java/io/spicelabs/cli/SurveyRegistrationTest.java
+++ b/src/test/java/io/spicelabs/cli/SurveyRegistrationTest.java
@@ -39,9 +39,12 @@ class SurveyRegistrationTest {
   @Test
   void register_postsToSurveys_andReturnsServerTimestamp() throws Exception {
     UUID parentId = UUID.randomUUID();
+    UUID analyzeSubJobId = UUID.randomUUID();
     server.enqueue(new MockResponse()
         .setResponseCode(201)
-        .setBody("{\"parent_id\":\"" + parentId + "\",\"submission_timestamp\":\"2026-05-20T12:00:00Z\"}"));
+        .setBody("{\"parent_id\":\"" + parentId
+            + "\",\"submission_timestamp\":\"2026-05-20T12:00:00Z\""
+            + ",\"analyze_sub_job_id\":\"" + analyzeSubJobId + "\"}"));
 
     // The pass's upload URL points at the mock server; ginger-j derives /surveys from it.
     String uploadServer = server.url("/api/v1/org/o/project/p/bundle/upload").toString();
@@ -51,6 +54,8 @@ class SurveyRegistrationTest {
         SurveyRegistration.register(pass, "INVENTORY_SURVEY", "my-subject", null);
 
     assertEquals(parentId, ctx.parentId());
+    assertEquals(analyzeSubJobId, ctx.analyzeSubJobId(),
+        "analyzeSubJobId must round-trip from initSurvey for ANALYZE progress publishes");
     assertEquals("2026-05-20T12:00:00Z", ctx.submissionTimestamp().toString(),
         "the bundle date must be the server value, verbatim");
     assertNotNull(ctx.idempotencyKey());


### PR DESCRIPTION
  Wires goat-rodeo's ProgressListener (inventory) and a callback on
  JfrEventExtractor.extract (runtime) to Ginger.publishStatus against
  the analyzeSubJobId daikon mints at initSurvey. Maps (current, total)
  into a 5..95% band with first-call / ≥1% / ≥2s throttling, brackets
  the work with RUNNING 0 / Analyzing source → 95 / Building bundle
  → COMPLETED 100, and emits FAILED at the last seen percent on
  exception.

  COMPLETED is wired through ginger-j's afterBundleWrapped hook so it
  fires at the actual wrap/upload boundary instead of after the whole
  ginger.run() returns. Terminal calls on AnalyzeProgressPublisher are
  idempotent, so an upload-side failure after the wrap completes won't
  try to drag a finished sub-job backwards.

  SurveyRegistration.Context carries analyzeSubJobId through;
  SurveyRuntimeCommand registers the survey before parsing so the row
  exists when the strip starts moving.
