### PR TITLE
Bump ginger-j to 0.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <logback.version>1.5.18</logback.version>
         <picocli.version>4.7.6</picocli.version>
         <goatrodeo.version>0.16.1</goatrodeo.version>
-        <ginger.version>0.3.3</ginger.version>
+        <ginger.version>0.4.0</ginger.version>
         <ancho.version>0.0.5</ancho.version>
         <coordinates.version>1.1.0</coordinates.version>
         <!--        Use these versions for local dev-->


### PR DESCRIPTION
Upgrades ginger-j from 0.3.3 to 0.4.0. Version-only change; picks up the static-survey payload support added in ginger-j 0.4.0.