### PR TITLE
Portfolios : Producer telemetry: spice:ci tags, volatile-subject warning, analyzeStats

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ spice pass decode
 
 Flags can appear anywhere before the `--` separator.
 
+### Subject names and CI metadata
+
+The `<subject>` argument names the thing you ship, not the build: use the same name on
+every run (for example `payments-api`) so results accumulate under one identity. Names
+ending in a date, build number, commit hash, UUID, or version print a warning; the run
+still proceeds, and the server can alias a name later.
+
+Volatile per-run facts belong in `--tag-json`. When running under a recognized CI system
+(GitHub Actions, GitLab CI, Jenkins), the CLI adds a `spice:ci` key to the tag JSON
+automatically with the provider and pipeline run URL/id, so survey results link back to
+the run that produced them. Supply your own `spice:ci` key in `--tag-json` to override
+this, or leave it out to accept the detected values.
+
 ### `--tag-json` on Windows PowerShell 5.1
 
 PowerShell 5.1 strips outer single quotes before passing an argument to the CLI,

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,10 @@
         <dependency>
             <groupId>io.spicelabs</groupId>
             <artifactId>ginger-j</artifactId>
+            <!-- Overrides the spice-bom pin: needs the publishStatus analyzeStats overload.
+                 Replace with the next ginger-j release (then drop the override once
+                 spice-bom picks it up). -->
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/io/spicelabs/cli/AnalyzeProgressPublisher.java
+++ b/src/main/java/io/spicelabs/cli/AnalyzeProgressPublisher.java
@@ -3,6 +3,7 @@
 
 package io.spicelabs.cli;
 
+import java.util.Map;
 import java.util.UUID;
 
 import io.spicelabs.goatrodeo.ProgressListener;
@@ -31,7 +32,8 @@ final class AnalyzeProgressPublisher implements ProgressListener {
     /** What this publisher knows how to invoke. Real code passes {@code ginger::publishStatus}. */
     @FunctionalInterface
     interface StatusPublisher {
-        void publish(UUID subJobId, String status, Integer progress, String message);
+        void publish(UUID subJobId, String status, Integer progress, String message,
+                Map<String, Object> analyzeStats);
     }
 
     private static final long MIN_INTERVAL_MS = 2000L;
@@ -42,14 +44,21 @@ final class AnalyzeProgressPublisher implements ProgressListener {
 
     private final StatusPublisher publisher;
     private final UUID subJobId;
+    private final AnalyzeStats stats;
 
     private long lastEmitMillis = 0L;
     private int lastEmitPercent = -1;
     private boolean terminated = false;
 
     AnalyzeProgressPublisher(StatusPublisher publisher, UUID subJobId) {
+        this(publisher, subJobId, null);
+    }
+
+    /** With a non-null {@code stats}, progress ticks are recorded into it and its payload rides the terminal publish. */
+    AnalyzeProgressPublisher(StatusPublisher publisher, UUID subJobId, AnalyzeStats stats) {
         this.publisher = publisher;
         this.subJobId = subJobId;
+        this.stats = stats;
     }
 
     /** Opening tick: RUNNING / 0 / "Analyzing source". */
@@ -59,6 +68,9 @@ final class AnalyzeProgressPublisher implements ProgressListener {
 
     @Override
     public void onProgress(long current, long total) {
+        if (stats != null) {
+            stats.recordProgress(current, total);
+        }
         int percent;
         if (total <= 0) {
             percent = START_PERCENT;
@@ -108,7 +120,7 @@ final class AnalyzeProgressPublisher implements ProgressListener {
         }
         lastEmitMillis = System.currentTimeMillis();
         lastEmitPercent = percent;
-        publisher.publish(subJobId, "RUNNING", percent, message);
+        publisher.publish(subJobId, "RUNNING", percent, message, null);
     }
 
     private void publishTerminal(int percent, String status, String message) {
@@ -118,6 +130,6 @@ final class AnalyzeProgressPublisher implements ProgressListener {
         terminated = true;
         lastEmitMillis = System.currentTimeMillis();
         lastEmitPercent = percent;
-        publisher.publish(subJobId, status, percent, message);
+        publisher.publish(subJobId, status, percent, message, stats != null ? stats.toPayload() : null);
     }
 }

--- a/src/main/java/io/spicelabs/cli/AnalyzeStats.java
+++ b/src/main/java/io/spicelabs/cli/AnalyzeStats.java
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors */
+
+package io.spicelabs.cli;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Completeness counters for one ANALYZE pass, published on the terminal status POST so the
+ * server can detect silent truncation (an analyzer that exits 0 having seen only part of
+ * the input).
+ *
+ * <p>Two independently-sourced sides, deliberately in different units:
+ * <ul>
+ *   <li><b>Encountered side</b> ({@code filesEncountered}/{@code bytesEncountered}/
+ *       {@code filesUnreadable}) — a cheap stat-only walk of the input tree done by the CLI
+ *       itself before goat-rodeo runs. Units are filesystem files.</li>
+ *   <li><b>Processed side</b> ({@code itemsSeen}/{@code itemsProcessed}) — the last
+ *       {@code (total, current)} tick observed from goat-rodeo's ProgressListener. Units are
+ *       goat-rodeo items, which include entries nested inside archives, so these are NOT
+ *       comparable 1:1 with the file counts. They are also lower bounds: the listener is
+ *       throttled, so the final tick can undercount slightly.</li>
+ * </ul>
+ *
+ * <p>Fields whose value is unknown are omitted from the payload, never reported as zero.
+ */
+final class AnalyzeStats {
+
+  private static final Logger log = LoggerFactory.getLogger(AnalyzeStats.class);
+
+  private long filesEncountered;
+  private long bytesEncountered;
+  private long filesUnreadable;
+  private final Map<String, Long> unreadableReasons = new TreeMap<>();
+  private boolean scanned;
+
+  private long itemsSeen = -1;
+  private long itemsProcessed = -1;
+
+  /**
+   * Walk the input tree counting regular files, their bytes, and unreadable entries.
+   * Best-effort: any failure leaves the encountered side unreported rather than partial.
+   */
+  static AnalyzeStats scanInput(Path input) {
+    AnalyzeStats stats = new AnalyzeStats();
+    try {
+      Files.walkFileTree(input, new SimpleFileVisitor<Path>() {
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+          if (attrs.isRegularFile()) {
+            stats.filesEncountered++;
+            stats.bytesEncountered += attrs.size();
+            if (!Files.isReadable(file)) {
+              stats.filesUnreadable++;
+              stats.unreadableReasons.merge("permission_denied", 1L, Long::sum);
+            }
+          }
+          return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFileFailed(Path file, IOException exc) {
+          stats.filesUnreadable++;
+          stats.unreadableReasons.merge("walk_error", 1L, Long::sum);
+          return FileVisitResult.CONTINUE;
+        }
+      });
+      stats.scanned = true;
+      log.debug("Input scan: {} files, {} bytes, {} unreadable",
+          stats.filesEncountered, stats.bytesEncountered, stats.filesUnreadable);
+    } catch (Exception e) {
+      log.debug("Input scan failed; analyzeStats will omit encountered counts: {}", e.getMessage());
+    }
+    return stats;
+  }
+
+  /** Record a goat-rodeo progress tick. {@code current} is monotonic; {@code total} may grow. */
+  synchronized void recordProgress(long current, long total) {
+    itemsProcessed = Math.max(itemsProcessed, current);
+    itemsSeen = Math.max(itemsSeen, total);
+  }
+
+  /**
+   * The wire payload, or null when nothing was measured. Key order and names are the
+   * contract consumed by the server's completeness record.
+   */
+  synchronized Map<String, Object> toPayload() {
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("version", 1);
+    if (scanned) {
+      payload.put("filesEncountered", filesEncountered);
+      payload.put("bytesEncountered", bytesEncountered);
+      payload.put("filesUnreadable", filesUnreadable);
+      if (!unreadableReasons.isEmpty()) {
+        payload.put("unreadableReasons", new TreeMap<>(unreadableReasons));
+      }
+    }
+    if (itemsSeen >= 0) {
+      payload.put("itemsSeen", itemsSeen);
+      payload.put("itemsProcessed", itemsProcessed);
+    }
+    return payload.size() > 1 ? payload : null;
+  }
+}

--- a/src/main/java/io/spicelabs/cli/CiTags.java
+++ b/src/main/java/io/spicelabs/cli/CiTags.java
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors */
+
+package io.spicelabs.cli;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Auto-populates the reserved {@code spice:ci} tag-json namespace from well-known CI
+ * environment variables (GitHub Actions, GitLab CI, Jenkins), so a survey run in CI links
+ * back to the pipeline run that produced it.
+ *
+ * <p>Merge semantics: the detected object is added under the {@code spice:ci} key of the
+ * user's {@code --tag-json} object. If the user already supplies a {@code spice:ci} key,
+ * their value wins unchanged. Outside CI (no recognized variables), nothing is added.
+ */
+final class CiTags {
+
+  static final String KEY = "spice:ci";
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private CiTags() {}
+
+  /**
+   * Inspect the environment for a recognized CI provider. Returns a map with
+   * {@code provider} plus {@code runId} / {@code runUrl} when derivable, or {@code null}
+   * when no provider is detected.
+   */
+  static Map<String, Object> detect(Map<String, String> env) {
+    String githubRunId = get(env, "GITHUB_RUN_ID");
+    if (githubRunId != null) {
+      Map<String, Object> ci = new LinkedHashMap<>();
+      ci.put("provider", "github");
+      ci.put("runId", githubRunId);
+      String server = get(env, "GITHUB_SERVER_URL");
+      String repo = get(env, "GITHUB_REPOSITORY");
+      if (server != null && repo != null) {
+        String base = server.endsWith("/") ? server.substring(0, server.length() - 1) : server;
+        ci.put("runUrl", base + "/" + repo + "/actions/runs/" + githubRunId);
+      }
+      return ci;
+    }
+
+    String gitlabUrl = get(env, "CI_JOB_URL");
+    if (gitlabUrl == null) {
+      gitlabUrl = get(env, "CI_PIPELINE_URL");
+    }
+    if (gitlabUrl != null) {
+      Map<String, Object> ci = new LinkedHashMap<>();
+      ci.put("provider", "gitlab");
+      ci.put("runUrl", gitlabUrl);
+      return ci;
+    }
+
+    String jenkinsUrl = get(env, "BUILD_URL");
+    if (jenkinsUrl != null) {
+      Map<String, Object> ci = new LinkedHashMap<>();
+      ci.put("provider", "jenkins");
+      ci.put("runUrl", jenkinsUrl);
+      return ci;
+    }
+
+    return null;
+  }
+
+  /**
+   * Merge a detected {@code spice:ci} object into the user's tag-json string. Returns the
+   * merged JSON, or the original string untouched when {@code ciTags} is null or the user
+   * already set a {@code spice:ci} key.
+   *
+   * @param userTagJson the raw {@code --tag-json} value; may be null/blank (treated as {})
+   */
+  static String merge(String userTagJson, Map<String, Object> ciTags) throws JsonProcessingException {
+    if (ciTags == null) {
+      return userTagJson;
+    }
+    Map<String, Object> tags;
+    if (userTagJson == null || userTagJson.isBlank()) {
+      tags = new LinkedHashMap<>();
+    } else {
+      tags = MAPPER.readValue(userTagJson, new TypeReference<Map<String, Object>>() {});
+    }
+    if (tags.containsKey(KEY)) {
+      return userTagJson;
+    }
+    tags.put(KEY, ciTags);
+    return MAPPER.writeValueAsString(tags);
+  }
+
+  private static String get(Map<String, String> env, String name) {
+    String value = env.get(name);
+    return (value == null || value.isBlank()) ? null : value;
+  }
+}

--- a/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
@@ -185,6 +185,18 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
       validateTagJson(tagJson);
     }
 
+    VolatileSubjectDetector.warnIfVolatile(log, subject);
+
+    Map<String, Object> ciTags = CiTags.detect(System.getenv());
+    if (ciTags != null) {
+      String merged = CiTags.merge(tagJson, ciTags);
+      if (merged != null && !merged.equals(tagJson)) {
+        tagJson = merged;
+        log.info("Detected {} CI environment; tagging survey with {} metadata",
+            ciTags.get("provider"), CiTags.KEY);
+      }
+    }
+
     if (threads == null) {
       int availableCores = Runtime.getRuntime().availableProcessors();
       threads = Math.max(1, Math.round(availableCores / 2.0f));
@@ -245,7 +257,11 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
           .parentId(survey.parentId())
           .idempotencyKey(survey.idempotencyKey())
           .userAgent(survey.userAgent());
-      analyzeProgress = new AnalyzeProgressPublisher(statusPublisher::publishStatus, survey.analyzeSubJobId());
+      // Completeness counters ride the terminal ANALYZE status publish; upload-only runs
+      // do no local analyze, so there is nothing to report.
+      AnalyzeStats analyzeStats = uploadOnly ? null : AnalyzeStats.scanInput(input);
+      analyzeProgress = new AnalyzeProgressPublisher(
+          statusPublisher::publishStatus, survey.analyzeSubJobId(), analyzeStats);
     }
 
     if (uploadOnly) {

--- a/src/main/java/io/spicelabs/cli/SurveyRuntimeCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyRuntimeCommand.java
@@ -151,6 +151,8 @@ public class SurveyRuntimeCommand implements Callable<Integer> {
                     "SPICE_PASS must be set for upload. Use --no-upload to run locally.");
         }
 
+        VolatileSubjectDetector.warnIfVolatile(log, subject);
+
         // Anchor: the build artifact this survey is of, hashed so the survey can be correlated with an
         // inventory survey into a combined CBOM. Validated + hashed up front; warn loudly if absent so
         // the user knows why no combined CBOM.

--- a/src/main/java/io/spicelabs/cli/VolatileSubjectDetector.java
+++ b/src/main/java/io/spicelabs/cli/VolatileSubjectDetector.java
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors */
+
+package io.spicelabs.cli;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Detects subject names that look like they change every run (date, build number, commit
+ * hash, UUID, or version tail). Used only to print a soft warning: a volatile name mints a
+ * new subject per pipeline run instead of accumulating history under one stable identity.
+ * Detection is advisory; the CLI never rejects a subject name.
+ */
+final class VolatileSubjectDetector {
+
+  /** What made the name look volatile, plus the stable stem left after stripping the tail (may be empty). */
+  record Volatility(String kind, String stableStem) {}
+
+  private static final String BOUNDARY = "(?:^|[-_./:@])";
+
+  private record Rule(String kind, Pattern pattern) {}
+
+  private static final List<Rule> RULES = List.of(
+      new Rule("a UUID",
+          rule("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")),
+      new Rule("a date",
+          rule("\\d{4}-?(?:0[1-9]|1[0-2])-?(?:0[1-9]|[12]\\d|3[01])")),
+      new Rule("a version number",
+          rule("v?\\d+\\.\\d+(?:\\.\\d+)?")),
+      new Rule("a build or run number",
+          rule("\\d{5,}")),
+      new Rule("a commit hash",
+          rule("(?=[0-9a-fA-F]*\\d)[0-9a-fA-F]{7,40}")));
+
+  private static Pattern rule(String tail) {
+    return Pattern.compile(BOUNDARY + "(?:" + tail + ")$");
+  }
+
+  private VolatileSubjectDetector() {}
+
+  /** Empty when the name looks stable; otherwise the matched kind and the stem before the volatile tail. */
+  static Optional<Volatility> check(String subject) {
+    if (subject == null || subject.isBlank()) {
+      return Optional.empty();
+    }
+    for (Rule r : RULES) {
+      Matcher m = r.pattern().matcher(subject);
+      if (m.find()) {
+        return Optional.of(new Volatility(r.kind(), subject.substring(0, m.start())));
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Log the soft warning for a volatile-looking subject name. Never throws, never fails the
+   * run, never contacts the server.
+   */
+  static void warnIfVolatile(org.slf4j.Logger log, String subject) {
+    check(subject).ifPresent(v -> {
+      String suggestion = v.stableStem().isBlank()
+          ? "a stable name that identifies what you ship (for example 'payments-api')"
+          : "a stable name such as '" + v.stableStem() + "'";
+      log.warn("Subject '{}' ends in {}, so every run will create a new subject instead of "
+          + "building history under one name. Use {} and put run details in --tag-json; "
+          + "the server can alias this name to a stable one later.",
+          subject, v.kind(), suggestion);
+    });
+  }
+}

--- a/src/test/java/io/spicelabs/cli/AnalyzeProgressPublisherTest.java
+++ b/src/test/java/io/spicelabs/cli/AnalyzeProgressPublisherTest.java
@@ -5,28 +5,37 @@ package io.spicelabs.cli;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AnalyzeProgressPublisherTest {
 
-    private record Call(UUID subJobId, String status, Integer percent, String message) {}
+    private record Call(UUID subJobId, String status, Integer percent, String message,
+            Map<String, Object> analyzeStats) {}
 
     private List<Call> calls;
     private UUID subJobId;
     private AnalyzeProgressPublisher publisher;
+
+    private Call call(UUID sid, String status, Integer percent, String message) {
+        return new Call(sid, status, percent, message, null);
+    }
 
     @BeforeEach
     void setUp() {
         calls = new ArrayList<>();
         subJobId = UUID.randomUUID();
         publisher = new AnalyzeProgressPublisher(
-                (sid, status, percent, message) -> calls.add(new Call(sid, status, percent, message)),
+                (sid, status, percent, message, stats) ->
+                        calls.add(new Call(sid, status, percent, message, stats)),
                 subJobId);
     }
 
@@ -34,7 +43,7 @@ class AnalyzeProgressPublisherTest {
     void start_emitsOpeningTickAtZero() {
         publisher.start();
         assertEquals(1, calls.size());
-        assertEquals(new Call(subJobId, "RUNNING", 0, "Analyzing source"), calls.get(0));
+        assertEquals(call(subJobId, "RUNNING", 0, "Analyzing source"), calls.get(0));
     }
 
     @Test
@@ -70,7 +79,7 @@ class AnalyzeProgressPublisherTest {
     @Test
     void complete_emitsCompletedTerminalAtOneHundred() {
         publisher.complete();
-        assertEquals(new Call(subJobId, "COMPLETED", 100, "Analysis complete"), calls.get(0));
+        assertEquals(call(subJobId, "COMPLETED", 100, "Analysis complete"), calls.get(0));
     }
 
     @Test
@@ -79,19 +88,19 @@ class AnalyzeProgressPublisherTest {
         publisher.fail("boom");
 
         assertEquals(2, calls.size());
-        assertEquals(new Call(subJobId, "FAILED", 50, "Analysis failed: boom"), calls.get(1));
+        assertEquals(call(subJobId, "FAILED", 50, "Analysis failed: boom"), calls.get(1));
     }
 
     @Test
     void fail_emitsZeroWhenNothingPublishedYet() {
         publisher.fail("never started");
-        assertEquals(new Call(subJobId, "FAILED", 0, "Analysis failed: never started"), calls.get(0));
+        assertEquals(call(subJobId, "FAILED", 0, "Analysis failed: never started"), calls.get(0));
     }
 
     @Test
     void building_pinsAtNinetyFive() {
         publisher.building();
-        assertEquals(new Call(subJobId, "RUNNING", 95, "Building bundle"), calls.get(0));
+        assertEquals(call(subJobId, "RUNNING", 95, "Building bundle"), calls.get(0));
     }
 
     @Test
@@ -112,5 +121,51 @@ class AnalyzeProgressPublisherTest {
         publisher.onProgress(0, 0);
         assertTrue(calls.size() >= 1);
         assertEquals(5, calls.get(0).percent());
+    }
+
+    private AnalyzeProgressPublisher withStats(AnalyzeStats stats) {
+        return new AnalyzeProgressPublisher(
+                (sid, status, percent, message, analyzeStats) ->
+                        calls.add(new Call(sid, status, percent, message, analyzeStats)),
+                subJobId, stats);
+    }
+
+    @Test
+    void complete_attachesStatsPayloadOnTerminalOnly() {
+        AnalyzeProgressPublisher p = withStats(new AnalyzeStats());
+        p.onProgress(40, 100);
+        p.onProgress(100, 100);
+        p.complete();
+
+        assertEquals(3, calls.size());
+        assertNull(calls.get(0).analyzeStats(), "running ticks carry no stats");
+        assertNull(calls.get(1).analyzeStats(), "running ticks carry no stats");
+        Map<String, Object> stats = calls.get(2).analyzeStats();
+        assertNotNull(stats);
+        assertEquals(100L, stats.get("itemsSeen"));
+        assertEquals(100L, stats.get("itemsProcessed"));
+    }
+
+    @Test
+    void fail_attachesStatsPayload() {
+        AnalyzeProgressPublisher p = withStats(new AnalyzeStats());
+        p.onProgress(30, 90);
+        p.fail("boom");
+
+        Map<String, Object> stats = calls.get(calls.size() - 1).analyzeStats();
+        assertNotNull(stats);
+        assertEquals(90L, stats.get("itemsSeen"));
+        assertEquals(30L, stats.get("itemsProcessed"));
+    }
+
+    @Test
+    void complete_withoutStatsOrTicksAttachesNothing() {
+        publisher.complete();
+        assertNull(calls.get(0).analyzeStats());
+
+        calls.clear();
+        AnalyzeProgressPublisher p = withStats(new AnalyzeStats());
+        p.complete();
+        assertNull(calls.get(0).analyzeStats(), "empty stats publish no payload");
     }
 }

--- a/src/test/java/io/spicelabs/cli/AnalyzeStatsTest.java
+++ b/src/test/java/io/spicelabs/cli/AnalyzeStatsTest.java
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors */
+
+package io.spicelabs.cli;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class AnalyzeStatsTest {
+
+  @TempDir
+  Path tempDir;
+
+  @Test
+  void scanInput_countsFilesAndBytesRecursively() throws Exception {
+    Files.writeString(tempDir.resolve("a.txt"), "12345");
+    Path sub = Files.createDirectories(tempDir.resolve("sub"));
+    Files.writeString(sub.resolve("b.bin"), "1234567890");
+
+    AnalyzeStats stats = AnalyzeStats.scanInput(tempDir);
+    Map<String, Object> payload = stats.toPayload();
+
+    assertNotNull(payload);
+    assertEquals(1, payload.get("version"));
+    assertEquals(2L, payload.get("filesEncountered"));
+    assertEquals(15L, payload.get("bytesEncountered"));
+    assertEquals(0L, payload.get("filesUnreadable"));
+    assertFalse(payload.containsKey("unreadableReasons"), "no reasons when nothing was unreadable");
+    assertFalse(payload.containsKey("itemsSeen"), "no analyzer items without progress ticks");
+  }
+
+  @Test
+  void scanInput_singleFileInput() throws Exception {
+    Path file = tempDir.resolve("only.jar");
+    Files.writeString(file, "abc");
+
+    Map<String, Object> payload = AnalyzeStats.scanInput(file).toPayload();
+
+    assertNotNull(payload);
+    assertEquals(1L, payload.get("filesEncountered"));
+    assertEquals(3L, payload.get("bytesEncountered"));
+  }
+
+  @Test
+  void recordProgress_reportsLastSeenItems() {
+    AnalyzeStats stats = new AnalyzeStats();
+    stats.recordProgress(10, 50);
+    stats.recordProgress(50, 80);
+
+    Map<String, Object> payload = stats.toPayload();
+    assertNotNull(payload);
+    assertEquals(80L, payload.get("itemsSeen"));
+    assertEquals(50L, payload.get("itemsProcessed"));
+    assertFalse(payload.containsKey("filesEncountered"), "no walk counts without a scan");
+  }
+
+  @Test
+  void toPayload_isNullWhenNothingMeasured() {
+    assertNull(new AnalyzeStats().toPayload());
+  }
+
+  @Test
+  void scanInput_inaccessibleRootCountsAsWalkError() {
+    Map<String, Object> payload = AnalyzeStats.scanInput(tempDir.resolve("does-not-exist")).toPayload();
+
+    assertNotNull(payload);
+    assertEquals(0L, payload.get("filesEncountered"));
+    assertEquals(1L, payload.get("filesUnreadable"));
+    assertEquals(Map.of("walk_error", 1L), payload.get("unreadableReasons"));
+  }
+}

--- a/src/test/java/io/spicelabs/cli/CiTagsTest.java
+++ b/src/test/java/io/spicelabs/cli/CiTagsTest.java
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors */
+
+package io.spicelabs.cli;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CiTagsTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private static Map<String, Object> parse(String json) throws Exception {
+    return MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {});
+  }
+
+  @Test
+  void detect_githubActions() {
+    Map<String, Object> ci = CiTags.detect(Map.of(
+        "GITHUB_RUN_ID", "1234567890",
+        "GITHUB_SERVER_URL", "https://github.com",
+        "GITHUB_REPOSITORY", "spice-labs-inc/spice-labs-cli"));
+
+    assertNotNull(ci);
+    assertEquals("github", ci.get("provider"));
+    assertEquals("1234567890", ci.get("runId"));
+    assertEquals("https://github.com/spice-labs-inc/spice-labs-cli/actions/runs/1234567890",
+        ci.get("runUrl"));
+  }
+
+  @Test
+  void detect_githubWithoutRepoStillReportsRunId() {
+    Map<String, Object> ci = CiTags.detect(Map.of("GITHUB_RUN_ID", "42"));
+
+    assertNotNull(ci);
+    assertEquals("github", ci.get("provider"));
+    assertEquals("42", ci.get("runId"));
+    assertFalse(ci.containsKey("runUrl"));
+  }
+
+  @Test
+  void detect_gitlabPrefersJobUrl() {
+    Map<String, Object> ci = CiTags.detect(Map.of(
+        "CI_JOB_URL", "https://gitlab.example.com/g/p/-/jobs/77",
+        "CI_PIPELINE_URL", "https://gitlab.example.com/g/p/-/pipelines/9"));
+
+    assertNotNull(ci);
+    assertEquals("gitlab", ci.get("provider"));
+    assertEquals("https://gitlab.example.com/g/p/-/jobs/77", ci.get("runUrl"));
+  }
+
+  @Test
+  void detect_gitlabFallsBackToPipelineUrl() {
+    Map<String, Object> ci = CiTags.detect(Map.of(
+        "CI_PIPELINE_URL", "https://gitlab.example.com/g/p/-/pipelines/9"));
+
+    assertNotNull(ci);
+    assertEquals("gitlab", ci.get("provider"));
+    assertEquals("https://gitlab.example.com/g/p/-/pipelines/9", ci.get("runUrl"));
+  }
+
+  @Test
+  void detect_jenkins() {
+    Map<String, Object> ci = CiTags.detect(Map.of(
+        "BUILD_URL", "https://jenkins.example.com/job/app/15/"));
+
+    assertNotNull(ci);
+    assertEquals("jenkins", ci.get("provider"));
+    assertEquals("https://jenkins.example.com/job/app/15/", ci.get("runUrl"));
+  }
+
+  @Test
+  void detect_githubWinsOverJenkinsVars() {
+    Map<String, Object> ci = CiTags.detect(Map.of(
+        "GITHUB_RUN_ID", "42",
+        "BUILD_URL", "https://jenkins.example.com/job/app/15/"));
+
+    assertNotNull(ci);
+    assertEquals("github", ci.get("provider"));
+  }
+
+  @Test
+  void detect_returnsNullOutsideCi() {
+    assertNull(CiTags.detect(Map.of()));
+    assertNull(CiTags.detect(Map.of("PATH", "/usr/bin", "HOME", "/home/u")));
+  }
+
+  @Test
+  void detect_ignoresBlankValues() {
+    assertNull(CiTags.detect(Map.of("GITHUB_RUN_ID", "", "BUILD_URL", " ")));
+  }
+
+  @Test
+  void merge_addsSpiceCiToExistingTagJson() throws Exception {
+    Map<String, Object> ci = CiTags.detect(Map.of("GITHUB_RUN_ID", "42"));
+    String merged = CiTags.merge("{\"env\":\"prod\"}", ci);
+
+    Map<String, Object> tags = parse(merged);
+    assertEquals("prod", tags.get("env"));
+    @SuppressWarnings("unchecked")
+    Map<String, Object> spiceCi = (Map<String, Object>) tags.get("spice:ci");
+    assertEquals("github", spiceCi.get("provider"));
+    assertEquals("42", spiceCi.get("runId"));
+  }
+
+  @Test
+  void merge_createsTagJsonWhenUserGaveNone() throws Exception {
+    Map<String, Object> ci = CiTags.detect(Map.of("BUILD_URL", "https://j/1/"));
+    String merged = CiTags.merge(null, ci);
+
+    Map<String, Object> tags = parse(merged);
+    assertEquals(1, tags.size());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> spiceCi = (Map<String, Object>) tags.get("spice:ci");
+    assertEquals("jenkins", spiceCi.get("provider"));
+  }
+
+  @Test
+  void merge_userSpiceCiKeyWins() throws Exception {
+    Map<String, Object> ci = CiTags.detect(Map.of("GITHUB_RUN_ID", "42"));
+    String user = "{\"spice:ci\":{\"provider\":\"custom\",\"runUrl\":\"https://my.ci/1\"}}";
+    String merged = CiTags.merge(user, ci);
+
+    assertEquals(user, merged);
+  }
+
+  @Test
+  void merge_noCiDetectedLeavesTagJsonUntouched() throws Exception {
+    assertNull(CiTags.merge(null, null));
+    assertEquals("{\"env\":\"prod\"}", CiTags.merge("{\"env\":\"prod\"}", null));
+  }
+}

--- a/src/test/java/io/spicelabs/cli/VolatileSubjectDetectorTest.java
+++ b/src/test/java/io/spicelabs/cli/VolatileSubjectDetectorTest.java
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors */
+
+package io.spicelabs.cli;
+
+import java.util.Optional;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VolatileSubjectDetectorTest {
+
+  @ParameterizedTest
+  @CsvSource({
+      "my-app-2026-08-03,   a date,                  my-app",
+      "myapp_20260803,      a date,                  myapp",
+      "my-app-12345,        a build or run number,   my-app",
+      "build.1234567890,    a build or run number,   build",
+      "my-app-1a2b3c4,      a commit hash,           my-app",
+      "svc-4e9f1c2ab7d8e6f0a1b2c3d4e5f60718293a4b5c, a commit hash, svc",
+      "my-app-v1.2.3,       a version number,        my-app",
+      "my-app-1.2,          a version number,        my-app",
+      "api:v10.0.1,         a version number,        api",
+  })
+  void volatileTailsAreDetected(String subject, String kind, String stem) {
+    Optional<VolatileSubjectDetector.Volatility> v = VolatileSubjectDetector.check(subject);
+    assertTrue(v.isPresent(), subject + " should look volatile");
+    assertEquals(kind, v.get().kind());
+    assertEquals(stem, v.get().stableStem());
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "d7f81a94-9a2b-4c6d-8e1f-0a2b3c4d5e6f, ''",
+      "my-app-d7f81a94-9a2b-4c6d-8e1f-0a2b3c4d5e6f, my-app",
+  })
+  void uuidTailsAreDetected(String subject, String stem) {
+    Optional<VolatileSubjectDetector.Volatility> v = VolatileSubjectDetector.check(subject);
+    assertTrue(v.isPresent(), subject + " should look volatile");
+    assertEquals("a UUID", v.get().kind());
+    assertEquals(stem == null ? "" : stem, v.get().stableStem());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "payments-api",
+      "mobile-android",
+      "my-app",
+      "my-app2",
+      "api-v2",
+      "release-x",
+      "my-app-build-4711",  // four digits: below the five-digit volatile threshold
+      "spice-labs-cli",
+      "app-beta",
+  })
+  void stableNamesAreNotFlagged(String subject) {
+    assertTrue(VolatileSubjectDetector.check(subject).isEmpty(),
+        subject + " should not look volatile");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "  "})
+  void blankNamesAreNotFlagged(String subject) {
+    assertTrue(VolatileSubjectDetector.check(subject).isEmpty());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"20260803"})
+  void entirelyVolatileNameHasEmptyStem(String subject) {
+    Optional<VolatileSubjectDetector.Volatility> v = VolatileSubjectDetector.check(subject);
+    assertTrue(v.isPresent());
+    assertEquals("", v.get().stableStem());
+  }
+}


### PR DESCRIPTION
Three producer-side telemetry additions to `spice survey`:

**`spice:ci` tag auto-population** (`CiTags`)
When `survey inventory` runs under a recognized CI system, the CLI adds a reserved `spice:ci` key to the survey tag JSON: `{"spice:ci": {"provider": ..., "runId": ..., "runUrl": ...}}`. Detection: GitHub Actions (`GITHUB_RUN_ID`, URL from `GITHUB_SERVER_URL`/`GITHUB_REPOSITORY`), GitLab CI (`CI_JOB_URL`, falling back to `CI_PIPELINE_URL`), Jenkins (`BUILD_URL`). A user-supplied `spice:ci` key in `--tag-json` wins unchanged; outside CI nothing is added. The enriched JSON flows to both the goat-rodeo tag body and the `POST /surveys` registration.

**Volatile subject-name warning** (`VolatileSubjectDetector`)
`survey inventory` and `survey runtime` print a soft warning (never a failure, no server call) when the `<subject>` argument ends in a date, a 5+ digit build/run number, a commit hash, a UUID, or a version tail. The message suggests the stable stem, points volatile details at `--tag-json`, and notes the server can alias the name later.

**`analyzeStats` completeness payload** (`AnalyzeStats`)
The terminal ANALYZE status POST (`COMPLETED` or `FAILED`) now carries an `analyzeStats` object so the server can detect an analyzer that exits 0 having seen only part of the input:

- Encountered side, from a stat-only pre-walk of the input tree: `filesEncountered`, `bytesEncountered`, `filesUnreadable`, `unreadableReasons` (reason buckets: `permission_denied`, `walk_error`).
- Processed side, from goat-rodeo progress ticks: `itemsSeen`, `itemsProcessed`. Item units include entries nested in archives, so these are deliberately named differently from the file counts; they are lower bounds because the listener is throttled.
- `version: 1`; unknown values are omitted, never reported as zero. Servers that predate the field ignore it.

README documents the subject-name contract and the `spice:ci` namespace. No wrapper flag changes.

Depends on the companion ginger-j PR adding the `publishStatus` overload that carries `analyzeStats`. The pom temporarily pins `ginger-j` `0.0.1-SNAPSHOT` for local builds; replace with the next ginger-j release (and drop the override once spice-bom picks it up) before merge.
