### PR TITLE
Bump embedded ancho agent to 0.0.7 for JDK 25 instrumentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
              is published independently. ancho is versioned here (NOT in the BOM): it
              is injected via -javaagent, never on the CLI's own classpath. -->
         <spice-bom.version>1.0.0-SNAPSHOT</spice-bom.version>
-        <ancho.version>0.0.5</ancho.version>
+        <ancho.version>0.0.7</ancho.version>
         <!--        Use this version for local dev-->
         <!--        <ancho.version>0.0.1-SNAPSHOT</ancho.version> -->
         <junit.jupiter.version>5.13.1</junit.jupiter.version>


### PR DESCRIPTION
## Summary

Bump the embedded ancho agent from 0.0.5 to 0.0.7 so `spice survey runtime` can instrument JDK 25 targets.

ancho 0.0.5 bundles Byte Buddy 1.15.11, which cannot instrument class file 69 (Java 25). On a Java 25 target every probe fails silently and the survey drops all instrumented findings, leaving only native JCA events, so post-quantum algorithms disappear and PQC reports can show a false GREEN of 0. ancho 0.0.7 ships Byte Buddy 1.18.11 and instruments cleanly on JDK 8, 21, and 25.

## Change

- `ancho.version` 0.0.5 to 0.0.7.

ancho is javaagent-injected and versioned directly here, not in spice-bom, so no BOM change is needed. ancho 0.0.7 is published to GitHub Packages, which CI resolves via its repository override.
