### PR TITLE
Force US locale so CLI output is deterministic

### DIFF
--- a/src/main/java/io/spicelabs/cli/SpiceLabsCLI.java
+++ b/src/main/java/io/spicelabs/cli/SpiceLabsCLI.java
@@ -15,6 +15,8 @@ limitations under the License. */
 
 package io.spicelabs.cli;
 
+import java.util.Locale;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +56,9 @@ public class SpiceLabsCLI implements Runnable {
   private static final Logger log = LoggerFactory.getLogger(SpiceLabsCLI.class);
 
   public static void main(String[] args) {
+    // Force US locale so the CLI's output (number/size formatting, etc.) is
+    // deterministic regardless of the host's default locale.
+    Locale.setDefault(Locale.US);
     int exitCode;
     try {
       exitCode = newCommandLine().execute(args);

--- a/src/main/java/io/spicelabs/cli/SurveyRuntimeCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyRuntimeCommand.java
@@ -12,6 +12,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.stream.Stream;
@@ -611,9 +612,9 @@ public class SurveyRuntimeCommand implements Callable<Integer> {
 
     static String humanReadableSize(long bytes) {
         if (bytes < 1024) return bytes + " B";
-        if (bytes < 1024 * 1024) return String.format("%.1f KB", bytes / 1024.0);
-        if (bytes < 1024 * 1024 * 1024) return String.format("%.1f MB", bytes / (1024.0 * 1024));
-        return String.format("%.1f GB", bytes / (1024.0 * 1024 * 1024));
+        if (bytes < 1024 * 1024) return String.format(Locale.US, "%.1f KB", bytes / 1024.0);
+        if (bytes < 1024 * 1024 * 1024) return String.format(Locale.US, "%.1f MB", bytes / (1024.0 * 1024));
+        return String.format(Locale.US, "%.1f GB", bytes / (1024.0 * 1024 * 1024));
     }
 
     /**


### PR DESCRIPTION
Numeric/size formatting used the JVM default locale, so on a comma-decimal host the CLI printed e.g. `1,0 KB` instead of `1.0 KB`, and `SurveyRuntimeCommandTest.humanReadableSize_variousSizes` failed there.

- `Locale.setDefault(Locale.US)` at the start of `main()` — all CLI output is formatted in US locale regardless of the host.
- `humanReadableSize` formats with an explicit `Locale.US`, so it's deterministic even when called outside `main()` (e.g. from unit tests).

Verified: the previously-failing test now passes under a comma-decimal default locale with no override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)