### PR TITLE
Fix maven-settings auth: use ${env.VAR} and set GH_USERNAME/GH_TOKEN in deploy env

### DIFF
--- a/.github/actions/maven-settings/action.yml
+++ b/.github/actions/maven-settings/action.yml
@@ -50,33 +50,33 @@ runs:
           <servers>
             <server>
               <id>github-spice-labs-goatrodeo</id>
-              <username>\${GH_USERNAME}</username>
-              <password>\${GH_TOKEN}</password>
+              <username>\${env.GH_USERNAME}</username>
+              <password>\${env.GH_TOKEN}</password>
             </server>
             <server>
               <id>github-spice-labs-ginger</id>
-              <username>\${GH_USERNAME}</username>
-              <password>\${GH_TOKEN}</password>
+              <username>\${env.GH_USERNAME}</username>
+              <password>\${env.GH_TOKEN}</password>
             </server>
             <server>
               <id>github-spice-labs-bom</id>
-              <username>\${GH_USERNAME}</username>
-              <password>\${GH_TOKEN}</password>
+              <username>\${env.GH_USERNAME}</username>
+              <password>\${env.GH_TOKEN}</password>
             </server>
             <server>
               <id>github-spice-labs-plugin-api</id>
-              <username>\${GH_USERNAME}</username>
-              <password>\${GH_TOKEN}</password>
+              <username>\${env.GH_USERNAME}</username>
+              <password>\${env.GH_TOKEN}</password>
             </server>
             <server>
               <id>github</id>
-              <username>\${GH_USERNAME}</username>
-              <password>\${GH_TOKEN}</password>
+              <username>\${env.GH_USERNAME}</username>
+              <password>\${env.GH_TOKEN}</password>
             </server>
             <server>
               <id>central</id>
-              <username>\${MAVEN_CENTRAL_USERNAME}</username>
-              <password>\${MAVEN_CENTRAL_PASSWORD}</password>
+              <username>\${env.MAVEN_CENTRAL_USERNAME}</username>
+              <password>\${env.MAVEN_CENTRAL_PASSWORD}</password>
             </server>
           </servers>
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,14 +91,16 @@ jobs:
         id: build-jars-github
         run: mvn --batch-mode clean deploy -P github
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_USERNAME: ${{ secrets.GH_USERNAME_SG }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
 
       - name: Build and publish all jars to Maven Central
         id: build-jars-maven-central
         run: mvn --batch-mode clean deploy -P maven-central
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_USERNAME: ${{ secrets.GH_USERNAME_SG }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
 
       - name: Upload wrapper scripts and completions to GitHub Release
@@ -164,6 +166,8 @@ jobs:
             -Dmdep.stripClassifier=true \
             -Dmdep.overWriteIfNewer=true
         env:
+          GH_USERNAME: ${{ secrets.GH_USERNAME_SG }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Log in to Docker Hub


### PR DESCRIPTION
The composite action wrote ${GH_USERNAME} (property syntax) into settings.xml, but Maven resolves environment variables via ${env.VAR}, not ${VAR}. Without the env. prefix, the username/password resolved to empty properties -> 401 on deploy to GHP.

Two fixes:
- maven-settings/action.yml: change ${GH_USERNAME}/${GH_TOKEN}/ ${MAVEN_CENTRAL_USERNAME}/${MAVEN_CENTRAL_PASSWORD} to ${env.*} so Maven reads them from the environment.
- publish.yml: the deploy steps set GITHUB_TOKEN but not GH_USERNAME/GH_TOKEN. Add GH_USERNAME and GH_TOKEN to the env of both deploy steps and the docker_image job's ancho-download step so the settings.xml ${env.*} refs resolve at Maven invocation time.
