### PR TITLE
Add MAVEN_CENTRAL_USERNAME/PASSWORD to maven-central deploy env

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,6 +101,8 @@ jobs:
         env:
           GH_USERNAME: ${{ secrets.GH_USERNAME_SG }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
 
       - name: Upload wrapper scripts and completions to GitHub Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -215,12 +215,15 @@ jobs:
           push: true
           provenance: mode=max
           sbom: true
+          build-args: |
+            GH_TOKEN=${{ secrets.GH_TOKEN }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Resolve GHCR image tags and digests
         id: resolve-ghcr
         env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           RELEASE_SHA: ${{ github.sha }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           VERSION: ${{ needs.publish_jars.outputs.version }}
@@ -250,6 +253,7 @@ jobs:
             echo "No ${image}:${cur} found; building ${RELEASE_TAG} from source"
             docker buildx build \
               --platform "${PLATFORMS}" \
+              --build-arg GH_TOKEN="${GH_TOKEN}" \
               --tag "${image}:${RELEASE_TAG}" \
               --tag "${image}:latest" \
               --push \


### PR DESCRIPTION
The central-publishing-maven-plugin authenticates via the 'central' server in settings.xml, which the composite action writes as ${env.MAVEN_CENTRAL_USERNAME} / ${env.MAVEN_CENTRAL_PASSWORD}. The maven-central deploy step didn't set those env vars, so the Sonatype Central upload used empty credentials and the server rejected the bundle: 'Unable to upload bundle for deployment: Deployment'.
