### PR TITLE
Download released JARs in enterprise + federal retag jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -289,6 +289,41 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Write settings.xml for GitHub Packages
+        uses: ./.github/actions/maven-settings
+        with:
+          github-username: SpicyGrzl
+          github-token: ${{ secrets.GH_TOKEN }}
+          central-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          active-profile: github
+
+      - name: Download released fat jar and ancho agent
+        run: |
+          mkdir -p target
+          curl -fL -o target/spice-labs-cli-${{ needs.publish_jars.outputs.version }}-fat.jar \
+            -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
+            -H "Accept: application/octet-stream" \
+            "https://maven.pkg.github.com/spice-labs-inc/spice-labs-cli/io/spicelabs/spice-labs-cli/${{ needs.publish_jars.outputs.version }}/spice-labs-cli-${{ needs.publish_jars.outputs.version }}-fat.jar"
+          ANCHO_VERSION=$(mvn help:evaluate -Dexpression=ancho.version -q -DforceStdout)
+          mvn --batch-mode dependency:copy \
+            -Dartifact=io.spicelabs:ancho:${ANCHO_VERSION}:jar:fat \
+            -DoutputDirectory=target \
+            -Dmdep.stripVersion=true \
+            -Dmdep.stripClassifier=true \
+            -Dmdep.overWriteIfNewer=true
+        env:
+          GH_USERNAME: ${{ secrets.GH_USERNAME_SG }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -411,6 +446,41 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Write settings.xml for GitHub Packages
+        uses: ./.github/actions/maven-settings
+        with:
+          github-username: SpicyGrzl
+          github-token: ${{ secrets.GH_TOKEN }}
+          central-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          active-profile: github
+
+      - name: Download released fat jar and ancho agent
+        run: |
+          mkdir -p target
+          curl -fL -o target/spice-labs-cli-${{ needs.publish_jars.outputs.version }}-fat.jar \
+            -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
+            -H "Accept: application/octet-stream" \
+            "https://maven.pkg.github.com/spice-labs-inc/spice-labs-cli/io/spicelabs/spice-labs-cli/${{ needs.publish_jars.outputs.version }}/spice-labs-cli-${{ needs.publish_jars.outputs.version }}-fat.jar"
+          ANCHO_VERSION=$(mvn help:evaluate -Dexpression=ancho.version -q -DforceStdout)
+          mvn --batch-mode dependency:copy \
+            -Dartifact=io.spicelabs:ancho:${ANCHO_VERSION}:jar:fat \
+            -DoutputDirectory=target \
+            -Dmdep.stripVersion=true \
+            -Dmdep.stripClassifier=true \
+            -Dmdep.overWriteIfNewer=true
+        env:
+          GH_USERNAME: ${{ secrets.GH_USERNAME_SG }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
The enterprise and federal retag steps use Dockerfile.retag, which COPYs the released fat JAR + ancho from target/ into the base image. But those jobs never downloaded the JARs — only docker_image did. The build context had an empty target/ (transferring context: 2B), so COPY target/ancho.jar failed: not found.

Add JDK + maven-settings + the download-released-artifacts step to both build_enterprise and build_federal, mirroring docker_image.
