### PR TITLE
Copy spice plugin JARs (not the fat JAR) into plugins/

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,9 +179,9 @@ jobs:
   build-image-enterprise:
     name: Build and publish enterprise image
     needs: build-image-spice
-    # The enterprise image layers the spice wrapper onto the latest released
-    # allspice image, so it only needs the spice source (Dockerfile.enterprise
-    # + wrapper scripts), not the deps cache.
+    # The enterprise image layers the spice wrapper onto the allspice asset
+    # image (pinned by digest in Dockerfile.enterprise), so it only needs the
+    # spice source (Dockerfile.enterprise + wrapper scripts), not the deps cache.
     concurrency:
       group: build-image-${{ github.event.pull_request.number }}-enterprise
       cancel-in-progress: true
@@ -209,49 +209,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Resolve allspice base tag
-        id: allspice
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          set -euo pipefail
-          set -v
-          # If a manual override is provided via a repository variable, use it
-          # verbatim. Otherwise fall back to the latest semver image tag published
-          # to GHCR. PR-number cross-repo pairing is intentionally not supported
-          # because PR numbers are not deterministic across repositories.
-          # The tag MUST be multi-arch (amd64+arm64) because the enterprise
-          # image builds for both platforms via cross-compilation (no QEMU).
-          ALLSPICE="ghcr.io/${OWNER}/allspice"
-
-          try_candidate() {
-            local tag="$1"
-            [ -n "${tag}" ] || return 1
-            if docker manifest inspect "${ALLSPICE}:${tag}" >/dev/null 2>&1; then
-              archs=$(docker manifest inspect "${ALLSPICE}:${tag}" \
-                | jq -r '[.manifests[].platform.architecture] | sort | unique | join(",")' 2>/dev/null)
-              if echo "$archs" | grep -q amd64 && echo "$archs" | grep -q arm64; then
-                echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-                echo "Using allspice base: ${ALLSPICE}:${tag} (multi-arch: ${archs})"
-                exit 0
-              else
-                echo "Candidate ${tag} is not multi-arch: ${archs}" >&2
-                return 1
-              fi
-            fi
-            echo "Candidate not found: ${ALLSPICE}:${tag}"
-            return 1
-          }
-
-          latest_semver=$(gh api "/orgs/${OWNER}/packages/container/allspice/versions" --paginate \
-            --jq '[.[] | .metadata.container.tags[] | select(test("^v?[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort | last' 2>/dev/null)
-          echo "latest_semver=${latest_semver}"
-          try_candidate "${latest_semver}" || true
-
-          echo "No multi-arch allspice base image found" >&2
-          exit 1
-
       - name: Build and publish enterprise image
         uses: docker/build-push-action@v7
         with:
@@ -264,8 +221,6 @@ jobs:
           build-args: |
             SPICE_IMAGE=ghcr.io/${{ env.OWNER }}/spice-labs-cli
             SPICE_TAG=pr-${{ github.event.number }}
-            ALLSPICE_IMAGE=ghcr.io/${{ env.OWNER }}/allspice
-            ALLSPICE_TAG=${{ steps.allspice.outputs.tag }}
           tags: |
             ghcr.io/${{ env.OWNER }}/spice-labs-cli-enterprise:pr-${{ github.event.number }}
 
@@ -273,7 +228,8 @@ jobs:
     name: Build and publish federal image
     needs: build-image-spice
     # The federal image extends the enterprise image with report_cli and the
-    # rogues gallery for CBOM generation. Same allspice base as enterprise.
+    # rogues gallery for CBOM generation. Same allspice base as enterprise
+    # (pinned by digest in Dockerfile.federal).
     concurrency:
       group: build-image-${{ github.event.pull_request.number }}-federal
       cancel-in-progress: true
@@ -298,50 +254,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Resolve allspice base tag
-        id: allspice
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          set -euo pipefail
-          set -v
-          # If a manual override is provided via a repository variable, use it
-          # verbatim. Otherwise fall back to the latest semver image tag published
-          # to GHCR. PR-number cross-repo pairing is intentionally not supported
-          # because PR numbers are not deterministic across repositories.
-          # The tag MUST be multi-arch (amd64+arm64) because the federal
-          # image builds for both platforms via cross-compilation (no QEMU).
-          ALLSPICE="ghcr.io/${OWNER}/allspice"
-
-          try_candidate() {
-            local tag="$1"
-            [ -n "${tag}" ] || return 1
-            echo "Trying allspice base candidate: ${ALLSPICE}:${tag}"
-            if docker manifest inspect "${ALLSPICE}:${tag}" >/dev/null 2>&1; then
-              archs=$(docker manifest inspect "${ALLSPICE}:${tag}" \
-                | jq -r '[.manifests[].platform.architecture] | sort | unique | join(",")' 2>/dev/null)
-              if echo "$archs" | grep -q amd64 && echo "$archs" | grep -q arm64; then
-                echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-                echo "Using allspice base: ${ALLSPICE}:${tag} (multi-arch: ${archs})"
-                exit 0
-              else
-                echo "Candidate ${tag} is not multi-arch: ${archs}" >&2
-                return 1
-              fi
-            fi
-            echo "Candidate not found: ${ALLSPICE}:${tag}"
-            return 1
-          }
-
-          latest_semver=$(gh api "/orgs/${OWNER}/packages/container/allspice/versions" --paginate \
-            --jq '[.[] | .metadata.container.tags[] | select(test("^v?[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort | last' 2>/dev/null)
-          echo "latest_semver=${latest_semver}"
-          try_candidate "${latest_semver}" || true
-
-          echo "No multi-arch allspice base image found" >&2
-          exit 1
-
       - name: Build and publish federal image
         uses: docker/build-push-action@v7
         with:
@@ -354,8 +266,6 @@ jobs:
           build-args: |
             SPICE_IMAGE=ghcr.io/${{ env.OWNER }}/spice-labs-cli
             SPICE_TAG=pr-${{ github.event.number }}
-            ALLSPICE_IMAGE=ghcr.io/${{ env.OWNER }}/allspice
-            ALLSPICE_TAG=${{ steps.allspice.outputs.tag }}
           tags: |
             ghcr.io/${{ env.OWNER }}/spice-labs-cli-federal:pr-${{ github.event.number }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,6 @@ env:
   PUBLIC_DOCKER_IMAGE: spicelabs/spice-labs-cli
   ENTERPRISE_IMAGE: ghcr.io/spice-labs-inc/spice-labs-cli-enterprise
   FEDERAL_IMAGE: ghcr.io/spice-labs-inc/spice-labs-cli-federal
-  ALLSPICE_IMAGE: ghcr.io/spice-labs-inc/allspice
 
 jobs:
   publish_jars:
@@ -211,47 +210,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Resolve latest allspice image tag
-        id: allspice
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          # Resolve the latest allspice tag from the actual image tags published
-          # to GHCR. The tag MUST be multi-arch (amd64+arm64) because the
-          # enterprise/federal images build for both platforms via
-          # cross-compilation (no QEMU).
-          ALLSPICE="ghcr.io/${OWNER}/allspice"
-
-          try_candidate() {
-            local tag="$1"
-            [ -n "${tag}" ] || return 1
-            if docker manifest inspect "${ALLSPICE}:${tag}" >/dev/null 2>&1; then
-              archs=$(docker manifest inspect "${ALLSPICE}:${tag}" \
-                | jq -r '[.manifests[].platform.architecture] | sort | unique | join(",")' 2>/dev/null)
-              if echo "$archs" | grep -q amd64 && echo "$archs" | grep -q arm64; then
-                echo "allspice_tag=${tag}" >> "$GITHUB_OUTPUT"
-                echo "Using allspice image tag: ${tag} (multi-arch: ${archs})"
-                exit 0
-              else
-                echo "Candidate ${tag} is not multi-arch: ${archs}" >&2
-                return 1
-              fi
-            fi
-            return 1
-          }
-
-          latest_semver=$(gh api "/orgs/${OWNER}/packages/container/allspice/versions" --paginate \
-            --jq '[.[] | .metadata.container.tags[] | select(test("^v?[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort | last' 2>/dev/null)
-          echo "latest_semver=${latest_semver}"
-          try_candidate "${latest_semver}" || true
-
-          echo "No multi-arch allspice base image found" >&2
-          exit 1
-
       - name: Build and push enterprise image
         # FROM the just-released OSS image (SPICE_TAG=vX.Y.Z), which already
-        # carries the released fat JAR. Layers allspice's JAR on top.
+        # carries the released fat JAR. Layers allspice's plugins on top.
+        # The allspice base image is pinned by digest in Dockerfile.enterprise.
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -263,8 +225,6 @@ jobs:
           build-args: |
             SPICE_IMAGE=ghcr.io/${{ env.OWNER }}/spice-labs-cli
             SPICE_TAG=${{ needs.publish_jars.outputs.version }}
-            ALLSPICE_IMAGE=${{ env.ALLSPICE_IMAGE }}
-            ALLSPICE_TAG=${{ steps.allspice.outputs.allspice_tag }}
           tags: |
             ${{ env.ENTERPRISE_IMAGE }}:${{ github.event.release.tag_name }}
             ${{ env.ENTERPRISE_IMAGE }}:latest
@@ -294,44 +254,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Resolve latest allspice image tag
-        id: allspice
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          ALLSPICE="ghcr.io/${OWNER}/allspice"
-
-          try_candidate() {
-            local tag="$1"
-            [ -n "${tag}" ] || return 1
-            if docker manifest inspect "${ALLSPICE}:${tag}" >/dev/null 2>&1; then
-              archs=$(docker manifest inspect "${ALLSPICE}:${tag}" \
-                | jq -r '[.manifests[].platform.architecture] | sort | unique | join(",")' 2>/dev/null)
-              if echo "$archs" | grep -q amd64 && echo "$archs" | grep -q arm64; then
-                echo "allspice_tag=${tag}" >> "$GITHUB_OUTPUT"
-                echo "Using allspice image tag: ${tag} (multi-arch: ${archs})"
-                exit 0
-              else
-                echo "Candidate ${tag} is not multi-arch: ${archs}" >&2
-                return 1
-              fi
-            fi
-            return 1
-          }
-
-          latest_semver=$(gh api "/orgs/${OWNER}/packages/container/allspice/versions" --paginate \
-            --jq '[.[] | .metadata.container.tags[] | select(test("^v?[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort | last' 2>/dev/null)
-          echo "latest_semver=${latest_semver}"
-          try_candidate "${latest_semver}" || true
-
-          echo "No multi-arch allspice base image found" >&2
-          exit 1
-
       - name: Build and push federal image
         # FROM the just-released OSS image (SPICE_TAG=vX.Y.Z), which already
         # carries the released fat JAR. Extends the enterprise image with
-        # report_cli and rogues_gallery for CBOM generation.
+        # report_cli and rogues_gallery for CBOM generation. The allspice base
+        # image is pinned by digest in Dockerfile.federal.
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -343,8 +270,6 @@ jobs:
           build-args: |
             SPICE_IMAGE=ghcr.io/${{ env.OWNER }}/spice-labs-cli
             SPICE_TAG=${{ needs.publish_jars.outputs.version }}
-            ALLSPICE_IMAGE=${{ env.ALLSPICE_IMAGE }}
-            ALLSPICE_TAG=${{ steps.allspice.outputs.allspice_tag }}
           tags: |
             ${{ env.FEDERAL_IMAGE }}:${{ github.event.release.tag_name }}
             ${{ env.FEDERAL_IMAGE }}:latest

--- a/Dockerfile.enterprise
+++ b/Dockerfile.enterprise
@@ -22,22 +22,25 @@
 
 # Global build args (available to FROM instructions). Declared before the
 # first FROM so both stages can use them.
+#
+# ALLSPICE_REF pins the allspice asset image by digest so the build is
+# reproducible. Update this reference (and the tag in the comment) to pull in
+# a new allspice release.
+ARG ALLSPICE_REF=ghcr.io/spice-labs-inc/allspice:v1.1.4@sha256:739626616f9871f8929c9d02ae2d6022f22d1f1d56a717e256445602ca754944
 ARG SPICE_IMAGE=spicelabs/spice-labs-cli
 ARG SPICE_TAG=latest
-ARG ALLSPICE_IMAGE=ghcr.io/spice-labs-inc/allspice
-ARG ALLSPICE_TAG=latest
 
 # Stage 1: pull the allspice image to extract its proprietary assets.
-FROM ${ALLSPICE_IMAGE}:${ALLSPICE_TAG} AS allspice
+FROM ${ALLSPICE_REF} AS allspice
 
 # Stage 2: start from the spice-labs-cli OSS image and add allspice's JAR.
 FROM ${SPICE_IMAGE}:${SPICE_TAG}
 
-# Copy only the allspice fat JAR (contains allspice + sassafras + transitive deps).
-# report_cli and rogues_gallery are NOT included — those are federal-only.
-# Drop the fat JAR into plugins/ so ServiceLoader discovers the spice-plugin
-# SPI (registry, survey static) on the classpath.
-COPY --from=allspice /opt/allspice/allspice.jar /opt/spice-labs-cli/plugins/allspice.jar
+# Copy the spice plugin JARs (SpiceCommandPlugin SPI + allspice module
+# classes) into plugins/ so ServiceLoader discovers the registry + survey
+# static commands. The allspice fat JAR stays at /opt/allspice/allspice.jar
+# as a classpath resource; only the plugin dist JARs go into plugins/.
+COPY --from=allspice /opt/allspice/plugins/ /opt/spice-labs-cli/plugins/
 
 # The spice entrypoint and wrapper scripts are already in the OSS image.
 # No changes needed — the CLI is the same; allspice is available as a resource.

--- a/Dockerfile.federal
+++ b/Dockerfile.federal
@@ -14,13 +14,16 @@
 
 # Global build args (available to FROM instructions). Declared before the
 # first FROM so both stages can use them.
+#
+# ALLSPICE_REF pins the allspice asset image by digest so the build is
+# reproducible. Update this reference (and the tag in the comment) to pull in
+# a new allspice release.
+ARG ALLSPICE_REF=ghcr.io/spice-labs-inc/allspice:v1.1.4@sha256:739626616f9871f8929c9d02ae2d6022f22d1f1d56a717e256445602ca754944
 ARG SPICE_IMAGE=spicelabs/spice-labs-cli
 ARG SPICE_TAG=latest
-ARG ALLSPICE_IMAGE=ghcr.io/spice-labs-inc/allspice
-ARG ALLSPICE_TAG=latest
 
 # Stage 1: pull the allspice image to extract all proprietary assets.
-FROM ${ALLSPICE_IMAGE}:${ALLSPICE_TAG} AS allspice
+FROM ${ALLSPICE_REF} AS allspice
 
 # Stage 2: start from the spice-labs-cli OSS image and add all allspice assets.
 FROM ${SPICE_IMAGE}:${SPICE_TAG}
@@ -31,7 +34,10 @@ FROM ${SPICE_IMAGE}:${SPICE_TAG}
 #                       discovery on the classpath
 #   report_cli        — Rust binary for CycloneDX CBOM generation
 #   rogues_gallery*   — PQC rogues gallery data
-COPY --from=allspice /opt/allspice/allspice.jar /opt/spice-labs-cli/plugins/allspice.jar
+# Copy the spice plugin JARs into plugins/ (same as enterprise) and the
+# allspice fat JAR + CBOM assets into /opt/allspice/.
+COPY --from=allspice /opt/allspice/plugins/ /opt/spice-labs-cli/plugins/
+COPY --from=allspice /opt/allspice/allspice.jar /opt/allspice/allspice.jar
 # COPY --chmod (BuildKit) sets the executable bit without a RUN, so the
 # federal image has zero RUN commands and needs no QEMU for cross-arch.
 COPY --chmod=755 --from=allspice /opt/allspice/report_cli /opt/allspice/report_cli


### PR DESCRIPTION
The allspice image now ships the spice-plugin distribution JARs at /opt/allspice/plugins/ (SpiceCommandPlugin SPI + allspice module classes). Copy those into /opt/spice-labs-cli/plugins/ for ServiceLoader discovery in the enterprise and federal images, instead of copying the allspice application fat JAR which has no plugin SPI registration.