### PR TITLE
Use version (not tag name) for SPICE_TAG in enterprise/federal builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -255,7 +255,7 @@ jobs:
           sbom: true
           build-args: |
             SPICE_IMAGE=ghcr.io/${{ env.OWNER }}/spice-labs-cli
-            SPICE_TAG=${{ github.event.release.tag_name }}
+            SPICE_TAG=${{ needs.publish_jars.outputs.version }}
             ALLSPICE_IMAGE=${{ env.ALLSPICE_IMAGE }}
             ALLSPICE_TAG=${{ steps.allspice.outputs.allspice_tag }}
           tags: |
@@ -327,7 +327,7 @@ jobs:
           sbom: true
           build-args: |
             SPICE_IMAGE=ghcr.io/${{ env.OWNER }}/spice-labs-cli
-            SPICE_TAG=${{ github.event.release.tag_name }}
+            SPICE_TAG=${{ needs.publish_jars.outputs.version }}
             ALLSPICE_IMAGE=${{ env.ALLSPICE_IMAGE }}
             ALLSPICE_TAG=${{ steps.allspice.outputs.allspice_tag }}
           tags: |


### PR DESCRIPTION
docker/metadata-action tags the OSS image with the semver without the 'v' prefix (1.5.7), but the enterprise/federal jobs passed SPICE_TAG=v1.5.7 (the release tag name with 'v'). The FROM ${SPICE_IMAGE}:${SPICE_TAG} lookup failed: ghcr.io/.../spice-labs-cli:v1.5.7: not found. Use needs.publish_jars.outputs.version (1.5.7) instead.
