### PR TITLE
pin runners to ubuntu-24.04 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   publish_jars:
     name: Publish CLI JARs to GitHub Packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       packages: write
@@ -176,7 +176,7 @@ jobs:
 
   docker_image:
     name: Build and Push Docker Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: publish_jars
     permissions:
       contents: read
@@ -290,7 +290,7 @@ jobs:
   notify:
     needs: [publish_jars, docker_image]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check deployment status
         id: deployment-status


### PR DESCRIPTION
### Summary

Updates the publish workflow to resolve Node.js 20 deprecation warnings on
GitHub Actions runners. All three unpinned `ubuntu-latest` runners have been
locked to `ubuntu-24.04` ahead of the June 16th enforcement date.
`buildAndTest.yml` required no changes — it was already fully up to date.

### Changes

- Pinned `runs-on` from `ubuntu-latest` to `ubuntu-24.04` on the `publish_jars`
  job in `publish.yml`
- Pinned `runs-on` from `ubuntu-latest` to `ubuntu-24.04` on the `docker_image`
  job in `publish.yml`
- Pinned `runs-on` from `ubuntu-latest` to `ubuntu-24.04` on the `notify` job
  in `publish.yml`

### Tests

- Publish a release with a semver tag (e.g. `v1.2.3`) and confirm all three
  jobs complete successfully:
  - `publish_jars`: JAR publish to GitHub Packages and Maven Central, GPG
    signing, and wrapper script upload to release
  - `docker_image`: multi-platform Docker build and push to Docker Hub,
    including fat JAR and ancho agent download, and pre-release flag handling
  - `notify`: correct Slack thread reply on both success and failure
- Push to any branch and confirm `buildAndTest.yml` continues to pass
  unchanged

### Impact

No change to build, test, or publish behaviour. `actions/checkout@v6` in both
`buildAndTest.yml` and `publish.yml` is already ahead of the current scope
target and has been left as-is. All other actions were already at correct
versions.

### Ticket

- https://github.com/spice-labs-inc/internal-docs/issues/509