### PR TITLE
Derive the wrapper's path arguments from the picocli model

### DIFF
--- a/src/main/java/io/spicelabs/cli/PathManifest.java
+++ b/src/main/java/io/spicelabs/cli/PathManifest.java
@@ -168,8 +168,13 @@ public final class PathManifest {
    * The trailing attribute list for one argument, each attribute space-prefixed.
    *
    * @param takesValue whether the wrapper must consume a following token
-   * @param positional whether this is a positional parameter (positional paths are inputs
-   *                   by convention throughout this CLI, so they are marked {@code exists})
+   * @param positional whether this is a positional parameter. Only positionals are marked
+   *     {@code exists}: they are inputs by convention throughout this CLI, and the wrapper
+   *     already refused a missing one before manifests existed. A path <em>option</em> is
+   *     never marked, even when {@code required()} — required says the flag must be given,
+   *     not that its target already exists ({@code registry init --file} names a file it
+   *     is about to create). Rejecting those in the wrapper would both break that case and
+   *     pre-empt the CLI's own diagnostic for the ones that genuinely are inputs.
    */
   private static String attributesOf(ArgSpec arg, boolean takesValue, boolean positional) {
     StringBuilder sb = new StringBuilder();
@@ -185,7 +190,7 @@ public final class PathManifest {
     if (isPathType(arg)) {
       sb.append(" path");
       sb.append(" create=").append(createHint(arg));
-      if (positional || arg.required()) {
+      if (positional) {
         sb.append(" exists");
       }
     }

--- a/src/main/java/io/spicelabs/cli/PathManifest.java
+++ b/src/main/java/io/spicelabs/cli/PathManifest.java
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.cli;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+
+import io.spicelabs.cli.spi.SpiceCommandPlugin;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Model.ArgSpec;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Model.OptionSpec;
+import picocli.CommandLine.Model.PositionalParamSpec;
+
+/**
+ * Renders the <em>path manifest</em>: a description of which arguments of which commands
+ * are host filesystem paths, for the host-side {@code spice} / {@code spice.ps1} wrappers.
+ *
+ * <p>The wrappers run <em>outside</em> the container and must decide, before {@code docker
+ * run} starts, which arguments to absolutise and bind-mount. They cannot see the picocli
+ * model, which lives inside the image — so historically each wrapper carried a hardcoded
+ * list of path flags, which drifted from the commands (notably plugin-contributed ones).
+ *
+ * <p>Instead, this class walks the <em>fully assembled</em> command tree — after
+ * {@link PluginLoader} has mounted every plugin — and derives the list. A plugin declares
+ * a parameter as a path simply by typing it as {@link Path} or {@link File}; no SPI method
+ * and no {@code SpiceContext#API_VERSION} bump is involved, so already-published plugin
+ * jars are covered without change.
+ *
+ * <p>The format is line-oriented and whitespace-separated so that bash 3.2 (macOS) and
+ * PowerShell 5.1 can both parse it without {@code jq}. See {@code shared/path-manifest.bash}
+ * for the consumer.
+ *
+ * <pre>
+ * # spice-path-manifest 1
+ * V 1
+ * G 1.4.2
+ * R /opt/spice-labs-cli
+ * C spice/registry/cbom
+ * O spice/registry/cbom --rogues value path create=parent
+ * P spice/survey/inventory 1 value path create=self exists
+ * </pre>
+ */
+public final class PathManifest {
+
+  /** Manifest schema version. Bump only on an incompatible format change. */
+  public static final int SCHEMA_VERSION = 1;
+
+  /** First line of every manifest; the wrappers validate it before trusting the rest. */
+  public static final String HEADER = "# spice-path-manifest " + SCHEMA_VERSION;
+
+  /**
+   * Options the wrapper consumes itself and strips from the container command line.
+   * Each is handled at the shell level (log files are written on the host; feature flags
+   * select the image), so they must not be mounted even when they name a path.
+   */
+  private static final Set<String> HOST_ONLY = Set.of("--log-file", "--features");
+
+  /** {@code paramLabel} values that mean "this names a directory". */
+  private static final Set<String> DIR_LABELS = Set.of("DIR", "DIRECTORY", "FOLDER", "OUTDIR");
+
+  /** {@code paramLabel} values that mean "this names a file". */
+  private static final Set<String> FILE_LABELS = Set.of("FILE", "PATH");
+
+  private static final Pattern DIRECTORY_WORD = Pattern.compile("\\bdirector(y|ies)\\b",
+      Pattern.CASE_INSENSITIVE);
+  private static final Pattern FILE_WORD = Pattern.compile("\\bfile\\b", Pattern.CASE_INSENSITIVE);
+
+  /**
+   * Filesystem roots that must never be shadowed by a bind mount. Matched <em>exactly</em>,
+   * never by prefix: {@code /var/folders/...} (macOS temp dirs) and {@code /home/...} must
+   * stay mountable, so prefix matching is reserved for the derived entries in
+   * {@link #reservedDirs()}.
+   */
+  private static final List<String> FHS_ROOTS = List.of(
+      "/", "/bin", "/boot", "/dev", "/etc", "/lib", "/lib32", "/lib64", "/libx32",
+      "/opt", "/proc", "/root", "/run", "/sbin", "/srv", "/sys", "/usr", "/var");
+
+  private PathManifest() {}
+
+  /** Render the manifest for a fully-assembled command tree. */
+  public static String render(CommandLine root) {
+    return render(root, true);
+  }
+
+  /**
+   * Render the manifest.
+   *
+   * @param deriveInstallDirs whether to emit the {@code RP} records naming this
+   *     installation's own directories. True when rendering inside the image, where those
+   *     directories are what they will be at runtime; false when rendering at build time,
+   *     where they would be the developer's checkout — a machine-specific value that must
+   *     not end up in the manifest embedded in the wrapper.
+   */
+  static String render(CommandLine root, boolean deriveInstallDirs) {
+    StringBuilder out = new StringBuilder();
+    out.append(HEADER).append('\n');
+    out.append("V ").append(SCHEMA_VERSION).append('\n');
+    out.append("G ").append(sanitize(SpiceLabsCLI.VersionProvider.getVersionString())).append('\n');
+    for (String dir : FHS_ROOTS) {
+      out.append("R ").append(dir).append('\n');
+    }
+    if (deriveInstallDirs) {
+      for (String dir : installDirs()) {
+        out.append("RP ").append(dir).append('\n');
+      }
+    }
+    walk(root.getCommandSpec(), root.getCommandName(),
+        Collections.newSetFromMap(new IdentityHashMap<>()), out);
+    return out.toString();
+  }
+
+  /**
+   * Emit records for {@code spec} and recurse into its subcommands. {@code seen} guards
+   * against a command reachable by more than one alias, and against any cycle.
+   */
+  static void walk(CommandSpec spec, String path, Set<CommandSpec> seen, StringBuilder out) {
+    if (!seen.add(spec)) {
+      return;
+    }
+    out.append("C ").append(path).append('\n');
+
+    for (OptionSpec option : spec.options()) {
+      String attrs = attributesOf(option, option.arity().max() > 0, false);
+      for (String name : option.names()) {
+        out.append("O ").append(path).append(' ').append(name).append(attrs).append('\n');
+      }
+    }
+    for (PositionalParamSpec param : spec.positionalParameters()) {
+      out.append("P ").append(path).append(' ').append(param.index().min())
+         .append(attributesOf(param, true, true)).append('\n');
+    }
+
+    for (CommandLine sub : spec.subcommands().values()) {
+      walk(sub.getCommandSpec(), path + "/" + sub.getCommandName(), seen, out);
+    }
+  }
+
+  /**
+   * The trailing attribute list for one argument, each attribute space-prefixed.
+   *
+   * @param takesValue whether the wrapper must consume a following token
+   * @param positional whether this is a positional parameter (positional paths are inputs
+   *                   by convention throughout this CLI, so they are marked {@code exists})
+   */
+  private static String attributesOf(ArgSpec arg, boolean takesValue, boolean positional) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(takesValue ? " value" : " flag");
+
+    boolean hostOnly = arg instanceof OptionSpec
+        && anyMatch(((OptionSpec) arg).names(), HOST_ONLY);
+    if (hostOnly) {
+      // Stripped by the wrapper, so never mounted — even though --log-file names a path.
+      return sb.append(" hostonly").toString();
+    }
+
+    if (isPathType(arg)) {
+      sb.append(" path");
+      sb.append(" create=").append(createHint(arg));
+      if (positional || arg.required()) {
+        sb.append(" exists");
+      }
+    }
+    if (arg.scopeType() == CommandLine.ScopeType.INHERIT) {
+      sb.append(" inherit");
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Whether an argument names a host filesystem path, derived purely from its declared
+   * type. This is the entire mechanism by which a plugin declares a mounted parameter:
+   * type it as {@link Path} or {@link File} (or an array/collection of either).
+   */
+  static boolean isPathType(ArgSpec arg) {
+    Class<?> type = arg.type();
+    if (type.isArray()) {
+      type = type.getComponentType();
+    } else if (Collection.class.isAssignableFrom(type)) {
+      Class<?>[] aux = arg.auxiliaryTypes();
+      if (aux.length > 0) {
+        type = aux[0];
+      }
+    }
+    return Path.class.isAssignableFrom(type) || File.class.isAssignableFrom(type);
+  }
+
+  /**
+   * Whether a missing path should be created as a directory itself ({@code self}) or have
+   * its parent directory created ({@code parent}).
+   *
+   * <p>Nothing in the type says whether a {@code Path} names a file or a directory, so this
+   * reads the {@code paramLabel} first (the convention plugins should follow:
+   * {@code paramLabel = "DIR"} or {@code "FILE"}), then falls back to the description text.
+   * When neither says, {@code parent} is chosen: mounting the parent lets the container
+   * create either a file or a directory there, so the worst case is that the command must
+   * {@code mkdir} its own output directory — never a directory created where a file belongs.
+   */
+  static String createHint(ArgSpec arg) {
+    String label = arg.paramLabel();
+    if (label != null) {
+      String bare = label.replaceAll("[<>\\[\\]]", "").toUpperCase(Locale.ROOT);
+      if (DIR_LABELS.contains(bare)) {
+        return "self";
+      }
+      if (FILE_LABELS.contains(bare)) {
+        return "parent";
+      }
+    }
+    String description = String.join(" ", arg.description());
+    if (DIRECTORY_WORD.matcher(description).find()) {
+      return "self";
+    }
+    if (FILE_WORD.matcher(description).find()) {
+      return "parent";
+    }
+    return "parent";
+  }
+
+  /**
+   * Install directories that a bind mount must never shadow, matched by <em>prefix</em>.
+   * Derived rather than listed, so it stays correct as plugins come and go: mounting a
+   * host directory over {@code /opt/allspice} would hide the plugin's own resources from
+   * the code that needs them.
+   */
+  static List<String> installDirs() {
+    Set<String> dirs = new TreeSet<>();
+    addCodeSourceDir(SpiceLabsCLI.class, dirs);
+    try {
+      for (SpiceCommandPlugin plugin : ServiceLoader.load(SpiceCommandPlugin.class)) {
+        addCodeSourceDir(plugin.getClass(), dirs);
+      }
+    } catch (Throwable ignored) {
+      // A plugin that cannot even be instantiated contributes no directory to protect.
+    }
+    return new ArrayList<>(dirs);
+  }
+
+  private static void addCodeSourceDir(Class<?> type, Set<String> dirs) {
+    try {
+      var source = type.getProtectionDomain().getCodeSource();
+      if (source == null || source.getLocation() == null) {
+        return;
+      }
+      Path location = Paths.get(source.getLocation().toURI());
+      Path dir = Files.isDirectory(location) ? location : location.getParent();
+      if (dir != null && dir.isAbsolute() && dir.getNameCount() > 0) {
+        dirs.add(dir.toString());
+      }
+    } catch (Throwable ignored) {
+      // Unusual class loaders (JPMS images, custom loaders) simply contribute nothing.
+    }
+  }
+
+  /**
+   * The built-in command tree with no plugins mounted, so the manifest rendered from it
+   * depends on nothing but this source. {@link SpiceLabsCLI#newCommandLine()} deliberately
+   * does load plugins, which is right at runtime and wrong for a committed artefact.
+   */
+  static CommandLine builtInCommandLine() {
+    return new CommandLine(new SpiceLabsCLI());
+  }
+
+  /** Collapse whitespace so a value can never break the record's token count. */
+  private static String sanitize(String value) {
+    if (value == null || value.isBlank()) {
+      return "unknown";
+    }
+    return value.trim().replaceAll("\\s+", "_");
+  }
+
+  private static boolean anyMatch(String[] names, Set<String> set) {
+    for (String name : names) {
+      if (set.contains(name)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Build-time entry point: render the manifest for the command tree on the current
+   * classpath and write it to {@code args[0]}, or to stdout if no path is given.
+   *
+   * <p>This output is committed into the wrapper scripts, so it must be identical on every
+   * machine. Hence two deliberate omissions: install directories (they would be the
+   * developer's checkout), and plugins (whichever happen to be on the build classpath).
+   * Both are carried by the manifest the wrapper fetches from the image at runtime; this
+   * one only has to describe the built-in commands well enough to be a safe fallback.
+   */
+  public static void main(String[] args) throws IOException {
+    String manifest = render(builtInCommandLine(), false);
+    if (args.length > 0) {
+      Files.writeString(Paths.get(args[0]), manifest, StandardCharsets.UTF_8);
+    } else {
+      System.out.print(manifest);
+    }
+  }
+}

--- a/src/main/java/io/spicelabs/cli/PathManifestCommand.java
+++ b/src/main/java/io/spicelabs/cli/PathManifestCommand.java
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.cli;
+
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+/**
+ * Prints the path manifest for this image, for the host-side wrapper to consume.
+ *
+ * <p>The wrapper invokes this once per image (caching the result by image ID) so that its
+ * bind-mount decisions reflect the plugins actually present in the image rather than a
+ * hardcoded list. Resolving the command tree through {@link CommandSpec#root()} is what
+ * makes the manifest complete: by the time this command executes, {@link PluginLoader} has
+ * already mounted every plugin onto the root.
+ */
+@Command(
+    name = "path-manifest",
+    hidden = true,
+    description = "Print the host wrapper's path manifest for this image.")
+public class PathManifestCommand implements Callable<Integer> {
+
+  @Spec
+  CommandSpec spec;
+
+  @Override
+  public Integer call() {
+    // Written straight to stdout, not through the logger: the wrapper parses this and any
+    // log decoration would corrupt it.
+    System.out.print(PathManifest.render(spec.root().commandLine()));
+    System.out.flush();
+    return 0;
+  }
+}

--- a/src/main/java/io/spicelabs/cli/SpiceLabsCLI.java
+++ b/src/main/java/io/spicelabs/cli/SpiceLabsCLI.java
@@ -44,6 +44,9 @@ import picocli.CommandLine.Command;
         AutoComplete.GenerateCompletion.class,
         // PowerShell equivalent: built-ins + each plugin's contributed fragment.
         GeneratePowershellCompletion.class,
+        // Tells the host wrapper which arguments are paths to bind-mount, derived from
+        // the live command model (plugins included) rather than a hardcoded list.
+        PathManifestCommand.class,
     },
     footer = {
         "",

--- a/src/test/java/io/spicelabs/cli/PathManifestTest.java
+++ b/src/test/java/io/spicelabs/cli/PathManifestTest.java
@@ -1,0 +1,235 @@
+package io.spicelabs.cli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.junit.jupiter.api.Test;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.ArgSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/**
+ * The manifest is what the host wrapper substitutes for knowing any flag names, so these
+ * tests pin the two things it must get right: which arguments are paths (derived from the
+ * declared type alone) and whether a missing one names a file or a directory.
+ */
+class PathManifestTest {
+
+  // ── Type derivation ────────────────────────────────────────────────────────
+
+  @Command(name = "types")
+  static class TypesCommand implements Callable<Integer> {
+    @Option(names = "--a-path") Path aPath;
+    @Option(names = "--a-file") File aFile;
+    @Option(names = "--path-array") Path[] pathArray;
+    @Option(names = "--path-list") List<Path> pathList;
+    @Option(names = "--a-string") String aString;
+    @Option(names = "--a-number") Integer aNumber;
+    @Option(names = "--a-flag") boolean aFlag;
+    @Option(names = "--string-list") List<String> stringList;
+    public Integer call() { return 0; }
+  }
+
+  @Test
+  void pathAndFileTypesAreMounted_othersAreNot() {
+    String manifest = PathManifest.render(new CommandLine(new TypesCommand()), false);
+
+    assertTrue(attrs(manifest, "types", "--a-path").contains("path"));
+    assertTrue(attrs(manifest, "types", "--a-file").contains("path"));
+    assertTrue(attrs(manifest, "types", "--path-array").contains("path"),
+        "an array of paths still names paths");
+    assertTrue(attrs(manifest, "types", "--path-list").contains("path"),
+        "a collection of paths still names paths");
+
+    assertFalse(attrs(manifest, "types", "--a-string").contains("path"));
+    assertFalse(attrs(manifest, "types", "--a-number").contains("path"));
+    assertFalse(attrs(manifest, "types", "--a-flag").contains("path"));
+    assertFalse(attrs(manifest, "types", "--string-list").contains("path"));
+  }
+
+  @Test
+  void valueVersusFlagIsRecorded() {
+    String manifest = PathManifest.render(new CommandLine(new TypesCommand()), false);
+    assertTrue(attrs(manifest, "types", "--a-string").contains("value"));
+    assertTrue(attrs(manifest, "types", "--a-flag").contains("flag"));
+    assertFalse(attrs(manifest, "types", "--a-flag").contains("value"));
+  }
+
+  // ── create=self vs create=parent ───────────────────────────────────────────
+
+  @Command(name = "hints")
+  static class HintsCommand implements Callable<Integer> {
+    @Option(names = "--labelled-dir", paramLabel = "DIR") Path labelledDir;
+    @Option(names = "--labelled-file", paramLabel = "FILE") Path labelledFile;
+    @Option(names = "--described-dir", description = "Output directory for results") Path describedDir;
+    @Option(names = "--described-file", description = "Path to the log file") Path describedFile;
+    @Option(names = "--unsaid") Path unsaid;
+    public Integer call() { return 0; }
+  }
+
+  @Test
+  void createHintPrefersParamLabelThenDescription() {
+    String manifest = PathManifest.render(new CommandLine(new HintsCommand()), false);
+
+    assertTrue(attrs(manifest, "hints", "--labelled-dir").contains("create=self"));
+    assertTrue(attrs(manifest, "hints", "--labelled-file").contains("create=parent"));
+    assertTrue(attrs(manifest, "hints", "--described-dir").contains("create=self"));
+    assertTrue(attrs(manifest, "hints", "--described-file").contains("create=parent"));
+    // Nothing says which it is. `parent` is the safe answer: it lets the container
+    // create either a file or a directory, and never makes a directory named like a file.
+    assertTrue(attrs(manifest, "hints", "--unsaid").contains("create=parent"));
+  }
+
+  @Test
+  void paramLabelBracketsAreIgnored() {
+    CommandLine cmd = new CommandLine(new HintsCommand());
+    ArgSpec arg = cmd.getCommandSpec().findOption("--labelled-dir");
+    assertEquals("self", PathManifest.createHint(arg));
+  }
+
+  // ── Built-in commands ──────────────────────────────────────────────────────
+
+  @Test
+  void logFileIsHostOnlyAndNeverMounted() {
+    String manifest = PathManifest.render(SpiceLabsCLI.newCommandLine(), false);
+    String logFile = attrs(manifest, "spice/survey/inventory", "--log-file");
+    assertTrue(logFile.contains("hostonly"),
+        "--log-file is written on the host, so the wrapper strips it");
+    assertFalse(logFile.contains("path"),
+        "a host-only argument must never be bind-mounted");
+  }
+
+  @Test
+  void surveyInventoryPositionalsAreSubjectThenInputPath() {
+    String manifest = PathManifest.render(SpiceLabsCLI.newCommandLine(), false);
+    assertFalse(positional(manifest, "spice/survey/inventory", 0).contains("path"),
+        "the subject is a label, not a path");
+    String input = positional(manifest, "spice/survey/inventory", 1);
+    assertTrue(input.contains("path"));
+    assertTrue(input.contains("exists"),
+        "a positional path is an input, so a missing one is an error rather than a mkdir");
+  }
+
+  @Test
+  void everyCommandInTheTreeIsDeclared() {
+    String manifest = PathManifest.render(SpiceLabsCLI.newCommandLine(), false);
+    assertTrue(manifest.contains("\nC spice\n"));
+    assertTrue(manifest.contains("\nC spice/survey/inventory\n"));
+    assertTrue(manifest.contains("\nC spice/pass/decode\n"));
+    assertTrue(manifest.contains("\nC spice/path-manifest\n"));
+  }
+
+  // ── Plugin-contributed options (the --rogues regression) ───────────────────
+
+  @Command(name = "widget", subcommands = WidgetReportCommand.class)
+  static class WidgetCommand implements Callable<Integer> {
+    public Integer call() { return 0; }
+  }
+
+  @Command(name = "report")
+  static class WidgetReportCommand implements Callable<Integer> {
+    @Option(names = "--config", required = true, paramLabel = "FILE") Path config;
+    @Option(names = "--rogues", paramLabel = "FILE") Path rogues;
+    @Option(names = "--out", paramLabel = "DIR") Path out;
+    @Option(names = "--json") boolean json;
+    @Parameters(index = "0") String subject;
+    public Integer call() { return 0; }
+  }
+
+  /**
+   * A plugin's path options must appear without the plugin declaring anything beyond the
+   * field's type. This is the defect that motivated the manifest: {@code --rogues} was a
+   * {@code Path} on a plugin subcommand, but absent from every wrapper's hardcoded list,
+   * so its value reached the container unmounted.
+   */
+  @Test
+  void pluginContributedPathOptionsAreDerivedFromTheirType() {
+    CommandLine root = SpiceLabsCLI.newCommandLine();
+    root.addSubcommand("widget", new CommandLine(new WidgetCommand()));
+
+    String manifest = PathManifest.render(root, false);
+
+    assertTrue(manifest.contains("\nC spice/widget/report\n"),
+        "a plugin's subcommands are part of the command tree");
+    String rogues = attrs(manifest, "spice/widget/report", "--rogues");
+    assertTrue(rogues.contains("path"), "--rogues is a Path, so it is mounted");
+    assertTrue(rogues.contains("create=parent"), "paramLabel=FILE means create the parent");
+    assertFalse(rogues.contains("exists"), "an optional output-ish path may be created");
+
+    assertTrue(attrs(manifest, "spice/widget/report", "--config").contains("exists"),
+        "a required path option names something the user must already have");
+    assertTrue(attrs(manifest, "spice/widget/report", "--out").contains("create=self"),
+        "paramLabel=DIR means create the directory itself");
+    assertFalse(attrs(manifest, "spice/widget/report", "--json").contains("path"));
+  }
+
+  // ── Reserved directories ───────────────────────────────────────────────────
+
+  @Test
+  void filesystemRootsAreReservedExactly() {
+    String manifest = PathManifest.render(SpiceLabsCLI.newCommandLine(), false);
+    assertTrue(manifest.contains("\nR /opt\n"));
+    assertTrue(manifest.contains("\nR /usr\n"));
+    assertTrue(manifest.contains("\nR /var\n"));
+    // /var is reserved but /var/folders (macOS temp dirs) must stay mountable, which is
+    // why R records are matched exactly and only RP records match by prefix.
+    assertFalse(manifest.contains("\nR /tmp\n"));
+    assertFalse(manifest.contains("\nR /home\n"));
+  }
+
+  @Test
+  void installDirsAreDerivedAndOmittedFromBuildTimeOutput() {
+    assertFalse(PathManifest.render(SpiceLabsCLI.newCommandLine(), false).contains("\nRP "),
+        "build-time output is committed into the wrapper, so it must carry no local path");
+    assertFalse(PathManifest.installDirs().isEmpty(),
+        "the CLI's own code source is always somewhere");
+    assertTrue(PathManifest.render(SpiceLabsCLI.newCommandLine(), true).contains("\nRP "));
+  }
+
+  // ── Format ─────────────────────────────────────────────────────────────────
+
+  @Test
+  void everyRecordHasAStableTokenCount() {
+    String manifest = PathManifest.render(SpiceLabsCLI.newCommandLine(), true);
+    assertTrue(manifest.startsWith(PathManifest.HEADER + "\n"));
+    for (String line : manifest.split("\n")) {
+      if (line.startsWith("#")) continue;
+      assertFalse(line.isBlank(), "blank records would confuse the wrapper's parser");
+      String[] fields = line.split(" ");
+      assertFalse(fields[0].isEmpty());
+      switch (fields[0]) {
+        case "V", "G", "R", "RP", "C" -> assertEquals(2, fields.length,
+            "single-value record must not contain whitespace: " + line);
+        case "O", "P" -> assertTrue(fields.length >= 4, "under-specified record: " + line);
+        default -> fail("unknown record kind in: " + line);
+      }
+    }
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  /** The attribute text of one option record, or "" if the option is absent. */
+  private static String attrs(String manifest, String cmdpath, String name) {
+    return record(manifest, "O " + cmdpath + " " + name);
+  }
+
+  private static String positional(String manifest, String cmdpath, int index) {
+    return record(manifest, "P " + cmdpath + " " + index);
+  }
+
+  private static String record(String manifest, String prefix) {
+    for (String line : manifest.split("\n")) {
+      if (line.equals(prefix) || line.startsWith(prefix + " ")) {
+        return line.substring(prefix.length());
+      }
+    }
+    return "";
+  }
+}

--- a/src/test/java/io/spicelabs/cli/PathManifestTest.java
+++ b/src/test/java/io/spicelabs/cli/PathManifestTest.java
@@ -163,8 +163,11 @@ class PathManifestTest {
     assertTrue(rogues.contains("create=parent"), "paramLabel=FILE means create the parent");
     assertFalse(rogues.contains("exists"), "an optional output-ish path may be created");
 
-    assertTrue(attrs(manifest, "spice/widget/report", "--config").contains("exists"),
-        "a required path option names something the user must already have");
+    // `required` says the flag must be given, not that its target already exists —
+    // `registry init --file` names a file it is about to create. Enforcing existence in
+    // the wrapper would break that, and pre-empt the CLI's diagnostic for the rest.
+    assertFalse(attrs(manifest, "spice/widget/report", "--config").contains("exists"),
+        "a required path option is still the CLI's to validate, not the wrapper's");
     assertTrue(attrs(manifest, "spice/widget/report", "--out").contains("create=self"),
         "paramLabel=DIR means create the directory itself");
     assertFalse(attrs(manifest, "spice/widget/report", "--json").contains("path"));


### PR DESCRIPTION
First of two stacked PRs. This one adds the generator; **nothing consumes it yet**, so there is no behaviour change. [#2 rewrites the wrappers](https://github.com/spice-labs-inc/spice-labs-cli/compare/jon/path-manifest-generator...jon/path-manifest-wrappers).

## Why

tl;dr This allows arbitrary plugin flags to reference files/directories, so they can be passed across the container boundary by means of mounting, without maintaining a list of the flags.

The `spice` wrapper runs on the host, before `docker run`, so it has to know which arguments are host filesystem paths *before* the JVM — and its picocli model — exists. So it carried a hardcoded list of path flags. That list drifted, and could never cover a plugin's options at all:

```
spice registry cbom --config ./allspice.toml --rogues ./rogues.json
```

`--rogues` is declared as a `java.nio.file.Path` in allspice's plugin, but appears in no wrapper's list, so the value reaches the container with nothing mounted for it and the command fails.

**Correction to an earlier version of this description:** `registry cbom` is not on allspice's `main` yet — it lives on an unmerged branch, so that command does not fail *today*; it will the moment it lands. On `main` the plugin's only `Path` options are `--config`, `--output` and `--discovery`, which the hardcoded list does happen to cover. The point stands and is structural rather than incidental: a list maintained in this repo cannot cover options declared in another, and the first plugin option to fall outside it breaks silently at runtime. `--dir` and `--file` are the same drift from the other direction — in the registry list, declared by no subcommand.

## What

`PathManifest` walks the fully-assembled command tree — after `PluginLoader` has mounted every plugin — and renders which arguments are paths. **A plugin declares one simply by typing it as `Path` or `File`**, so there is no new SPI method, no `SpiceContext.API_VERSION` bump, and already-published plugin jars are covered without changing them.

```
# spice-path-manifest 1
C spice/registry/cbom
O spice/registry/cbom --rogues value path create=parent
P spice/survey/inventory 1 value path create=self exists
```

Line-oriented and whitespace-separated so bash 3.2 (macOS) and PowerShell 5.1 can both parse it without `jq`. Records are scoped per command because a flat table cannot work: `registry discover --output` is a file and `registry cbom --output` is a directory, and one `--output` entry would create a *directory* named `discovery.toml`.

Two entry points: `spice path-manifest` (hidden) resolves through `CommandSpec.root()` so plugins are included, and a build-time `main()` that deliberately omits both plugins and install directories — that output gets committed into the wrapper, so it must not vary by machine.

## Judgement call worth reviewing

A type cannot say whether a `Path` names a file or a directory. `createHint` reads `paramLabel` (`DIR`/`FILE`) first, then the description text, then defaults to creating the **parent** — which lets the container create either, and never makes a directory where a file belongs. Worst case the command mkdirs its own output directory, which they all already do. I documented `paramLabel = "DIR"/"FILE"` as a convention in `SpiceCommandPlugin`'s javadoc rather than a contract.

## Testing

`PathManifestTest` covers type derivation (`Path`, `File`, `Path[]`, `List<Path>` in; `String`, `Integer`, `boolean` out), each `createHint` rule, `--log-file` being marked host-only and never mounted, and a synthetic plugin that reproduces the `--rogues` defect without depending on allspice. `mvn test` is green on this commit alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
