### PR TITLE
CI traces to OpenObserve

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,11 +285,12 @@ jobs:
       pull-requests: read
       checks: read
     steps:
-      - name: Export workflow traces to Honeycomb
+      - name: Export workflow traces to OpenObserve
         uses: dash0hq/otel-cicd-action@v4
         with:
-          otlpEndpoint: "grpc://api.eu1.honeycomb.io:443/"
-          otlpHeaders: "x-honeycomb-team=${{ secrets.HONEYCOMB_API_KEY }},x-honeycomb-dataset=build"
+          otlpEndpoint: "https://openobserve-ingest.shared-services.scw.spicelabs.systems/api/default/v1/traces"
+          otlpHeaders: "Authorization=Basic ${{ secrets.OPENOBSERVE_CI_AUTH }}"
+          extraAttributes: "environment=ci"
           githubToken: "${{ secrets.GITHUB_TOKEN }}"
 
 # Requirements for builder machine

--- a/.github/workflows/cleanup-ghcr-pr-tags.yml
+++ b/.github/workflows/cleanup-ghcr-pr-tags.yml
@@ -90,9 +90,10 @@ jobs:
       pull-requests: read
       checks: read
     steps:
-      - name: Export workflow traces to Honeycomb
+      - name: Export workflow traces to OpenObserve
         uses: dash0hq/otel-cicd-action@v4
         with:
-          otlpEndpoint: "grpc://api.eu1.honeycomb.io:443/"
-          otlpHeaders: "x-honeycomb-team=${{ secrets.HONEYCOMB_API_KEY }},x-honeycomb-dataset=build"
+          otlpEndpoint: "https://openobserve-ingest.shared-services.scw.spicelabs.systems/api/default/v1/traces"
+          otlpHeaders: "Authorization=Basic ${{ secrets.OPENOBSERVE_CI_AUTH }}"
+          extraAttributes: "environment=ci"
           githubToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -326,9 +326,10 @@ jobs:
       pull-requests: read
       checks: read
     steps:
-      - name: Export workflow traces to Honeycomb
+      - name: Export workflow traces to OpenObserve
         uses: dash0hq/otel-cicd-action@v4
         with:
-          otlpEndpoint: "grpc://api.eu1.honeycomb.io:443/"
-          otlpHeaders: "x-honeycomb-team=${{ secrets.HONEYCOMB_API_KEY }},x-honeycomb-dataset=build"
+          otlpEndpoint: "https://openobserve-ingest.shared-services.scw.spicelabs.systems/api/default/v1/traces"
+          otlpHeaders: "Authorization=Basic ${{ secrets.OPENOBSERVE_CI_AUTH }}"
+          extraAttributes: "environment=ci"
           githubToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Workflow traces now export to OpenObserve instead of Honeycomb, as part of the Honeycomb retirement.

Same `dash0hq/otel-cicd-action@v4` step, pointed at the public OpenObserve ingest endpoint over OTLP http/protobuf (the `https://` scheme selects the proto exporter; the URL carries the full `/api/default/v1/traces` path because the exporter uses it verbatim). Auth is the `OPENOBSERVE_CI_AUTH` org secret, a dedicated ingest-only OpenObserve service account (`ci-traces@spicelabs.io`) separate from the fleet collector's credentials. `extraAttributes: environment=ci` routes the spans into their own `ci` trace stream, viewable at https://logs.scw.spicelabs.systems (stream `ci`, traces).

Endpoint, auth, and stream routing were verified end to end with a live test span before this change.
