### PR TITLE
Drive the wrappers from the path manifest, mounting paths at their own path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,9 +68,12 @@ jobs:
       # invocation for all files, so a single run reports every finding.
       - name: Run ShellCheck on shell scripts
         run: |
+          # `spice` embeds shared/path-manifest.bash, so checking the wrapper
+          # covers the shared library in the context it actually runs in.
           docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck:v0.11.0 \
             install.sh \
             test/wrapper/entrypoint.sh \
+            scripts/update-path-manifest.sh \
             spice
 
       - name: Run PSScriptAnalyzer on PowerShell scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -157,6 +157,10 @@ COPY --from=builder /workspace/target/plugins/ ./plugins/
 COPY --from=builder /workspace/src/main/resources/jfr/spice-jfr.jfc ./spice-jfr.jfc
 COPY --from=builder /workspace/spice ./spice
 COPY --from=builder /workspace/spice.ps1 ./spice.ps1
+# No path manifest is baked into the image: `spice path-manifest` renders it from the
+# live command model, so it stays correct when the enterprise/federal images layer
+# further plugins on top of this one. install.sh seeds it, and the wrapper refreshes
+# it per image ID.
 
 # -cp (not -jar) so plugins/* joins the classpath; the wildcard is quoted so the JVM,
 # not the shell, expands it. Main class is named explicitly.

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ spice pass decode
 | `--threads` | Number of threads to use | half of available CPU cores |
 | `--max-records` | Max records to process per batch | `5000` |
 | `--chunk-size` | Target chunk size in MB for uploads | `64` |
-| `--goat-rodeo-args` | Additional GoatRodeo args in key=value format | _(none)_ |
-| `--ginger-args` | Additional Ginger args in key=value format | _(none)_ |
+| `--analysis-args` | Additional analysis args in key=value format | _(none)_ |
+| `--upload-args` | Additional upload args in key=value format | _(none)_ |
 
 ### Runtime Survey
 

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # To Install : `curl -sSfL https://install.spicelabs.io | bash`
 
 TARGET_DIR="${HOME}/.local/bin"
+DATA_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/spice"
 COMPLETION_DIR="${HOME}/.local/share/spice/completions"
 SCRIPT_URL="https://github.com/spice-labs-inc/spice-labs-cli/releases/latest/download/spice"
 
@@ -28,6 +29,19 @@ else
   rm -f "$COMPLETION_DIR/spice.bash.tmp"
   echo "💡 Skipped tab completion (needs Docker + the spice image). Generate it later with:"
   echo "   spice generate-completion > \"$COMPLETION_DIR/spice.bash\""
+fi
+
+# Seed the path manifest from the same image, so the first invocation already
+# knows which arguments to bind-mount — including any plugin's. The wrapper
+# refreshes this itself when the image changes; this only removes the cost from
+# the first run. Skipped gracefully, exactly like completion above.
+mkdir -p "$DATA_DIR"
+if SPICE_LABS_CLI_SKIP_PULL=1 SPICE_SKIP_MANIFEST_REFRESH=1 \
+     "$TARGET_DIR/spice" path-manifest > "$DATA_DIR/path-manifest.tmp" 2>/dev/null \
+   && grep -q '^# spice-path-manifest ' "$DATA_DIR/path-manifest.tmp"; then
+  mv "$DATA_DIR/path-manifest.tmp" "$DATA_DIR/path-manifest"
+else
+  rm -f "$DATA_DIR/path-manifest.tmp"
 fi
 
 if [[ ":$PATH:" != *":$TARGET_DIR:"* ]]; then

--- a/scripts/update-path-manifest.sh
+++ b/scripts/update-path-manifest.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 Spice Labs, Inc. & Contributors
+#
+# Regenerates the two spliced regions in the wrapper scripts:
+#
+#   BEGIN/END SHARED path-manifest.bash  — the canonical argument-walking code,
+#     kept in shared/path-manifest.bash so `spice` and allspice's wrapper cannot
+#     drift apart.
+#   BEGIN/END GENERATED PATH MANIFEST    — the built-in commands' path manifest,
+#     the last-resort fallback when the image cannot be queried.
+#
+# Run after changing shared/path-manifest.bash or any command's options.
+# PathManifestGoldenTest fails the build when these regions are stale.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+SHARED="shared/path-manifest.bash"
+MANIFEST="target/spice.path-manifest"
+
+# ── Render the built-ins manifest ────────────────────────────────────────────
+
+echo "Rendering ${MANIFEST}..."
+mvn -q -DskipTests compile
+CP_FILE="$(mktemp)"
+trap 'rm -f "$CP_FILE"' EXIT
+mvn -q dependency:build-classpath "-Dmdep.outputFile=$CP_FILE" -Dmdep.includeScope=runtime
+mkdir -p target
+java -cp "target/classes:$(cat "$CP_FILE")" io.spicelabs.cli.PathManifest "$MANIFEST"
+
+# ── Splice ───────────────────────────────────────────────────────────────────
+
+# splice <file> <begin-marker> <end-marker> <payload-file>
+splice() {
+  local file="$1" begin="$2" end="$3" payload="$4" tmp
+  grep -qF "$begin" "$file" || { echo "❌ $file: missing marker $begin" >&2; exit 1; }
+  grep -qF "$end" "$file" || { echo "❌ $file: missing marker $end" >&2; exit 1; }
+  tmp="$(mktemp)"
+  awk -v begin="$begin" -v end="$end" -v payload="$payload" '
+    index($0, begin) { print; while ((getline line < payload) > 0) print line; skip = 1; next }
+    index($0, end)   { skip = 0 }
+    !skip            { print }
+  ' "$file" >"$tmp"
+  mv "$tmp" "$file"
+  chmod +x "$file" 2>/dev/null || true
+}
+
+BODY="$(mktemp)"
+trap 'rm -f "$CP_FILE" "$BODY"' EXIT
+
+# The shared library, verbatim.
+cp "$SHARED" "$BODY"
+splice spice "# ── BEGIN SHARED path-manifest.bash ──" \
+             "# ── END SHARED path-manifest.bash ──" "$BODY"
+
+# The manifest, wrapped in the function the library calls for its final fallback.
+{
+  echo "mf_embedded_manifest() {"
+  echo "  cat <<'SPICE_EMBEDDED_MANIFEST'"
+  cat "$MANIFEST"
+  echo "SPICE_EMBEDDED_MANIFEST"
+  echo "}"
+} >"$BODY"
+splice spice "# ── BEGIN GENERATED PATH MANIFEST ──" \
+             "# ── END GENERATED PATH MANIFEST ──" "$BODY"
+
+# PowerShell mirrors the same library and the same manifest.
+if [ -f spice.ps1 ]; then
+  cp shared/path-manifest.ps1 "$BODY"
+  splice spice.ps1 "# ── BEGIN SHARED path-manifest.ps1 ──" \
+                   "# ── END SHARED path-manifest.ps1 ──" "$BODY"
+  {
+    echo "\$MfEmbeddedManifest = @'"
+    cat "$MANIFEST"
+    echo "'@"
+  } >"$BODY"
+  splice spice.ps1 "# ── BEGIN GENERATED PATH MANIFEST ──" \
+                   "# ── END GENERATED PATH MANIFEST ──" "$BODY"
+fi
+
+bash -n spice
+echo "✅ spice and spice.ps1 updated from $SHARED"

--- a/shared/path-manifest.bash
+++ b/shared/path-manifest.bash
@@ -147,7 +147,8 @@ mf_parse() {
         MF_CMDS="${MF_CMDS}${MF_REC}${a}"
         ;;
       O|P)
-        [ -n "$a" ] && [ -n "$b" ] || continue
+        # A record needs both a command path and a name to be usable at all.
+        if [ -z "$a" ] || [ -z "$b" ]; then continue; fi
         # Positionals are keyed by index so they cannot collide with a flag.
         [ "$kind" = "P" ] && b="#${b}"
         key="${a}|${b}"

--- a/shared/path-manifest.bash
+++ b/shared/path-manifest.bash
@@ -28,7 +28,6 @@
 MF_REC=$'\001'
 MF_SEP=$'\002'
 
-MF_LOADED=0
 MF_ROOT="spice"
 MF_CMDS=""            # \001<cmdpath>\001…  — command nodes
 MF_ATTRS=""           # \001<cmdpath>|<name>\002<attrs>\001…  — scoped lookup
@@ -113,6 +112,9 @@ mf_refresh() {
   if mkdir -p "$cache_dir" 2>/dev/null; then
     printf '%s\n' "$text" >"$cache_file" 2>/dev/null || true
     # Keep the cache from growing without bound as images come and go.
+    # Cache entries are named after image IDs, so they are always plain hex —
+    # `ls` parsing is safe here in a way it would not be for arbitrary names.
+    # shellcheck disable=SC2012
     {
       ls -1t "$cache_dir" 2>/dev/null | tail -n +11 | while read -r stale; do
         rm -f "${cache_dir}/${stale}" 2>/dev/null || true
@@ -129,7 +131,6 @@ mf_parse() {
   local kind a b rest key attrs first_cmd=""
   MF_CMDS=""; MF_ATTRS=""; MF_INHERITED=""; MF_FLAT=""
   MF_RESERVED_EXACT=":"; MF_RESERVED_PREFIX=":"
-  MF_LOADED=0
 
   # Matched anywhere rather than at the start: a warning logged to stdout inside
   # the container would otherwise be enough to reject an otherwise good manifest.
@@ -169,7 +170,6 @@ EOF
   MF_INHERITED="${MF_INHERITED}${MF_REC}"
   MF_FLAT="${MF_FLAT}${MF_REC}"
   [ -n "$first_cmd" ] && MF_ROOT="$first_cmd"
-  MF_LOADED=1
   return 0
 }
 
@@ -192,11 +192,15 @@ mf_flat_merge() {
 # ── Lookup ───────────────────────────────────────────────────────────────────
 
 # Echo the attribute string stored for $2 in table $1, or nothing.
+#
+# The delimiters and the key are quoted so they match literally: only the
+# leading `*` is meant as a wildcard. Unquoted, an option name containing a
+# glob character would be matched as a pattern rather than looked up.
 mf_raw_lookup() {
   local table="$1" key="$2" rest
-  rest="${table#*${MF_REC}${key}${MF_SEP}}"
+  rest="${table#*"${MF_REC}${key}${MF_SEP}"}"
   [ "$rest" = "$table" ] && return 1
-  printf '%s' "${rest%%${MF_REC}*}"
+  printf '%s' "${rest%%"${MF_REC}"*}"
 }
 
 # Resolve the attributes of <cmdpath> <name> into MF_A, trying in order:
@@ -319,7 +323,9 @@ mount_path() {
     mf_mount "$dir_abs" "$target"
   fi
 
-  container="${target}${abs#$dir_abs}"
+  # Quoted so a directory whose name contains a glob character is stripped
+  # literally rather than matched as a pattern.
+  container="${target}${abs#"$dir_abs"}"
   MF_RESULT="$container"
 }
 

--- a/shared/path-manifest.bash
+++ b/shared/path-manifest.bash
@@ -55,32 +55,36 @@ MF_MOUNT_N=0
 # floor. This must never abort the CLI — at worst the wrapper behaves as it did
 # before manifests existed.
 mf_load() {
-  local text=""
+  local text installed
 
   # 1. Explicit override (tests, air-gapped installs).
   if [ -n "${SPICE_PATH_MANIFEST:-}" ] && [ -f "${SPICE_PATH_MANIFEST}" ]; then
     text="$(cat "${SPICE_PATH_MANIFEST}" 2>/dev/null)" || text=""
+    if mf_parse "$text"; then return 0; fi
   fi
 
   # 2. Per-image cache, refreshed from the image when cold.
-  if [ -z "$text" ]; then
-    text="$(mf_refresh)" || text=""
-  fi
+  text="$(mf_refresh)" || text=""
+  if mf_parse "$text"; then return 0; fi
 
   # 3. Manifest installed alongside the wrapper by install.sh. Each wrapper sets
   #    MF_INSTALLED_MANIFEST to its own file: loading another CLI's manifest
   #    would describe a command tree this wrapper never sees.
-  if [ -z "$text" ]; then
-    local installed="${MF_INSTALLED_MANIFEST:-${XDG_DATA_HOME:-$HOME/.local/share}/spice/path-manifest}"
-    [ -f "$installed" ] && { text="$(cat "$installed" 2>/dev/null)" || text=""; }
+  installed="${MF_INSTALLED_MANIFEST:-${XDG_DATA_HOME:-$HOME/.local/share}/spice/path-manifest}"
+  if [ -f "$installed" ]; then
+    text="$(cat "$installed" 2>/dev/null)" || text=""
+    if mf_parse "$text"; then return 0; fi
   fi
 
   # 4. Built-ins, embedded in this script at build time.
-  if [ -z "$text" ]; then
-    text="$(mf_embedded_manifest)" || text=""
-  fi
+  text="$(mf_embedded_manifest)" || text=""
+  mf_parse "$text" || true
 
-  mf_parse "$text"
+  # Always succeeds. A manifest that cannot be parsed at any tier leaves the
+  # tables empty, which makes the wrapper pass arguments through untouched —
+  # degraded, but working. Returning non-zero here would instead abort the whole
+  # script under `set -e`, which is the opposite of the intent.
+  return 0
 }
 
 # Echo the manifest for $IMAGE_REF, using a cache keyed by the image ID so a

--- a/shared/path-manifest.bash
+++ b/shared/path-manifest.bash
@@ -1,0 +1,437 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 Spice Labs, Inc. & Contributors
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Path-manifest driven argument walking.
+#
+# CANONICAL SOURCE: spice-labs-cli/shared/path-manifest.bash
+# This block is spliced verbatim into the `spice` wrapper and vendored into
+# allspice's `allspice` wrapper. Edit it here; CI checks the copies match.
+#
+# The wrappers run on the HOST, before `docker run`, so they must know which
+# arguments are host filesystem paths before the JVM (and its picocli model)
+# exists. Rather than hardcode a flag list — which drifted from the commands,
+# and could never cover third-party plugins — they read a *path manifest*
+# rendered from the live command model inside the image. See PathManifest.java.
+#
+# Mounting strategy: identity mounts (`-v $dir:$dir`), so a path's container
+# location equals its host location and arguments need only be absolutised.
+# The one exception is a path under a reserved directory (mounting the host's
+# /opt over the image's would destroy the installation), which is remapped to
+# /mnt/spice/N and recorded in SPICE_PATH_MAP for PathTranslator to reverse.
+#
+# Bash 3.2 (macOS system bash) — no associative arrays, no ${var,,}, no mapfile.
+# Lookup tables are therefore single strings delimited by \001 (record) and
+# \002 (key/value), searched with parameter expansion rather than loops.
+# ─────────────────────────────────────────────────────────────────────────────
+
+MF_REC=$'\001'
+MF_SEP=$'\002'
+
+MF_LOADED=0
+MF_ROOT="spice"
+MF_CMDS=""            # \001<cmdpath>\001…  — command nodes
+MF_ATTRS=""           # \001<cmdpath>|<name>\002<attrs>\001…  — scoped lookup
+MF_INHERITED=""       # same, but only args marked `inherit`
+MF_FLAT=""            # \001<name>\002<attrs>\001…  — union across all commands
+MF_RESERVED_EXACT=""  # :/:/usr:…: — matched exactly, never by prefix
+MF_RESERVED_PREFIX="" # :/opt/allspice:…: — matched by prefix
+
+# Outputs, consumed by the caller after walk_args.
+MF_ARGS=()
+MF_VOLUMES=()
+MF_PATH_MAP=()
+MF_RESULT=""
+
+MF_SEEN_DIRS=""       # :dir:… — directories already mounted
+MF_IDENTITY_DIRS=":"  # :dir:… — of those, the ones mounted at their host path
+MF_MOUNT_MAP=""       # \001<hostdir>\002<containerdir>\001… — assigned targets
+MF_MOUNT_N=0
+
+# ── Loading ──────────────────────────────────────────────────────────────────
+
+# Resolve a manifest into MF_* tables. Every tier is best-effort: an unreadable
+# file, a failed `docker run`, or an image too old to know `path-manifest` all
+# fall through to the next tier, and the embedded built-ins manifest is the
+# floor. This must never abort the CLI — at worst the wrapper behaves as it did
+# before manifests existed.
+mf_load() {
+  local text=""
+
+  # 1. Explicit override (tests, air-gapped installs).
+  if [ -n "${SPICE_PATH_MANIFEST:-}" ] && [ -f "${SPICE_PATH_MANIFEST}" ]; then
+    text="$(cat "${SPICE_PATH_MANIFEST}" 2>/dev/null)" || text=""
+  fi
+
+  # 2. Per-image cache, refreshed from the image when cold.
+  if [ -z "$text" ]; then
+    text="$(mf_refresh)" || text=""
+  fi
+
+  # 3. Manifest installed alongside the wrapper by install.sh. Each wrapper sets
+  #    MF_INSTALLED_MANIFEST to its own file: loading another CLI's manifest
+  #    would describe a command tree this wrapper never sees.
+  if [ -z "$text" ]; then
+    local installed="${MF_INSTALLED_MANIFEST:-${XDG_DATA_HOME:-$HOME/.local/share}/spice/path-manifest}"
+    [ -f "$installed" ] && { text="$(cat "$installed" 2>/dev/null)" || text=""; }
+  fi
+
+  # 4. Built-ins, embedded in this script at build time.
+  if [ -z "$text" ]; then
+    text="$(mf_embedded_manifest)" || text=""
+  fi
+
+  mf_parse "$text"
+}
+
+# Echo the manifest for $IMAGE_REF, using a cache keyed by the image ID so a
+# `docker pull` invalidates it automatically — no TTL, no staleness heuristics.
+mf_refresh() {
+  [ "${SPICE_SKIP_MANIFEST_REFRESH:-0}" = "1" ] && return 1
+  command -v docker >/dev/null 2>&1 || return 1
+
+  local image_id cache_dir cache_file
+  image_id="$(docker image inspect --format '{{.Id}}' "$IMAGE_REF" 2>/dev/null)" || return 1
+  [ -n "$image_id" ] || return 1
+
+  cache_dir="${SPICE_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/spice}/path-manifest"
+  # Image IDs are `sha256:<hex>`; the colon is legal in a filename but awkward.
+  cache_file="${cache_dir}/${image_id#sha256:}"
+
+  if [ -s "$cache_file" ]; then
+    cat "$cache_file" 2>/dev/null
+    return 0
+  fi
+
+  local text
+  text="$(docker run --rm ${PULL_FLAG:+$PULL_FLAG} "$IMAGE_REF" path-manifest 2>/dev/null)" || return 1
+  case "$text" in
+    *"# spice-path-manifest "*) ;;
+    *) return 1 ;;  # an image too old to know the command, or log noise only
+  esac
+
+  if mkdir -p "$cache_dir" 2>/dev/null; then
+    printf '%s\n' "$text" >"$cache_file" 2>/dev/null || true
+    # Keep the cache from growing without bound as images come and go.
+    {
+      ls -1t "$cache_dir" 2>/dev/null | tail -n +11 | while read -r stale; do
+        rm -f "${cache_dir}/${stale}" 2>/dev/null || true
+      done
+    } || true
+  fi
+  printf '%s\n' "$text"
+}
+
+# Build the lookup tables from manifest text. Unrecognised lines are ignored
+# rather than rejected, so log output that leaks onto stdout inside the
+# container cannot corrupt the tables.
+mf_parse() {
+  local kind a b rest key attrs first_cmd=""
+  MF_CMDS=""; MF_ATTRS=""; MF_INHERITED=""; MF_FLAT=""
+  MF_RESERVED_EXACT=":"; MF_RESERVED_PREFIX=":"
+  MF_LOADED=0
+
+  # Matched anywhere rather than at the start: a warning logged to stdout inside
+  # the container would otherwise be enough to reject an otherwise good manifest.
+  case "$1" in
+    *"# spice-path-manifest 1"$'\n'*) ;;
+    *) return 1 ;;  # unknown schema version — leave the tables empty
+  esac
+
+  while read -r kind a b rest; do
+    case "$kind" in
+      C)
+        [ -n "$a" ] || continue
+        [ -n "$first_cmd" ] || first_cmd="$a"
+        MF_CMDS="${MF_CMDS}${MF_REC}${a}"
+        ;;
+      O|P)
+        [ -n "$a" ] && [ -n "$b" ] || continue
+        # Positionals are keyed by index so they cannot collide with a flag.
+        [ "$kind" = "P" ] && b="#${b}"
+        key="${a}|${b}"
+        attrs=" ${rest} "
+        MF_ATTRS="${MF_ATTRS}${MF_REC}${key}${MF_SEP}${attrs}"
+        case "$attrs" in *" inherit "*)
+          MF_INHERITED="${MF_INHERITED}${MF_REC}${key}${MF_SEP}${attrs}" ;;
+        esac
+        [ "$kind" = "O" ] && mf_flat_merge "$b" "$attrs"
+        ;;
+      R)  [ -n "$a" ] && MF_RESERVED_EXACT="${MF_RESERVED_EXACT}${a}:" ;;
+      RP) [ -n "$a" ] && MF_RESERVED_PREFIX="${MF_RESERVED_PREFIX}${a}:" ;;
+    esac
+  done <<EOF
+$1
+EOF
+
+  MF_CMDS="${MF_CMDS}${MF_REC}"
+  MF_ATTRS="${MF_ATTRS}${MF_REC}"
+  MF_INHERITED="${MF_INHERITED}${MF_REC}"
+  MF_FLAT="${MF_FLAT}${MF_REC}"
+  [ -n "$first_cmd" ] && MF_ROOT="$first_cmd"
+  MF_LOADED=1
+  return 0
+}
+
+# Merge one option's attributes into the flat (command-agnostic) fallback table.
+# The union is deliberately conservative: `create=parent` and never `exists`, so
+# that falling back can neither create a directory where a file belongs nor
+# reject a path the command would have accepted.
+mf_flat_merge() {
+  local name="$1" attrs="$2" existing merged
+  existing="$(mf_raw_lookup "$MF_FLAT" "$name")" || existing=""
+  merged=" "
+  case "${existing}${attrs}" in *" value "*) merged="${merged}value " ;; esac
+  case "${existing}${attrs}" in *" path "*) merged="${merged}path create=parent " ;; esac
+  case "${existing}${attrs}" in *" hostonly "*) merged="${merged}hostonly " ;; esac
+  # Prepended, not replaced: mf_raw_lookup finds the first match, so the newest
+  # merge wins and the superseded record is simply never read.
+  MF_FLAT="${MF_REC}${name}${MF_SEP}${merged}${MF_FLAT}"
+}
+
+# ── Lookup ───────────────────────────────────────────────────────────────────
+
+# Echo the attribute string stored for $2 in table $1, or nothing.
+mf_raw_lookup() {
+  local table="$1" key="$2" rest
+  rest="${table#*${MF_REC}${key}${MF_SEP}}"
+  [ "$rest" = "$table" ] && return 1
+  printf '%s' "${rest%%${MF_REC}*}"
+}
+
+# Resolve the attributes of <cmdpath> <name> into MF_A, trying in order:
+# the exact command, then any ancestor that declares the arg as inherited, then
+# the flat union. The flat tier exists so that a manifest older than the image
+# (or missing entirely) degrades to roughly the previous behaviour instead of
+# mis-parsing the command line.
+mf_attrs() {
+  local cmdpath="$1" name="$2" ancestor
+  MF_A="$(mf_raw_lookup "$MF_ATTRS" "${cmdpath}|${name}")" && return 0
+  ancestor="$cmdpath"
+  while [ "$ancestor" != "${ancestor%/*}" ]; do
+    ancestor="${ancestor%/*}"
+    MF_A="$(mf_raw_lookup "$MF_INHERITED" "${ancestor}|${name}")" && return 0
+  done
+  MF_A="$(mf_raw_lookup "$MF_FLAT" "$name")" && return 0
+  MF_A=""
+  return 1
+}
+
+mf_is_cmd() {
+  case "$MF_CMDS" in *"${MF_REC}${1}${MF_REC}"*) return 0 ;; esac
+  return 1
+}
+
+# Whether $1 is the leaf name of any command, at any depth. Used where a branch
+# scans arguments without tracking its position in the command tree.
+mf_is_cmd_token() {
+  case "$MF_CMDS" in *"/${1}${MF_REC}"*) return 0 ;; esac
+  return 1
+}
+
+mf_has() { # $1=attrs $2=attribute
+  case "$1" in *" ${2} "*) return 0 ;; esac
+  return 1
+}
+
+mf_takes_value() { mf_attrs "$1" "$2" || return 1; mf_has "$MF_A" value; }
+mf_is_hostonly() { mf_attrs "$1" "$2" || return 1; mf_has "$MF_A" hostonly; }
+mf_is_path() { mf_attrs "$1" "$2" || return 1; mf_has "$MF_A" path; }
+
+# Whether a directory must not be shadowed by a bind mount. Filesystem roots
+# match exactly — /var must be protected while the macOS temp dirs beneath it
+# (/var/folders/…) stay mountable — whereas install directories match by prefix,
+# since everything below /opt/allspice belongs to the image.
+mf_reserved() {
+  local dir="$1" prefix rest
+  case "$MF_RESERVED_EXACT" in *":${dir}:"*) return 0 ;; esac
+  rest="${MF_RESERVED_PREFIX#:}"
+  while [ -n "$rest" ]; do
+    prefix="${rest%%:*}"
+    rest="${rest#*:}"
+    [ -n "$prefix" ] || continue
+    [ "$dir" = "$prefix" ] && return 0
+    case "$dir" in "${prefix}"/*) return 0 ;; esac
+  done
+  return 1
+}
+
+# ── Mounting ─────────────────────────────────────────────────────────────────
+
+# Resolve one path argument for use inside the container, adding whatever bind
+# mount it needs, and leave the result in MF_RESULT.
+#
+# Sets a global rather than echoing because command substitution would run this
+# in a subshell and discard the mounts it registers.
+#
+# $1 value  $2 create mode (self|parent)  $3 must-already-exist (0|1)
+mount_path() {
+  local value="$1" create="$2" must_exist="$3"
+  local dir dir_abs abs target container
+
+  [[ "$value" == ~* ]] && value="${value/#\~/$HOME}"
+  MF_RESULT="$value"
+
+  # A URL or a bare `key=value` is not a host path even on a Path-typed option.
+  case "$value" in *://*) return 0 ;; esac
+
+  if [ -e "$value" ]; then
+    if [ -d "$value" ]; then dir="$value"; else dir="$(dirname "$value")"; fi
+  elif [ "$must_exist" = "1" ]; then
+    echo "ERROR ❌ Input path does not exist: $value" >&2
+    echo "INFO  Use --help for usage information." >&2
+    exit 2
+  elif [ "$create" = "self" ]; then
+    mkdir -p "$value" 2>/dev/null || return 0
+    dir="$value"
+  else
+    dir="$(dirname "$value")"
+    mkdir -p "$dir" 2>/dev/null || return 0
+  fi
+
+  # If the directory still isn't there, the value was probably never a path.
+  # Pass it through untouched and let the CLI produce the real diagnostic.
+  [ -d "$dir" ] || return 0
+  dir_abs="$(cd "$dir" 2>/dev/null && pwd)" || return 0
+  if [ -d "$value" ]; then
+    abs="$dir_abs"
+  else
+    abs="${dir_abs%/}/$(basename "$value")"
+  fi
+
+  target="$(mf_raw_lookup "$MF_MOUNT_MAP" "$dir_abs")" || target=""
+  if [ -z "$target" ] && mf_under_identity_mount "$dir_abs"; then
+    # Already visible through an ancestor's identity mount; a nested bind mount
+    # would add nothing.
+    target="$dir_abs"
+  fi
+  if [ -z "$target" ]; then
+    if mf_reserved "$dir_abs"; then
+      # Mounting here would hide part of the image, so relocate and record the
+      # mapping for PathTranslator to reverse in user-facing messages.
+      MF_MOUNT_N=$((MF_MOUNT_N + 1))
+      target="/mnt/spice/${MF_MOUNT_N}"
+      MF_PATH_MAP+=("${target}:${dir_abs}")
+    else
+      target="$dir_abs"
+    fi
+    MF_MOUNT_MAP="${MF_MOUNT_MAP}${MF_REC}${dir_abs}${MF_SEP}${target}${MF_REC}"
+    mf_mount "$dir_abs" "$target"
+  fi
+
+  container="${target}${abs#$dir_abs}"
+  MF_RESULT="$container"
+}
+
+# Add a deduped bind mount, recording identity mounts so nested paths can reuse
+# them instead of stacking a redundant mount inside one.
+mf_mount() {
+  local host="$1" container="$2"
+  case ":$MF_SEEN_DIRS:" in *":${host}:"*) return 0 ;; esac
+  MF_SEEN_DIRS="${MF_SEEN_DIRS}:${host}"
+  [ "$host" = "$container" ] && MF_IDENTITY_DIRS="${MF_IDENTITY_DIRS}${host}:"
+  MF_VOLUMES+=("-v" "${host}:${container}")
+  return 0
+}
+
+# Whether $1 is already reachable inside the container via an identity mount of
+# one of its ancestors.
+mf_under_identity_mount() {
+  local dir="$1" rest prefix
+  rest="${MF_IDENTITY_DIRS#:}"
+  while [ -n "$rest" ]; do
+    prefix="${rest%%:*}"
+    rest="${rest#*:}"
+    [ -n "$prefix" ] || continue
+    case "$dir" in "${prefix}"/*) return 0 ;; esac
+  done
+  return 1
+}
+
+# ── Argument walking ─────────────────────────────────────────────────────────
+
+# Rewrite "$@" into MF_ARGS, mounting every argument the manifest calls a path.
+walk_args() {
+  local cmdpath="$MF_ROOT" posidx=0 pending="" endopts=0
+  local arg flag val create must_exist
+  MF_ARGS=()
+
+  for arg in "$@"; do
+    if [ "$endopts" = "1" ]; then
+      MF_ARGS+=("$arg")
+      continue
+    fi
+
+    # The value of a flag seen on the previous iteration.
+    if [ -n "$pending" ]; then
+      if mf_is_hostonly "$cmdpath" "$pending"; then
+        : # the wrapper handles it; strip both tokens
+      elif mf_is_path "$cmdpath" "$pending"; then
+        mf_create_args "$MF_A"
+        mount_path "$arg" "$create" "$must_exist"
+        MF_ARGS+=("$pending" "$MF_RESULT")
+      else
+        MF_ARGS+=("$pending" "$arg")
+      fi
+      pending=""
+      continue
+    fi
+
+    if [ "$arg" = "--" ]; then
+      endopts=1
+      MF_ARGS+=("$arg")
+      continue
+    fi
+
+    if [[ "$arg" == -* ]]; then
+      flag="${arg%%=*}"
+      if [ "$flag" != "$arg" ]; then
+        val="${arg#*=}"
+        if mf_is_hostonly "$cmdpath" "$flag"; then
+          continue
+        elif mf_is_path "$cmdpath" "$flag"; then
+          mf_create_args "$MF_A"
+          mount_path "$val" "$create" "$must_exist"
+          MF_ARGS+=("${flag}=${MF_RESULT}")
+        else
+          MF_ARGS+=("$arg")
+        fi
+      elif mf_takes_value "$cmdpath" "$arg"; then
+        pending="$arg"
+      elif mf_is_hostonly "$cmdpath" "$arg"; then
+        : # a valueless host-only flag
+      else
+        MF_ARGS+=("$arg")
+      fi
+      continue
+    fi
+
+    # A positional token descends into a subcommand only before any positional
+    # has been consumed here, so a subject that happens to be named `run` or
+    # `status` is still treated as a subject.
+    if [ "$posidx" = "0" ] && mf_is_cmd "${cmdpath}/${arg}"; then
+      cmdpath="${cmdpath}/${arg}"
+      MF_ARGS+=("$arg")
+      continue
+    fi
+
+    if mf_attrs "$cmdpath" "#${posidx}" && mf_has "$MF_A" path; then
+      mf_create_args "$MF_A"
+      mount_path "$arg" "$create" "$must_exist"
+      MF_ARGS+=("$MF_RESULT")
+    else
+      MF_ARGS+=("$arg")
+    fi
+    posidx=$((posidx + 1))
+  done
+
+  # A trailing flag with no value: pass it through so picocli reports it.
+  [ -n "$pending" ] && MF_ARGS+=("$pending")
+  return 0
+}
+
+# Split an attribute string into the two parameters mount_path needs.
+mf_create_args() {
+  case "$1" in *" create=self "*) create="self" ;; *) create="parent" ;; esac
+  case "$1" in *" exists "*) must_exist="1" ;; *) must_exist="0" ;; esac
+}

--- a/shared/path-manifest.ps1
+++ b/shared/path-manifest.ps1
@@ -120,10 +120,17 @@ function Mf-Parse($text) {
 
   # Matched anywhere rather than at the start: a warning logged to stdout inside
   # the container would otherwise be enough to reject an otherwise good manifest.
-  if (-not $text -or -not ($text -match '(?m)^# spice-path-manifest 1$')) { return }
+  # `\r?` because the manifest embedded in this script arrives with whatever line
+  # endings git checked it out with — CRLF on Windows — and `$` in a .NET regex
+  # matches before the `\n`, i.e. after the `\r`.
+  if (-not $text -or -not ($text -match '(?m)^# spice-path-manifest 1\r?$')) { return }
 
   $firstCmd = ""
-  foreach ($line in ($text -split "`r?`n")) {
+  foreach ($rawLine in ($text -split "`r?`n")) {
+    # Trimmed for the same reason: a trailing \r would otherwise survive into the
+    # last field of every record.
+    $line = $rawLine.Trim()
+    if (-not $line) { continue }
     $f = $line -split '\s+'
     if ($f.Count -lt 2) { continue }
     switch ($f[0]) {

--- a/shared/path-manifest.ps1
+++ b/shared/path-manifest.ps1
@@ -1,0 +1,378 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 Spice Labs, Inc. & Contributors
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Path-manifest driven argument walking — PowerShell mirror of
+# shared/path-manifest.bash. See that file for the design; this one differs only
+# where the platform forces it:
+#
+#   * Windows container paths are not host paths, so an identity mount still
+#     rewrites `C:\work` to `/c/work` and records the pair in SPICE_PATH_MAP for
+#     PathTranslator to reverse. On Linux/macOS Convert-ToDockerPath is the
+#     identity function and no rewriting happens, matching bash exactly.
+#   * Hashtables are available, so the lookup tables are real hashtables rather
+#     than the delimited strings bash 3.2 forces.
+#
+# CANONICAL SOURCE: spice-labs-cli/shared/path-manifest.ps1
+# Spliced into spice.ps1 by scripts/update-path-manifest.sh; CI checks the copy.
+#
+# Windows PowerShell 5.1 compatible — no `??`, no ternary, no `-Parallel`.
+# ─────────────────────────────────────────────────────────────────────────────
+
+$script:MfRoot = 'spice'
+$script:MfCmds = @{}
+$script:MfAttrs = @{}
+$script:MfInherited = @{}
+$script:MfFlat = @{}
+$script:MfReservedExact = @{}
+$script:MfReservedPrefix = @()
+
+$script:MfArgs = @()
+$script:MfVolumes = @()
+$script:MfPathMap = @()
+$script:MfMountMap = @{}
+$script:MfIdentityDirs = @()
+$script:MfMountN = 0
+
+# ── Loading ──────────────────────────────────────────────────────────────────
+
+# Resolve a manifest into the tables above. Every tier is best-effort and the
+# embedded built-ins manifest is the floor, so this can never abort the CLI.
+function Mf-Load {
+  $text = ""
+
+  if ($env:SPICE_PATH_MANIFEST -and (Test-Path -LiteralPath $env:SPICE_PATH_MANIFEST)) {
+    try { $text = Get-Content -LiteralPath $env:SPICE_PATH_MANIFEST -Raw } catch { $text = "" }
+  }
+  if (-not $text) { $text = Mf-Refresh }
+  if (-not $text) {
+    $installed = Join-Path (Mf-DataDir) 'path-manifest'
+    if (Test-Path -LiteralPath $installed) {
+      try { $text = Get-Content -LiteralPath $installed -Raw } catch { $text = "" }
+    }
+  }
+  if (-not $text) { $text = $MfEmbeddedManifest }
+
+  Mf-Parse $text
+}
+
+function Mf-CacheDir {
+  if ($env:SPICE_CACHE_DIR) { return (Join-Path $env:SPICE_CACHE_DIR 'path-manifest') }
+  if ($IsWindows -and $env:LOCALAPPDATA) {
+    return (Join-Path (Join-Path $env:LOCALAPPDATA 'spice') 'path-manifest')
+  }
+  $base = $env:XDG_CACHE_HOME
+  if (-not $base) { $base = Join-Path $HOME '.cache' }
+  return (Join-Path (Join-Path $base 'spice') 'path-manifest')
+}
+
+function Mf-DataDir {
+  if ($IsWindows -and $env:LOCALAPPDATA) { return (Join-Path $env:LOCALAPPDATA 'spice') }
+  $base = $env:XDG_DATA_HOME
+  if (-not $base) { $base = Join-Path (Join-Path $HOME '.local') 'share' }
+  return (Join-Path $base 'spice')
+}
+
+# Return the manifest for $imageRef, cached by image ID so a `docker pull`
+# invalidates it automatically. Returns "" on any failure.
+function Mf-Refresh {
+  if ($env:SPICE_SKIP_MANIFEST_REFRESH -eq '1') { return "" }
+  if (-not (Get-Command docker -ErrorAction SilentlyContinue)) { return "" }
+
+  $ErrorActionPreference = 'Continue'
+  $imageId = (docker image inspect --format '{{.Id}}' "$imageRef" 2>$null | Select-Object -First 1)
+  if (-not $imageId) { return "" }
+
+  $cacheDir = Mf-CacheDir
+  $cacheFile = Join-Path $cacheDir ($imageId -replace '^sha256:', '')
+  if (Test-Path -LiteralPath $cacheFile) {
+    try { return (Get-Content -LiteralPath $cacheFile -Raw) } catch { return "" }
+  }
+
+  $text = (docker run --rm @pullFlag "$imageRef" path-manifest 2>$null) -join "`n"
+  if (-not $text -or -not ($text -match '(?m)^# spice-path-manifest ')) { return "" }
+
+  try {
+    if (-not (Test-Path -LiteralPath $cacheDir)) {
+      New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+    }
+    Set-Content -LiteralPath $cacheFile -Value $text -NoNewline
+    # Keep the cache from growing without bound as images come and go.
+    Get-ChildItem -LiteralPath $cacheDir -File |
+      Sort-Object LastWriteTime -Descending |
+      Select-Object -Skip 10 |
+      ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue }
+  } catch {
+    # An unwritable cache just means the next invocation queries again.
+  }
+  return $text
+}
+
+# Build the lookup tables. Unrecognised lines are ignored rather than rejected,
+# so log output leaking onto stdout in the container cannot corrupt them.
+function Mf-Parse($text) {
+  $script:MfCmds = @{}
+  $script:MfAttrs = @{}
+  $script:MfInherited = @{}
+  $script:MfFlat = @{}
+  $script:MfReservedExact = @{}
+  $script:MfReservedPrefix = @()
+
+  # Matched anywhere rather than at the start: a warning logged to stdout inside
+  # the container would otherwise be enough to reject an otherwise good manifest.
+  if (-not $text -or -not ($text -match '(?m)^# spice-path-manifest 1$')) { return }
+
+  $firstCmd = ""
+  foreach ($line in ($text -split "`r?`n")) {
+    $f = $line -split '\s+'
+    if ($f.Count -lt 2) { continue }
+    switch ($f[0]) {
+      'C' {
+        if (-not $firstCmd) { $firstCmd = $f[1] }
+        $script:MfCmds[$f[1]] = $true
+      }
+      'R'  { $script:MfReservedExact[$f[1]] = $true }
+      'RP' { $script:MfReservedPrefix += $f[1] }
+      default {
+        if ($f[0] -ne 'O' -and $f[0] -ne 'P') { continue }
+        if ($f.Count -lt 3) { continue }
+        $name = $f[2]
+        # Positionals are keyed by index so they cannot collide with a flag.
+        if ($f[0] -eq 'P') { $name = "#$($f[2])" }
+        $attrs = " " + (($f[3..($f.Count - 1)]) -join ' ') + " "
+        $key = "$($f[1])|$name"
+        $script:MfAttrs[$key] = $attrs
+        if ($attrs -like '* inherit *') { $script:MfInherited[$key] = $attrs }
+        if ($f[0] -eq 'O') { Mf-FlatMerge $name $attrs }
+      }
+    }
+  }
+  if ($firstCmd) { $script:MfRoot = $firstCmd }
+}
+
+# Merge one option's attributes into the flat (command-agnostic) fallback. The
+# union is deliberately conservative — `create=parent`, never `exists` — so
+# falling back can neither create a directory where a file belongs nor reject a
+# path the command would have accepted.
+function Mf-FlatMerge($name, $attrs) {
+  $existing = ""
+  if ($script:MfFlat.ContainsKey($name)) { $existing = $script:MfFlat[$name] }
+  $both = $existing + $attrs
+  $merged = " "
+  if ($both -like '* value *') { $merged += "value " }
+  if ($both -like '* path *') { $merged += "path create=parent " }
+  if ($both -like '* hostonly *') { $merged += "hostonly " }
+  $script:MfFlat[$name] = $merged
+}
+
+# ── Lookup ───────────────────────────────────────────────────────────────────
+
+# Attributes of <cmdpath> <name>: the exact command, then any ancestor that
+# declares the arg inherited, then the flat union. The flat tier is what makes a
+# manifest older than the image degrade instead of mis-parsing the command line.
+function Mf-Attrs($cmdpath, $name) {
+  $key = "$cmdpath|$name"
+  if ($script:MfAttrs.ContainsKey($key)) { return $script:MfAttrs[$key] }
+  $ancestor = $cmdpath
+  while ($ancestor -match '/') {
+    $ancestor = $ancestor -replace '/[^/]*$', ''
+    $key = "$ancestor|$name"
+    if ($script:MfInherited.ContainsKey($key)) { return $script:MfInherited[$key] }
+  }
+  if ($script:MfFlat.ContainsKey($name)) { return $script:MfFlat[$name] }
+  return $null
+}
+
+function Mf-Has($attrs, $attribute) {
+  if (-not $attrs) { return $false }
+  return ($attrs -like "* $attribute *")
+}
+
+function Mf-IsCmd($cmdpath) { return $script:MfCmds.ContainsKey($cmdpath) }
+
+# Whether $token is the leaf name of any command, at any depth. Used where a
+# branch scans arguments without tracking its position in the command tree.
+function Mf-IsCmdToken($token) {
+  foreach ($c in $script:MfCmds.Keys) {
+    if ($c -like "*/$token") { return $true }
+  }
+  return $false
+}
+
+function Mf-TakesValue($cmdpath, $name) { return (Mf-Has (Mf-Attrs $cmdpath $name) 'value') }
+function Mf-IsHostOnly($cmdpath, $name) { return (Mf-Has (Mf-Attrs $cmdpath $name) 'hostonly') }
+function Mf-IsPath($cmdpath, $name) { return (Mf-Has (Mf-Attrs $cmdpath $name) 'path') }
+
+# Whether a directory must not be shadowed by a bind mount. Filesystem roots
+# match exactly — /var must be protected while the temp directories beneath it
+# stay mountable — whereas install directories match by prefix, since everything
+# below /opt/allspice belongs to the image.
+function Mf-Reserved($dir) {
+  $normalized = ($dir -replace '\\', '/').TrimEnd('/')
+  if (-not $normalized) { $normalized = '/' }
+  if ($script:MfReservedExact.ContainsKey($normalized)) { return $true }
+  foreach ($prefix in $script:MfReservedPrefix) {
+    if ($normalized -eq $prefix -or $normalized.StartsWith($prefix + '/')) { return $true }
+  }
+  return $false
+}
+
+function Mf-UnderIdentityMount($dir) {
+  foreach ($prefix in $script:MfIdentityDirs) {
+    if ($dir.StartsWith($prefix + [IO.Path]::DirectorySeparatorChar) -or
+        $dir.StartsWith($prefix + '/')) { return $true }
+  }
+  return $false
+}
+
+# ── Mounting ─────────────────────────────────────────────────────────────────
+
+# Add a deduped bind mount, recording identity mounts so nested paths reuse them
+# rather than stacking a redundant mount inside one.
+function Mf-Mount($hostDir, $containerDir) {
+  if ($script:MfMountMap.ContainsKey($hostDir)) { return }
+  $script:MfMountMap[$hostDir] = $containerDir
+  $script:MfVolumes += '-v'
+  $script:MfVolumes += "${hostDir}:${containerDir}"
+  if ($containerDir -eq (Convert-ToDockerPath $hostDir)) { $script:MfIdentityDirs += $hostDir }
+}
+
+# Resolve one path argument for use inside the container, adding whatever bind
+# mount it needs, and return the container-side path.
+function Mount-Path($value, $create, $mustExist) {
+  if ($value -eq '~') { $value = $HOME }
+  elseif ($value -like '~/*' -or $value -like '~\*') {
+    $value = Join-Path $HOME ($value -replace '^~[/\\]')
+  }
+
+  # A URL or a bare key=value is not a host path even on a Path-typed option.
+  if ($value -match '://') { return $value }
+
+  $isDir = Test-Path -LiteralPath $value -PathType Container
+  if (Test-Path -LiteralPath $value) {
+    if ($isDir) { $dir = $value } else { $dir = Split-Path -Parent $value }
+  } elseif ($mustExist) {
+    Write-Host "ERROR ❌ Input path does not exist: $value"
+    Write-Host "INFO  Use --help for usage information."
+    exit 2
+  } elseif ($create -eq 'self') {
+    try { New-Item -ItemType Directory -Path $value -Force | Out-Null } catch { return $value }
+    $dir = $value
+    $isDir = $true
+  } else {
+    $dir = Split-Path -Parent $value
+    if (-not $dir) { $dir = "." }
+    try { New-Item -ItemType Directory -Path $dir -Force | Out-Null } catch { return $value }
+  }
+  if (-not $dir) { $dir = "." }
+
+  # If the directory still isn't there, the value was probably never a path.
+  # Pass it through untouched and let the CLI produce the real diagnostic.
+  if (-not (Test-Path -LiteralPath $dir -PathType Container)) { return $value }
+  try { $dirAbs = (Resolve-Path -LiteralPath $dir -ErrorAction Stop).ProviderPath } catch { return $value }
+  $dirAbs = $dirAbs.TrimEnd([IO.Path]::DirectorySeparatorChar)
+  if ($isDir) { $abs = $dirAbs } else { $abs = Join-Path $dirAbs (Split-Path -Leaf $value) }
+
+  $target = $null
+  if ($script:MfMountMap.ContainsKey($dirAbs)) {
+    $target = $script:MfMountMap[$dirAbs]
+  } elseif (Mf-UnderIdentityMount $dirAbs) {
+    # Already visible through an ancestor's identity mount.
+    $target = Convert-ToDockerPath $dirAbs
+  } else {
+    if (Mf-Reserved (Convert-ToDockerPath $dirAbs)) {
+      # Mounting here would hide part of the image, so relocate and record the
+      # mapping for PathTranslator to reverse in user-facing messages.
+      $script:MfMountN++
+      $target = "/mnt/spice/$($script:MfMountN)"
+      $script:MfPathMap += "${target}:${dirAbs}"
+    } else {
+      $target = Convert-ToDockerPath $dirAbs
+      if ($target -ne $dirAbs) { $script:MfPathMap += "${target}:${dirAbs}" }
+    }
+    Mf-Mount $dirAbs $target
+  }
+
+  if ($abs -eq $dirAbs) { return $target }
+  return ($target.TrimEnd('/') + '/' + (Split-Path -Leaf $value))
+}
+
+# ── Argument walking ─────────────────────────────────────────────────────────
+
+# Rewrite $argList into $script:MfArgs, mounting every argument the manifest
+# calls a path.
+function Walk-Args($argList) {
+  $cmdpath = $script:MfRoot
+  $posidx = 0
+  $pending = ""
+  $endOpts = $false
+  $script:MfArgs = @()
+
+  foreach ($arg in $argList) {
+    if ($endOpts) { $script:MfArgs += $arg; continue }
+
+    # The value of a flag seen on the previous iteration.
+    if ($pending) {
+      if (Mf-IsHostOnly $cmdpath $pending) {
+        # the wrapper handles it; strip both tokens
+      } elseif (Mf-IsPath $cmdpath $pending) {
+        $a = Mf-Attrs $cmdpath $pending
+        $script:MfArgs += $pending
+        $script:MfArgs += (Mount-Path $arg (Mf-CreateMode $a) (Mf-Has $a 'exists'))
+      } else {
+        $script:MfArgs += $pending
+        $script:MfArgs += $arg
+      }
+      $pending = ""
+      continue
+    }
+
+    if ($arg -eq '--') { $endOpts = $true; $script:MfArgs += $arg; continue }
+
+    if ($arg -like '-*') {
+      if ($arg -match '^([^=]+)=(.*)$') {
+        $flag = $matches[1]
+        $val = $matches[2]
+        if (Mf-IsHostOnly $cmdpath $flag) {
+          continue
+        } elseif (Mf-IsPath $cmdpath $flag) {
+          $a = Mf-Attrs $cmdpath $flag
+          $script:MfArgs += "$flag=$(Mount-Path $val (Mf-CreateMode $a) (Mf-Has $a 'exists'))"
+        } else {
+          $script:MfArgs += $arg
+        }
+      } elseif (Mf-TakesValue $cmdpath $arg) {
+        $pending = $arg
+      } elseif (Mf-IsHostOnly $cmdpath $arg) {
+        # a valueless host-only flag
+      } else {
+        $script:MfArgs += $arg
+      }
+      continue
+    }
+
+    # A positional token descends into a subcommand only before any positional
+    # has been consumed here, so a subject named `run` is still a subject.
+    if ($posidx -eq 0 -and (Mf-IsCmd "$cmdpath/$arg")) {
+      $cmdpath = "$cmdpath/$arg"
+      $script:MfArgs += $arg
+      continue
+    }
+
+    $a = Mf-Attrs $cmdpath "#$posidx"
+    if (Mf-Has $a 'path') {
+      $script:MfArgs += (Mount-Path $arg (Mf-CreateMode $a) (Mf-Has $a 'exists'))
+    } else {
+      $script:MfArgs += $arg
+    }
+    $posidx++
+  }
+
+  # A trailing flag with no value: pass it through so picocli reports it.
+  if ($pending) { $script:MfArgs += $pending }
+}
+
+function Mf-CreateMode($attrs) {
+  if (Mf-Has $attrs 'create=self') { return 'self' }
+  return 'parent'
+}

--- a/spice
+++ b/spice
@@ -49,38 +49,539 @@ if [ "${SPICE_LABS_CLI_SKIP_PULL:-0}" != "1" ]; then
 fi
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
+#
+# Which arguments are host paths is not decided here. It is read from a path
+# manifest rendered from the live picocli model inside the image — including
+# plugin-contributed commands — so this script needs no knowledge of any
+# specific flag. The two regions below are generated; edit
+# shared/path-manifest.bash and run scripts/update-path-manifest.sh.
 
-abs_path() {
-  local path="$1"
-  [[ "$path" == ~* ]] && path="${path/#\~/$HOME}"
-  if [ ! -e "$path" ]; then
-    echo "ERROR ❌ Input path does not exist: $path" >&2
+# ── BEGIN SHARED path-manifest.bash ──
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 Spice Labs, Inc. & Contributors
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Path-manifest driven argument walking.
+#
+# CANONICAL SOURCE: spice-labs-cli/shared/path-manifest.bash
+# This block is spliced verbatim into the `spice` wrapper and vendored into
+# allspice's `allspice` wrapper. Edit it here; CI checks the copies match.
+#
+# The wrappers run on the HOST, before `docker run`, so they must know which
+# arguments are host filesystem paths before the JVM (and its picocli model)
+# exists. Rather than hardcode a flag list — which drifted from the commands,
+# and could never cover third-party plugins — they read a *path manifest*
+# rendered from the live command model inside the image. See PathManifest.java.
+#
+# Mounting strategy: identity mounts (`-v $dir:$dir`), so a path's container
+# location equals its host location and arguments need only be absolutised.
+# The one exception is a path under a reserved directory (mounting the host's
+# /opt over the image's would destroy the installation), which is remapped to
+# /mnt/spice/N and recorded in SPICE_PATH_MAP for PathTranslator to reverse.
+#
+# Bash 3.2 (macOS system bash) — no associative arrays, no ${var,,}, no mapfile.
+# Lookup tables are therefore single strings delimited by \001 (record) and
+# \002 (key/value), searched with parameter expansion rather than loops.
+# ─────────────────────────────────────────────────────────────────────────────
+
+MF_REC=$'\001'
+MF_SEP=$'\002'
+
+MF_LOADED=0
+MF_ROOT="spice"
+MF_CMDS=""            # \001<cmdpath>\001…  — command nodes
+MF_ATTRS=""           # \001<cmdpath>|<name>\002<attrs>\001…  — scoped lookup
+MF_INHERITED=""       # same, but only args marked `inherit`
+MF_FLAT=""            # \001<name>\002<attrs>\001…  — union across all commands
+MF_RESERVED_EXACT=""  # :/:/usr:…: — matched exactly, never by prefix
+MF_RESERVED_PREFIX="" # :/opt/allspice:…: — matched by prefix
+
+# Outputs, consumed by the caller after walk_args.
+MF_ARGS=()
+MF_VOLUMES=()
+MF_PATH_MAP=()
+MF_RESULT=""
+
+MF_SEEN_DIRS=""       # :dir:… — directories already mounted
+MF_IDENTITY_DIRS=":"  # :dir:… — of those, the ones mounted at their host path
+MF_MOUNT_MAP=""       # \001<hostdir>\002<containerdir>\001… — assigned targets
+MF_MOUNT_N=0
+
+# ── Loading ──────────────────────────────────────────────────────────────────
+
+# Resolve a manifest into MF_* tables. Every tier is best-effort: an unreadable
+# file, a failed `docker run`, or an image too old to know `path-manifest` all
+# fall through to the next tier, and the embedded built-ins manifest is the
+# floor. This must never abort the CLI — at worst the wrapper behaves as it did
+# before manifests existed.
+mf_load() {
+  local text=""
+
+  # 1. Explicit override (tests, air-gapped installs).
+  if [ -n "${SPICE_PATH_MANIFEST:-}" ] && [ -f "${SPICE_PATH_MANIFEST}" ]; then
+    text="$(cat "${SPICE_PATH_MANIFEST}" 2>/dev/null)" || text=""
+  fi
+
+  # 2. Per-image cache, refreshed from the image when cold.
+  if [ -z "$text" ]; then
+    text="$(mf_refresh)" || text=""
+  fi
+
+  # 3. Manifest installed alongside the wrapper by install.sh. Each wrapper sets
+  #    MF_INSTALLED_MANIFEST to its own file: loading another CLI's manifest
+  #    would describe a command tree this wrapper never sees.
+  if [ -z "$text" ]; then
+    local installed="${MF_INSTALLED_MANIFEST:-${XDG_DATA_HOME:-$HOME/.local/share}/spice/path-manifest}"
+    [ -f "$installed" ] && { text="$(cat "$installed" 2>/dev/null)" || text=""; }
+  fi
+
+  # 4. Built-ins, embedded in this script at build time.
+  if [ -z "$text" ]; then
+    text="$(mf_embedded_manifest)" || text=""
+  fi
+
+  mf_parse "$text"
+}
+
+# Echo the manifest for $IMAGE_REF, using a cache keyed by the image ID so a
+# `docker pull` invalidates it automatically — no TTL, no staleness heuristics.
+mf_refresh() {
+  [ "${SPICE_SKIP_MANIFEST_REFRESH:-0}" = "1" ] && return 1
+  command -v docker >/dev/null 2>&1 || return 1
+
+  local image_id cache_dir cache_file
+  image_id="$(docker image inspect --format '{{.Id}}' "$IMAGE_REF" 2>/dev/null)" || return 1
+  [ -n "$image_id" ] || return 1
+
+  cache_dir="${SPICE_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/spice}/path-manifest"
+  # Image IDs are `sha256:<hex>`; the colon is legal in a filename but awkward.
+  cache_file="${cache_dir}/${image_id#sha256:}"
+
+  if [ -s "$cache_file" ]; then
+    cat "$cache_file" 2>/dev/null
+    return 0
+  fi
+
+  local text
+  text="$(docker run --rm ${PULL_FLAG:+$PULL_FLAG} "$IMAGE_REF" path-manifest 2>/dev/null)" || return 1
+  case "$text" in
+    *"# spice-path-manifest "*) ;;
+    *) return 1 ;;  # an image too old to know the command, or log noise only
+  esac
+
+  if mkdir -p "$cache_dir" 2>/dev/null; then
+    printf '%s\n' "$text" >"$cache_file" 2>/dev/null || true
+    # Keep the cache from growing without bound as images come and go.
+    {
+      ls -1t "$cache_dir" 2>/dev/null | tail -n +11 | while read -r stale; do
+        rm -f "${cache_dir}/${stale}" 2>/dev/null || true
+      done
+    } || true
+  fi
+  printf '%s\n' "$text"
+}
+
+# Build the lookup tables from manifest text. Unrecognised lines are ignored
+# rather than rejected, so log output that leaks onto stdout inside the
+# container cannot corrupt the tables.
+mf_parse() {
+  local kind a b rest key attrs first_cmd=""
+  MF_CMDS=""; MF_ATTRS=""; MF_INHERITED=""; MF_FLAT=""
+  MF_RESERVED_EXACT=":"; MF_RESERVED_PREFIX=":"
+  MF_LOADED=0
+
+  # Matched anywhere rather than at the start: a warning logged to stdout inside
+  # the container would otherwise be enough to reject an otherwise good manifest.
+  case "$1" in
+    *"# spice-path-manifest 1"$'\n'*) ;;
+    *) return 1 ;;  # unknown schema version — leave the tables empty
+  esac
+
+  while read -r kind a b rest; do
+    case "$kind" in
+      C)
+        [ -n "$a" ] || continue
+        [ -n "$first_cmd" ] || first_cmd="$a"
+        MF_CMDS="${MF_CMDS}${MF_REC}${a}"
+        ;;
+      O|P)
+        [ -n "$a" ] && [ -n "$b" ] || continue
+        # Positionals are keyed by index so they cannot collide with a flag.
+        [ "$kind" = "P" ] && b="#${b}"
+        key="${a}|${b}"
+        attrs=" ${rest} "
+        MF_ATTRS="${MF_ATTRS}${MF_REC}${key}${MF_SEP}${attrs}"
+        case "$attrs" in *" inherit "*)
+          MF_INHERITED="${MF_INHERITED}${MF_REC}${key}${MF_SEP}${attrs}" ;;
+        esac
+        [ "$kind" = "O" ] && mf_flat_merge "$b" "$attrs"
+        ;;
+      R)  [ -n "$a" ] && MF_RESERVED_EXACT="${MF_RESERVED_EXACT}${a}:" ;;
+      RP) [ -n "$a" ] && MF_RESERVED_PREFIX="${MF_RESERVED_PREFIX}${a}:" ;;
+    esac
+  done <<EOF
+$1
+EOF
+
+  MF_CMDS="${MF_CMDS}${MF_REC}"
+  MF_ATTRS="${MF_ATTRS}${MF_REC}"
+  MF_INHERITED="${MF_INHERITED}${MF_REC}"
+  MF_FLAT="${MF_FLAT}${MF_REC}"
+  [ -n "$first_cmd" ] && MF_ROOT="$first_cmd"
+  MF_LOADED=1
+  return 0
+}
+
+# Merge one option's attributes into the flat (command-agnostic) fallback table.
+# The union is deliberately conservative: `create=parent` and never `exists`, so
+# that falling back can neither create a directory where a file belongs nor
+# reject a path the command would have accepted.
+mf_flat_merge() {
+  local name="$1" attrs="$2" existing merged
+  existing="$(mf_raw_lookup "$MF_FLAT" "$name")" || existing=""
+  merged=" "
+  case "${existing}${attrs}" in *" value "*) merged="${merged}value " ;; esac
+  case "${existing}${attrs}" in *" path "*) merged="${merged}path create=parent " ;; esac
+  case "${existing}${attrs}" in *" hostonly "*) merged="${merged}hostonly " ;; esac
+  # Prepended, not replaced: mf_raw_lookup finds the first match, so the newest
+  # merge wins and the superseded record is simply never read.
+  MF_FLAT="${MF_REC}${name}${MF_SEP}${merged}${MF_FLAT}"
+}
+
+# ── Lookup ───────────────────────────────────────────────────────────────────
+
+# Echo the attribute string stored for $2 in table $1, or nothing.
+mf_raw_lookup() {
+  local table="$1" key="$2" rest
+  rest="${table#*${MF_REC}${key}${MF_SEP}}"
+  [ "$rest" = "$table" ] && return 1
+  printf '%s' "${rest%%${MF_REC}*}"
+}
+
+# Resolve the attributes of <cmdpath> <name> into MF_A, trying in order:
+# the exact command, then any ancestor that declares the arg as inherited, then
+# the flat union. The flat tier exists so that a manifest older than the image
+# (or missing entirely) degrades to roughly the previous behaviour instead of
+# mis-parsing the command line.
+mf_attrs() {
+  local cmdpath="$1" name="$2" ancestor
+  MF_A="$(mf_raw_lookup "$MF_ATTRS" "${cmdpath}|${name}")" && return 0
+  ancestor="$cmdpath"
+  while [ "$ancestor" != "${ancestor%/*}" ]; do
+    ancestor="${ancestor%/*}"
+    MF_A="$(mf_raw_lookup "$MF_INHERITED" "${ancestor}|${name}")" && return 0
+  done
+  MF_A="$(mf_raw_lookup "$MF_FLAT" "$name")" && return 0
+  MF_A=""
+  return 1
+}
+
+mf_is_cmd() {
+  case "$MF_CMDS" in *"${MF_REC}${1}${MF_REC}"*) return 0 ;; esac
+  return 1
+}
+
+# Whether $1 is the leaf name of any command, at any depth. Used where a branch
+# scans arguments without tracking its position in the command tree.
+mf_is_cmd_token() {
+  case "$MF_CMDS" in *"/${1}${MF_REC}"*) return 0 ;; esac
+  return 1
+}
+
+mf_has() { # $1=attrs $2=attribute
+  case "$1" in *" ${2} "*) return 0 ;; esac
+  return 1
+}
+
+mf_takes_value() { mf_attrs "$1" "$2" || return 1; mf_has "$MF_A" value; }
+mf_is_hostonly() { mf_attrs "$1" "$2" || return 1; mf_has "$MF_A" hostonly; }
+mf_is_path() { mf_attrs "$1" "$2" || return 1; mf_has "$MF_A" path; }
+
+# Whether a directory must not be shadowed by a bind mount. Filesystem roots
+# match exactly — /var must be protected while the macOS temp dirs beneath it
+# (/var/folders/…) stay mountable — whereas install directories match by prefix,
+# since everything below /opt/allspice belongs to the image.
+mf_reserved() {
+  local dir="$1" prefix rest
+  case "$MF_RESERVED_EXACT" in *":${dir}:"*) return 0 ;; esac
+  rest="${MF_RESERVED_PREFIX#:}"
+  while [ -n "$rest" ]; do
+    prefix="${rest%%:*}"
+    rest="${rest#*:}"
+    [ -n "$prefix" ] || continue
+    [ "$dir" = "$prefix" ] && return 0
+    case "$dir" in "${prefix}"/*) return 0 ;; esac
+  done
+  return 1
+}
+
+# ── Mounting ─────────────────────────────────────────────────────────────────
+
+# Resolve one path argument for use inside the container, adding whatever bind
+# mount it needs, and leave the result in MF_RESULT.
+#
+# Sets a global rather than echoing because command substitution would run this
+# in a subshell and discard the mounts it registers.
+#
+# $1 value  $2 create mode (self|parent)  $3 must-already-exist (0|1)
+mount_path() {
+  local value="$1" create="$2" must_exist="$3"
+  local dir dir_abs abs target container
+
+  [[ "$value" == ~* ]] && value="${value/#\~/$HOME}"
+  MF_RESULT="$value"
+
+  # A URL or a bare `key=value` is not a host path even on a Path-typed option.
+  case "$value" in *://*) return 0 ;; esac
+
+  if [ -e "$value" ]; then
+    if [ -d "$value" ]; then dir="$value"; else dir="$(dirname "$value")"; fi
+  elif [ "$must_exist" = "1" ]; then
+    echo "ERROR ❌ Input path does not exist: $value" >&2
     echo "INFO  Use --help for usage information." >&2
     exit 2
-  fi
-  if [ -d "$path" ]; then
-    (cd "$path" && pwd)
+  elif [ "$create" = "self" ]; then
+    mkdir -p "$value" 2>/dev/null || return 0
+    dir="$value"
   else
-    (cd "$(dirname "$path")" && echo "$(pwd)/$(basename "$path")")
+    dir="$(dirname "$value")"
+    mkdir -p "$dir" 2>/dev/null || return 0
   fi
+
+  # If the directory still isn't there, the value was probably never a path.
+  # Pass it through untouched and let the CLI produce the real diagnostic.
+  [ -d "$dir" ] || return 0
+  dir_abs="$(cd "$dir" 2>/dev/null && pwd)" || return 0
+  if [ -d "$value" ]; then
+    abs="$dir_abs"
+  else
+    abs="${dir_abs%/}/$(basename "$value")"
+  fi
+
+  target="$(mf_raw_lookup "$MF_MOUNT_MAP" "$dir_abs")" || target=""
+  if [ -z "$target" ] && mf_under_identity_mount "$dir_abs"; then
+    # Already visible through an ancestor's identity mount; a nested bind mount
+    # would add nothing.
+    target="$dir_abs"
+  fi
+  if [ -z "$target" ]; then
+    if mf_reserved "$dir_abs"; then
+      # Mounting here would hide part of the image, so relocate and record the
+      # mapping for PathTranslator to reverse in user-facing messages.
+      MF_MOUNT_N=$((MF_MOUNT_N + 1))
+      target="/mnt/spice/${MF_MOUNT_N}"
+      MF_PATH_MAP+=("${target}:${dir_abs}")
+    else
+      target="$dir_abs"
+    fi
+    MF_MOUNT_MAP="${MF_MOUNT_MAP}${MF_REC}${dir_abs}${MF_SEP}${target}${MF_REC}"
+    mf_mount "$dir_abs" "$target"
+  fi
+
+  container="${target}${abs#$dir_abs}"
+  MF_RESULT="$container"
 }
 
-# Known subcommand tokens (not paths)
-is_subcommand() {
-  case "$1" in
-    survey|inventory|static|runtime|pass|decode) return 0 ;;
-    registry|discover|run|status|list|retry) return 0 ;;
-    *) return 1 ;;
-  esac
+# Add a deduped bind mount, recording identity mounts so nested paths can reuse
+# them instead of stacking a redundant mount inside one.
+mf_mount() {
+  local host="$1" container="$2"
+  case ":$MF_SEEN_DIRS:" in *":${host}:"*) return 0 ;; esac
+  MF_SEEN_DIRS="${MF_SEEN_DIRS}:${host}"
+  [ "$host" = "$container" ] && MF_IDENTITY_DIRS="${MF_IDENTITY_DIRS}${host}:"
+  MF_VOLUMES+=("-v" "${host}:${container}")
+  return 0
 }
 
-# Flags that consume the next arg as a value
-is_value_flag() {
-  case "$1" in
-  --output | --threads | --max-records | --chunk-size | --log-level | --log-file | --tag-json | --goat-rodeo-args | --ginger-args | --features | --config | --discovery) return 0 ;;
-  *) return 1 ;;
-  esac
+# Whether $1 is already reachable inside the container via an identity mount of
+# one of its ancestors.
+mf_under_identity_mount() {
+  local dir="$1" rest prefix
+  rest="${MF_IDENTITY_DIRS#:}"
+  while [ -n "$rest" ]; do
+    prefix="${rest%%:*}"
+    rest="${rest#*:}"
+    [ -n "$prefix" ] || continue
+    case "$dir" in "${prefix}"/*) return 0 ;; esac
+  done
+  return 1
 }
+
+# ── Argument walking ─────────────────────────────────────────────────────────
+
+# Rewrite "$@" into MF_ARGS, mounting every argument the manifest calls a path.
+walk_args() {
+  local cmdpath="$MF_ROOT" posidx=0 pending="" endopts=0
+  local arg flag val create must_exist
+  MF_ARGS=()
+
+  for arg in "$@"; do
+    if [ "$endopts" = "1" ]; then
+      MF_ARGS+=("$arg")
+      continue
+    fi
+
+    # The value of a flag seen on the previous iteration.
+    if [ -n "$pending" ]; then
+      if mf_is_hostonly "$cmdpath" "$pending"; then
+        : # the wrapper handles it; strip both tokens
+      elif mf_is_path "$cmdpath" "$pending"; then
+        mf_create_args "$MF_A"
+        mount_path "$arg" "$create" "$must_exist"
+        MF_ARGS+=("$pending" "$MF_RESULT")
+      else
+        MF_ARGS+=("$pending" "$arg")
+      fi
+      pending=""
+      continue
+    fi
+
+    if [ "$arg" = "--" ]; then
+      endopts=1
+      MF_ARGS+=("$arg")
+      continue
+    fi
+
+    if [[ "$arg" == -* ]]; then
+      flag="${arg%%=*}"
+      if [ "$flag" != "$arg" ]; then
+        val="${arg#*=}"
+        if mf_is_hostonly "$cmdpath" "$flag"; then
+          continue
+        elif mf_is_path "$cmdpath" "$flag"; then
+          mf_create_args "$MF_A"
+          mount_path "$val" "$create" "$must_exist"
+          MF_ARGS+=("${flag}=${MF_RESULT}")
+        else
+          MF_ARGS+=("$arg")
+        fi
+      elif mf_takes_value "$cmdpath" "$arg"; then
+        pending="$arg"
+      elif mf_is_hostonly "$cmdpath" "$arg"; then
+        : # a valueless host-only flag
+      else
+        MF_ARGS+=("$arg")
+      fi
+      continue
+    fi
+
+    # A positional token descends into a subcommand only before any positional
+    # has been consumed here, so a subject that happens to be named `run` or
+    # `status` is still treated as a subject.
+    if [ "$posidx" = "0" ] && mf_is_cmd "${cmdpath}/${arg}"; then
+      cmdpath="${cmdpath}/${arg}"
+      MF_ARGS+=("$arg")
+      continue
+    fi
+
+    if mf_attrs "$cmdpath" "#${posidx}" && mf_has "$MF_A" path; then
+      mf_create_args "$MF_A"
+      mount_path "$arg" "$create" "$must_exist"
+      MF_ARGS+=("$MF_RESULT")
+    else
+      MF_ARGS+=("$arg")
+    fi
+    posidx=$((posidx + 1))
+  done
+
+  # A trailing flag with no value: pass it through so picocli reports it.
+  [ -n "$pending" ] && MF_ARGS+=("$pending")
+  return 0
+}
+
+# Split an attribute string into the two parameters mount_path needs.
+mf_create_args() {
+  case "$1" in *" create=self "*) create="self" ;; *) create="parent" ;; esac
+  case "$1" in *" exists "*) must_exist="1" ;; *) must_exist="0" ;; esac
+}
+# ── END SHARED path-manifest.bash ──
+
+# ── BEGIN GENERATED PATH MANIFEST ──
+mf_embedded_manifest() {
+  cat <<'SPICE_EMBEDDED_MANIFEST'
+# spice-path-manifest 1
+V 1
+G unknown
+R /
+R /bin
+R /boot
+R /dev
+R /etc
+R /lib
+R /lib32
+R /lib64
+R /libx32
+R /opt
+R /proc
+R /root
+R /run
+R /sbin
+R /srv
+R /sys
+R /usr
+R /var
+C spice
+O spice -h flag
+O spice --help flag
+O spice -V flag
+O spice --version flag
+C spice/survey
+O spice/survey -h flag
+O spice/survey --help flag
+O spice/survey -V flag
+O spice/survey --version flag
+C spice/survey/inventory
+O spice/survey/inventory --output value path create=self
+O spice/survey/inventory --no-upload flag
+O spice/survey/inventory --upload-only flag
+O spice/survey/inventory --tag-json value
+O spice/survey/inventory --threads value
+O spice/survey/inventory --max-records value
+O spice/survey/inventory --chunk-size value
+O spice/survey/inventory --log-level value
+O spice/survey/inventory --log-file value hostonly
+O spice/survey/inventory --goat-rodeo-args value
+O spice/survey/inventory --ginger-args value
+O spice/survey/inventory -h flag
+O spice/survey/inventory --help flag
+O spice/survey/inventory -V flag
+O spice/survey/inventory --version flag
+P spice/survey/inventory 0 value
+P spice/survey/inventory 1 value path create=self exists
+C spice/survey/runtime
+O spice/survey/runtime --jfr flag
+O spice/survey/runtime --native-only flag
+O spice/survey/runtime --keep-recording flag
+O spice/survey/runtime --no-upload flag
+O spice/survey/runtime --output value path create=self
+O spice/survey/runtime --log-level value
+O spice/survey/runtime --chunk-size value
+O spice/survey/runtime --anchor value path create=parent
+O spice/survey/runtime -h flag
+O spice/survey/runtime --help flag
+O spice/survey/runtime -V flag
+O spice/survey/runtime --version flag
+P spice/survey/runtime 0 value
+C spice/pass
+O spice/pass -h flag
+O spice/pass --help flag
+O spice/pass -V flag
+O spice/pass --version flag
+C spice/pass/decode
+O spice/pass/decode -h flag
+O spice/pass/decode --help flag
+O spice/pass/decode -V flag
+O spice/pass/decode --version flag
+C spice/generate-completion
+O spice/generate-completion -h flag
+O spice/generate-completion --help flag
+O spice/generate-completion -V flag
+O spice/generate-completion --version flag
+C spice/generate-powershell-completion
+C spice/path-manifest
+SPICE_EMBEDDED_MANIFEST
+}
+# ── END GENERATED PATH MANIFEST ──
 
 SPICE_LABS_CLI_JAR="${SPICE_LABS_CLI_JAR:-/opt/spice-labs-cli/spice-labs-cli.jar}"
 IMAGE="${SPICE_IMAGE:-spicelabs/spice-labs-cli}"
@@ -214,6 +715,12 @@ for arg in "$@"; do
   [[ "$arg" == "-V" || "$arg" == "--version" ]] && echo "script version ${LOCAL_HASH}" && break
 done
 
+# ── Path manifest ────────────────────────────────────────────────────────────
+# Load before any argument walking: everything below asks the manifest which
+# arguments are paths rather than deciding for itself.
+
+mf_load
+
 # ── Runtime survey detection (must happen before general arg parsing) ───────
 # survey runtime args contain "-- <command...>" which the general parser
 # would misinterpret as positional path args. Detect and handle early.
@@ -303,7 +810,7 @@ if [ "$IS_RUNTIME_SURVEY" = "1" ]; then
       [[ "$arg" == "--no-upload" ]] && RT_NO_UPLOAD=1
       [[ "$arg" == "--native-only" ]] && RT_NATIVE_ONLY=1
       [[ "$arg" == "--keep-recording" ]] && RT_KEEP_RECORDING=1
-      if is_value_flag "$arg"; then
+      if mf_takes_value "${MF_ROOT}/survey/runtime" "$arg"; then
         rt_prev="$arg"
       else
         RT_CLI_ARGS+=("$arg")
@@ -312,7 +819,7 @@ if [ "$IS_RUNTIME_SURVEY" = "1" ]; then
     fi
 
     # Positional: subcommands pass through, first non-subcommand is subject
-    if is_subcommand "$arg"; then
+    if mf_is_cmd_token "$arg"; then
       RT_CLI_ARGS+=("$arg")
     else
       rt_pos=$((rt_pos + 1))
@@ -426,9 +933,10 @@ if [ "$IS_RUNTIME_SURVEY" = "1" ]; then
 
   RT_ANCHOR_MOUNT=()
   if [ -n "$RT_ANCHOR" ]; then
-    RT_ANCHOR_ABS="$(abs_path "$RT_ANCHOR")"
-    RT_ANCHOR_MOUNT=("-v" "${RT_ANCHOR_ABS}:${RT_ANCHOR_ABS}:ro")
-    RT_COLLECT_ARGS+=("--anchor" "${RT_ANCHOR_ABS}")
+    # Mounted like any other path argument, so --anchor stops being special-cased.
+    mount_path "$RT_ANCHOR" parent 1
+    RT_ANCHOR_MOUNT=(${MF_VOLUMES[@]+"${MF_VOLUMES[@]}"})
+    RT_COLLECT_ARGS+=("--anchor" "${MF_RESULT}")
   fi
 
   docker run --rm --entrypoint java \
@@ -454,558 +962,28 @@ if [ "$IS_RUNTIME_SURVEY" = "1" ]; then
   exit $((RT_TARGET_RC != 0 ? RT_TARGET_RC : RT_COLLECT_RC))
 fi
 
-# ── Registry (allspice) detection ─────────────────────────────────────────────
-# `registry` has its own grammar: --config/--discovery/--output are file paths and there
-# are no subject/input positionals. Mount each path flag's directory at the SAME path in
-# the container (so args need no remapping beyond becoming absolute), which also lets the
-# git-backed state dir — created next to the config — persist on the host.
-
-IS_REGISTRY=0
-for arg in "$@"; do
-  [[ "$arg" == -* ]] && continue # skip leading global flags
-  [ "$arg" = "registry" ] && IS_REGISTRY=1
-  break # first positional decides
-done
-
-if [ "$IS_REGISTRY" = "1" ]; then
-  REG_ARGS=()
-  REG_VOLUMES=()
-  REG_SEEN_DIRS=""
-  reg_prev=""
-
-  reg_dir_of() { # echo the directory to mount for a path (file may not yet exist)
-    local p="$1"
-    if [ -d "$p" ]; then
-      (cd "$p" && pwd)
-    else
-      local parent
-      parent="$(dirname "$p" 2>/dev/null)"
-      [ -n "$parent" ] || parent="."
-      (cd "$parent" 2>/dev/null && pwd) || {
-        echo "ERROR ❌ Directory does not exist for path: $p" >&2
-        exit 2
-      }
-    fi
-  }
-  reg_abs_of() { # echo the absolute path (file may not yet exist)
-    local p="$1"
-    if [ -d "$p" ]; then
-      (cd "$p" && pwd)
-    else echo "$(cd "$(dirname "$p")" && pwd)/$(basename "$p")"; fi
-  }
-  reg_mount() { # add a same-path volume for the given path's dir (deduped)
-    local dir
-    dir="$(reg_dir_of "$1")"
-    case ":$REG_SEEN_DIRS:" in *":$dir:"*) ;; *)
-      REG_SEEN_DIRS="$REG_SEEN_DIRS:$dir"
-      REG_VOLUMES+=("-v" "${dir}:${dir}")
-      ;;
-    esac
-  }
-
-  for arg in "$@"; do
-    # Strip --log-file (handled at shell level)
-    if [[ "$arg" == --log-file=* ]]; then
-      continue
-    elif [[ "$reg_prev" == "--log-file" ]]; then
-      reg_prev=""
-      continue
-    elif [[ "$arg" == "--log-file" ]]; then
-      reg_prev="$arg"
-      continue
-    fi
-
-    # Path flags (=joined form)
-    case "$arg" in
-    --config=* | --discovery=* | --output=* | --dir=* | --file=*)
-      flag="${arg%%=*}"
-      val="${arg#*=}"
-      reg_mount "$val"
-      REG_ARGS+=("${flag}=$(reg_abs_of "$val")")
-      continue
-      ;;
-    --config | --discovery | --output | --dir | --file)
-      reg_prev="$arg"
-      continue
-      ;;
-    esac
-
-    # Path flags (space-separated value)
-    if [[ "$reg_prev" == "--config" || "$reg_prev" == "--discovery" || "$reg_prev" == "--output" || "$reg_prev" == "--dir" || "$reg_prev" == "--file" ]]; then
-      reg_mount "$arg"
-      REG_ARGS+=("$reg_prev" "$(reg_abs_of "$arg")")
-      reg_prev=""
-      continue
-    fi
-
-    REG_ARGS+=("$arg")
-  done
-  [ -n "$reg_prev" ] && REG_ARGS+=("$reg_prev")
-
-  exec docker run --rm \
-    --user "$(id -u):$(id -g)" \
-    --network host \
-    ${PULL_FLAG:+$PULL_FLAG} \
-    ${SPICE_DOCKER_FLAGS:+$SPICE_DOCKER_FLAGS} \
-    ${REG_VOLUMES[@]+"${REG_VOLUMES[@]}"} \
-    -e SPICE_PASS \
-    -e SPICE_PATH_MAP \
-    ${SPICE_LABS_JVM_ARGS:+-e SPICE_LABS_JVM_ARGS} \
-    "$IMAGE_REF" \
-    ${REG_ARGS[@]+"${REG_ARGS[@]}"}
-fi
-
-# ── Registry (allspice) detection ─────────────────────────────────────────────
-# `registry` has its own grammar: --config/--discovery/--output are file paths and there
-# are no subject/input positionals. Mount each path flag's directory at the SAME path in
-# the container (so args need no remapping beyond becoming absolute), which also lets the
-# git-backed state dir — created next to the config — persist on the host.
-
-IS_REGISTRY=0
-for arg in "$@"; do
-  [[ "$arg" == -* ]] && continue # skip leading global flags
-  [ "$arg" = "registry" ] && IS_REGISTRY=1
-  break # first positional decides
-done
-
-if [ "$IS_REGISTRY" = "1" ]; then
-  REG_ARGS=()
-  REG_VOLUMES=()
-  REG_SEEN_DIRS=""
-  reg_prev=""
-
-  reg_dir_of() { # echo the directory to mount for a path (file may not yet exist)
-    local p="$1"
-    if [ -d "$p" ]; then
-      (cd "$p" && pwd)
-    else
-      local parent
-      parent="$(dirname "$p" 2>/dev/null)"
-      [ -n "$parent" ] || parent="."
-      (cd "$parent" 2>/dev/null && pwd) || {
-        echo "ERROR ❌ Directory does not exist for path: $p" >&2
-        exit 2
-      }
-    fi
-  }
-  reg_abs_of() { # echo the absolute path (file may not yet exist)
-    local p="$1"
-    if [ -d "$p" ]; then
-      (cd "$p" && pwd)
-    else echo "$(cd "$(dirname "$p")" && pwd)/$(basename "$p")"; fi
-  }
-  reg_mount() { # add a same-path volume for the given path's dir (deduped)
-    local dir
-    dir="$(reg_dir_of "$1")"
-    case ":$REG_SEEN_DIRS:" in *":$dir:"*) ;; *)
-      REG_SEEN_DIRS="$REG_SEEN_DIRS:$dir"
-      REG_VOLUMES+=("-v" "${dir}:${dir}")
-      ;;
-    esac
-  }
-
-  for arg in "$@"; do
-    # Strip --log-file (handled at shell level)
-    if [[ "$arg" == --log-file=* ]]; then
-      continue
-    elif [[ "$reg_prev" == "--log-file" ]]; then
-      reg_prev=""
-      continue
-    elif [[ "$arg" == "--log-file" ]]; then
-      reg_prev="$arg"
-      continue
-    fi
-
-    # Path flags (=joined form)
-    case "$arg" in
-    --config=* | --discovery=* | --output=* | --dir=* | --file=*)
-      flag="${arg%%=*}"
-      val="${arg#*=}"
-      reg_mount "$val"
-      REG_ARGS+=("${flag}=$(reg_abs_of "$val")")
-      continue
-      ;;
-    --config | --discovery | --output | --dir | --file)
-      reg_prev="$arg"
-      continue
-      ;;
-    esac
-
-    # Path flags (space-separated value)
-    if [[ "$reg_prev" == "--config" || "$reg_prev" == "--discovery" || "$reg_prev" == "--output" || "$reg_prev" == "--dir" || "$reg_prev" == "--file" ]]; then
-      reg_mount "$arg"
-      REG_ARGS+=("$reg_prev" "$(reg_abs_of "$arg")")
-      reg_prev=""
-      continue
-    fi
-
-    REG_ARGS+=("$arg")
-  done
-  [ -n "$reg_prev" ] && REG_ARGS+=("$reg_prev")
-
-  exec docker run --rm \
-    --user "$(id -u):$(id -g)" \
-    --network host \
-    ${PULL_FLAG:+$PULL_FLAG} \
-    ${SPICE_DOCKER_FLAGS:+$SPICE_DOCKER_FLAGS} \
-    ${REG_VOLUMES[@]+"${REG_VOLUMES[@]}"} \
-    -e SPICE_PASS \
-    -e SPICE_PATH_MAP \
-    ${SPICE_LABS_JVM_ARGS:+-e SPICE_LABS_JVM_ARGS} \
-    "$IMAGE_REF" \
-    ${REG_ARGS[@]+"${REG_ARGS[@]}"}
-fi
-
-# ── Registry (allspice) detection ─────────────────────────────────────────────
-# `registry` has its own grammar: --config/--discovery/--output are file paths and there
-# are no subject/input positionals. Mount each path flag's directory at the SAME path in
-# the container (so args need no remapping beyond becoming absolute), which also lets the
-# git-backed state dir — created next to the config — persist on the host.
-
-IS_REGISTRY=0
-for arg in "$@"; do
-  [[ "$arg" == -* ]] && continue          # skip leading global flags
-  [ "$arg" = "registry" ] && IS_REGISTRY=1
-  break                                    # first positional decides
-done
-
-if [ "$IS_REGISTRY" = "1" ]; then
-  REG_ARGS=()
-  REG_VOLUMES=()
-  REG_SEEN_DIRS=""
-  reg_prev=""
-
-  reg_dir_of() {                           # echo the directory to mount for a path (file may not yet exist)
-    local p="$1"
-    if [ -d "$p" ]; then (cd "$p" && pwd)
-    else (cd "$(dirname "$p")" 2>/dev/null && pwd) || {
-      echo "ERROR ❌ Directory does not exist for path: $p" >&2; exit 2; }
-    fi
-  }
-  reg_abs_of() {                           # echo the absolute path (file may not yet exist)
-    local p="$1"
-    if [ -d "$p" ]; then (cd "$p" && pwd)
-    else echo "$(cd "$(dirname "$p")" && pwd)/$(basename "$p")"; fi
-  }
-  reg_mount() {                            # add a same-path volume for the given path's dir (deduped)
-    local dir; dir="$(reg_dir_of "$1")"
-    case ":$REG_SEEN_DIRS:" in *":$dir:"*) ;; *)
-      REG_SEEN_DIRS="$REG_SEEN_DIRS:$dir"
-      REG_VOLUMES+=("-v" "${dir}:${dir}") ;;
-    esac
-  }
-
-  for arg in "$@"; do
-    # Strip --log-file (handled at shell level)
-    if [[ "$arg" == --log-file=* ]]; then continue
-    elif [[ "$reg_prev" == "--log-file" ]]; then reg_prev=""; continue
-    elif [[ "$arg" == "--log-file" ]]; then reg_prev="$arg"; continue; fi
-
-    # Path flags (=joined form)
-    case "$arg" in
-      --config=*|--discovery=*|--output=*)
-        flag="${arg%%=*}"; val="${arg#*=}"
-        reg_mount "$val"
-        REG_ARGS+=("${flag}=$(reg_abs_of "$val")")
-        continue ;;
-      --config|--discovery|--output)
-        reg_prev="$arg"; continue ;;
-    esac
-
-    # Path flags (space-separated value)
-    if [[ "$reg_prev" == "--config" || "$reg_prev" == "--discovery" || "$reg_prev" == "--output" || "$reg_prev" == "--dir" || "$reg_prev" == "--file" ]]; then
-      reg_mount "$arg"
-      REG_ARGS+=("$reg_prev" "$(reg_abs_of "$arg")")
-      reg_prev=""
-      continue
-    fi
-
-    REG_ARGS+=("$arg")
-  done
-  [ -n "$reg_prev" ] && REG_ARGS+=("$reg_prev")
-
-  exec docker run --rm \
-    --user "$(id -u):$(id -g)" \
-    --network host \
-    ${PULL_FLAG:+$PULL_FLAG} \
-    ${SPICE_DOCKER_FLAGS:+$SPICE_DOCKER_FLAGS} \
-    ${REG_VOLUMES[@]+"${REG_VOLUMES[@]}"} \
-    -e SPICE_PASS \
-    ${SPICE_LABS_JVM_ARGS:+-e SPICE_LABS_JVM_ARGS} \
-    "$IMAGE_REF" \
-    ${REG_ARGS[@]+"${REG_ARGS[@]}"}
-fi
-
-# ── Registry (allspice) detection ─────────────────────────────────────────────
-# `registry` has its own grammar: --config/--discovery/--output are file paths and there
-# are no subject/input positionals. Mount each path flag's directory at the SAME path in
-# the container (so args need no remapping beyond becoming absolute), which also lets the
-# git-backed state dir — created next to the config — persist on the host.
-
-IS_REGISTRY=0
-for arg in "$@"; do
-  [[ "$arg" == -* ]] && continue          # skip leading global flags
-  [ "$arg" = "registry" ] && IS_REGISTRY=1
-  break                                    # first positional decides
-done
-
-if [ "$IS_REGISTRY" = "1" ]; then
-  REG_ARGS=()
-  REG_VOLUMES=()
-  REG_SEEN_DIRS=""
-  reg_prev=""
-
-  reg_dir_of() {                           # echo the directory to mount for a path (file may not yet exist)
-    local p="$1"
-    if [ -d "$p" ]; then (cd "$p" && pwd)
-    else (cd "$(dirname "$p")" 2>/dev/null && pwd) || {
-      echo "ERROR ❌ Directory does not exist for path: $p" >&2; exit 2; }
-    fi
-  }
-  reg_abs_of() {                           # echo the absolute path (file may not yet exist)
-    local p="$1"
-    if [ -d "$p" ]; then (cd "$p" && pwd)
-    else echo "$(cd "$(dirname "$p")" && pwd)/$(basename "$p")"; fi
-  }
-  reg_mount() {                            # add a same-path volume for the given path's dir (deduped)
-    local dir; dir="$(reg_dir_of "$1")"
-    case ":$REG_SEEN_DIRS:" in *":$dir:"*) ;; *)
-      REG_SEEN_DIRS="$REG_SEEN_DIRS:$dir"
-      REG_VOLUMES+=("-v" "${dir}:${dir}") ;;
-    esac
-  }
-
-  for arg in "$@"; do
-    # Strip --log-file (handled at shell level)
-    if [[ "$arg" == --log-file=* ]]; then continue
-    elif [[ "$reg_prev" == "--log-file" ]]; then reg_prev=""; continue
-    elif [[ "$arg" == "--log-file" ]]; then reg_prev="$arg"; continue; fi
-
-    # Path flags (=joined form)
-    case "$arg" in
-      --config=*|--discovery=*|--output=*)
-        flag="${arg%%=*}"; val="${arg#*=}"
-        reg_mount "$val"
-        REG_ARGS+=("${flag}=$(reg_abs_of "$val")")
-        continue ;;
-      --config|--discovery|--output)
-        reg_prev="$arg"; continue ;;
-    esac
-
-    # Path flags (space-separated value)
-    if [[ "$reg_prev" == "--config" || "$reg_prev" == "--discovery" || "$reg_prev" == "--output" || "$reg_prev" == "--dir" || "$reg_prev" == "--file" ]]; then
-      reg_mount "$arg"
-      REG_ARGS+=("$reg_prev" "$(reg_abs_of "$arg")")
-      reg_prev=""
-      continue
-    fi
-
-    REG_ARGS+=("$arg")
-  done
-  [ -n "$reg_prev" ] && REG_ARGS+=("$reg_prev")
-
-  exec docker run --rm \
-    --user "$(id -u):$(id -g)" \
-    --network host \
-    ${PULL_FLAG:+$PULL_FLAG} \
-    ${SPICE_DOCKER_FLAGS:+$SPICE_DOCKER_FLAGS} \
-    ${REG_VOLUMES[@]+"${REG_VOLUMES[@]}"} \
-    -e SPICE_PASS \
-    -e SPICE_PATH_MAP \
-    ${SPICE_LABS_JVM_ARGS:+-e SPICE_LABS_JVM_ARGS} \
-    "$IMAGE_REF" \
-    ${REG_ARGS[@]+"${REG_ARGS[@]}"}
-fi
-
-# ── Find paths in args and build docker command ──────────────────────────────
+# ── Argument walking and mounts ──────────────────────────────────────────────
 #
-# Walk the args to find:
-#   - The input path: second positional arg (first is subject)
-#   - The --output value: named flag
-# Everything else passes through, with paths rewritten to container mounts.
+# One pass for every command, built-in or plugin-contributed. Each argument the
+# manifest calls a path is absolutised and bind-mounted at its own host path, so
+# the container sees it where the user typed it and nothing needs rewriting —
+# except a path under a reserved directory, which is remapped and recorded in
+# SPICE_PATH_MAP for the CLI to reverse in its messages.
 
-INPUT_PATH=""
-OUTPUT_PATH=""
-CONFIG_PATH=""
-DISCOVERY_PATH=""
-POSITIONAL_INDEX=0
-DOCKER_ARGS=()
-VOLUMES=()
-# Build a path map (container→host) so the CLI can translate container paths
-# back to host paths in error messages. Passed via SPICE_PATH_MAP env var.
-PATH_MAP=()
+walk_args "$@"
 
-prev=""
-for arg in "$@"; do
-  # Strip --log-file (handled at shell level)
-  if [[ "$arg" == --log-file=* ]]; then
-    continue
-  elif [[ "$prev" == "--log-file" ]]; then
-    prev=""
-    continue
-  elif [[ "$arg" == "--log-file" ]]; then
-    prev="$arg"
-    continue
-  fi
-
-  # Capture --output value
-  if [[ "$arg" == --output=* ]]; then
-    OUTPUT_PATH="${arg#--output=}"
-    prev=""
-    continue # will re-add after resolving
-  elif [[ "$prev" == "--output" ]]; then
-    OUTPUT_PATH="$arg"
-    prev=""
-    continue # will re-add after resolving
-  elif [[ "$arg" == "--output" ]]; then
-    prev="$arg"
-    continue
-  fi
-
-  # Capture --config value (registry subcommands)
-  if [[ "$arg" == --config=* ]]; then
-    CONFIG_PATH="${arg#--config=}"
-    prev=""
-    continue
-  elif [[ "$prev" == "--config" ]]; then
-    CONFIG_PATH="$arg"
-    prev=""
-    continue
-  elif [[ "$arg" == "--config" ]]; then
-    prev="$arg"
-    continue
-  fi
-
-  # Capture --discovery value (registry run)
-  if [[ "$arg" == --discovery=* ]]; then
-    DISCOVERY_PATH="${arg#--discovery=}"
-    prev=""
-    continue
-  elif [[ "$prev" == "--discovery" ]]; then
-    DISCOVERY_PATH="$arg"
-    prev=""
-    continue
-  elif [[ "$arg" == "--discovery" ]]; then
-    prev="$arg"
-    continue
-  fi
-
-  # Handle other value-consuming flags
-  if [ -n "$prev" ]; then
-    DOCKER_ARGS+=("$prev" "$arg")
-    prev=""
-    continue
-  fi
-
-  if [[ "$arg" == -* ]]; then
-    if is_value_flag "$arg"; then
-      prev="$arg"
-    else
-      DOCKER_ARGS+=("$arg")
-    fi
-    continue
-  fi
-
-  # It's a positional arg
-  if is_subcommand "$arg"; then
-    DOCKER_ARGS+=("$arg")
-  else
-    POSITIONAL_INDEX=$((POSITIONAL_INDEX + 1))
-    if [ "$POSITIONAL_INDEX" -eq 1 ]; then
-      # Subject — pass through
-      DOCKER_ARGS+=("$arg")
-    elif [ "$POSITIONAL_INDEX" -eq 2 ]; then
-      # Input path — capture for volume mount
-      INPUT_PATH="$arg"
-    else
-      DOCKER_ARGS+=("$arg")
-    fi
-  fi
-done
-# Flush any trailing flag
-[ -n "$prev" ] && DOCKER_ARGS+=("$prev")
-
-# ── Resolve input path ───────────────────────────────────────────────────────
-
-if [ -n "$INPUT_PATH" ]; then
-  HOST_INPUT="$(abs_path "$INPUT_PATH")"
-  if [ -f "$HOST_INPUT" ]; then
-    VOLUMES+=("-v" "$(dirname "$HOST_INPUT"):/mnt/input")
-    DOCKER_ARGS+=("/mnt/input/$(basename "$HOST_INPUT")")
-    PATH_MAP+=("/mnt/input/$(basename "$HOST_INPUT"):$INPUT_PATH")
-  else
-    VOLUMES+=("-v" "${HOST_INPUT}:/mnt/input")
-    DOCKER_ARGS+=("/mnt/input")
-    PATH_MAP+=("/mnt/input:$INPUT_PATH")
-  fi
+# Always make the working directory visible, so relative paths the CLI resolves
+# itself (and its default output location) land on the host.
+if ! mf_reserved "$PWD" && ! mf_under_identity_mount "$PWD"; then
+  mf_mount "$PWD" "$PWD"
 fi
+WORKDIR_FLAG=()
+mf_reserved "$PWD" || WORKDIR_FLAG=("-w" "$PWD")
 
-# ── Resolve output path ─────────────────────────────────────────────────────
-
-if [ -n "$OUTPUT_PATH" ]; then
-  [ ! -d "$OUTPUT_PATH" ] && mkdir -p "$OUTPUT_PATH"
-  HOST_OUTPUT="$(abs_path "$OUTPUT_PATH")"
-  VOLUMES+=("-v" "${HOST_OUTPUT}:/mnt/output")
-  DOCKER_ARGS+=("--output" "/mnt/output")
-  PATH_MAP+=("/mnt/output:$OUTPUT_PATH")
-elif [ -z "$CONFIG_PATH" ]; then
-  # Always mount an output directory at /mnt/output so container output
-  # persists on the host. Default to the current directory.
-  # Skip for registry commands (which use --config) — they manage their own
-  # output dirs via the config TOML.
-  DEFAULT_OUTPUT="$PWD"
-  VOLUMES+=("-v" "${DEFAULT_OUTPUT}:/mnt/output")
-  PATH_MAP+=("/mnt/output:$DEFAULT_OUTPUT")
+SPICE_PATH_MAP=""
+if [ ${#MF_PATH_MAP[@]} -gt 0 ]; then
+  SPICE_PATH_MAP=$(printf '%s\n' "${MF_PATH_MAP[@]}")
 fi
-
-# ── Resolve config path (registry subcommands) ──────────────────────────────
-# Mount the config file's parent dir so allspice can read the config AND write
-# to the allspice-state/ git repo it creates beside it.
-
-if [ -n "$CONFIG_PATH" ]; then
-  HOST_CONFIG="$(abs_path "$CONFIG_PATH")"
-  CONFIG_DIR="$(dirname "$HOST_CONFIG")"
-  CONFIG_FILE="$(basename "$HOST_CONFIG")"
-  VOLUMES+=("-v" "${CONFIG_DIR}:/mnt/config")
-  # Replace the config path in DOCKER_ARGS with the container path
-  for i in "${!DOCKER_ARGS[@]}"; do
-    if [[ "${DOCKER_ARGS[$i]}" == "$CONFIG_PATH" ]]; then
-      DOCKER_ARGS[i]="/mnt/config/${CONFIG_FILE}"
-    fi
-  done
-  PATH_MAP+=("/mnt/config/${CONFIG_FILE}:$CONFIG_PATH")
-  PATH_MAP+=("/mnt/config:$(dirname "$CONFIG_PATH")")
-fi
-
-# ── Resolve discovery path (registry run) ───────────────────────────────────
-
-if [ -n "$DISCOVERY_PATH" ]; then
-  HOST_DISCOVERY="$(abs_path "$DISCOVERY_PATH")"
-  DISCOVERY_DIR="$(dirname "$HOST_DISCOVERY")"
-  DISCOVERY_FILE="$(basename "$HOST_DISCOVERY")"
-  # If discovery is in the same dir as config, it's already mounted
-  if [ -n "$CONFIG_PATH" ] && [ "$DISCOVERY_DIR" = "$(dirname "$(abs_path "$CONFIG_PATH")")" ]; then
-    for i in "${!DOCKER_ARGS[@]}"; do
-      if [[ "${DOCKER_ARGS[$i]}" == "$DISCOVERY_PATH" ]]; then
-        DOCKER_ARGS[i]="/mnt/config/${DISCOVERY_FILE}"
-      fi
-    done
-  else
-    VOLUMES+=("-v" "${DISCOVERY_DIR}:/mnt/discovery")
-    for i in "${!DOCKER_ARGS[@]}"; do
-      if [[ "${DOCKER_ARGS[$i]}" == "$DISCOVERY_PATH" ]]; then
-        DOCKER_ARGS[i]="/mnt/discovery/${DISCOVERY_FILE}"
-      fi
-    done
-    PATH_MAP+=("/mnt/discovery/${DISCOVERY_FILE}:$DISCOVERY_PATH")
-    PATH_MAP+=("/mnt/discovery:$(dirname "$DISCOVERY_PATH")")
-  fi
-fi
-
-# ── Run (non-runtime) ────────────────────────────────────────────────────────
-
-# Serialize PATH_MAP into a newline-separated string for the container
-SPICE_PATH_MAP=$(printf '%s\n' "${PATH_MAP[@]}")
 export SPICE_PATH_MAP
 
 exec docker run --rm \
@@ -1013,9 +991,10 @@ exec docker run --rm \
   --network host \
   ${PULL_FLAG:+$PULL_FLAG} \
   ${SPICE_DOCKER_FLAGS:+$SPICE_DOCKER_FLAGS} \
-  ${VOLUMES+"${VOLUMES[@]}"} \
+  ${MF_VOLUMES[@]+"${MF_VOLUMES[@]}"} \
+  ${WORKDIR_FLAG[@]+"${WORKDIR_FLAG[@]}"} \
   -e SPICE_PASS \
   -e SPICE_PATH_MAP \
   ${SPICE_LABS_JVM_ARGS:+-e SPICE_LABS_JVM_ARGS} \
   "$IMAGE_REF" \
-  ${DOCKER_ARGS[@]+"${DOCKER_ARGS[@]}"}
+  ${MF_ARGS[@]+"${MF_ARGS[@]}"}

--- a/spice
+++ b/spice
@@ -551,8 +551,8 @@ O spice/survey/inventory --max-records value
 O spice/survey/inventory --chunk-size value
 O spice/survey/inventory --log-level value
 O spice/survey/inventory --log-file value hostonly
-O spice/survey/inventory --goat-rodeo-args value
-O spice/survey/inventory --ginger-args value
+O spice/survey/inventory --analysis-args value
+O spice/survey/inventory --upload-args value
 O spice/survey/inventory -h flag
 O spice/survey/inventory --help flag
 O spice/survey/inventory -V flag

--- a/spice
+++ b/spice
@@ -114,32 +114,36 @@ MF_MOUNT_N=0
 # floor. This must never abort the CLI — at worst the wrapper behaves as it did
 # before manifests existed.
 mf_load() {
-  local text=""
+  local text installed
 
   # 1. Explicit override (tests, air-gapped installs).
   if [ -n "${SPICE_PATH_MANIFEST:-}" ] && [ -f "${SPICE_PATH_MANIFEST}" ]; then
     text="$(cat "${SPICE_PATH_MANIFEST}" 2>/dev/null)" || text=""
+    if mf_parse "$text"; then return 0; fi
   fi
 
   # 2. Per-image cache, refreshed from the image when cold.
-  if [ -z "$text" ]; then
-    text="$(mf_refresh)" || text=""
-  fi
+  text="$(mf_refresh)" || text=""
+  if mf_parse "$text"; then return 0; fi
 
   # 3. Manifest installed alongside the wrapper by install.sh. Each wrapper sets
   #    MF_INSTALLED_MANIFEST to its own file: loading another CLI's manifest
   #    would describe a command tree this wrapper never sees.
-  if [ -z "$text" ]; then
-    local installed="${MF_INSTALLED_MANIFEST:-${XDG_DATA_HOME:-$HOME/.local/share}/spice/path-manifest}"
-    [ -f "$installed" ] && { text="$(cat "$installed" 2>/dev/null)" || text=""; }
+  installed="${MF_INSTALLED_MANIFEST:-${XDG_DATA_HOME:-$HOME/.local/share}/spice/path-manifest}"
+  if [ -f "$installed" ]; then
+    text="$(cat "$installed" 2>/dev/null)" || text=""
+    if mf_parse "$text"; then return 0; fi
   fi
 
   # 4. Built-ins, embedded in this script at build time.
-  if [ -z "$text" ]; then
-    text="$(mf_embedded_manifest)" || text=""
-  fi
+  text="$(mf_embedded_manifest)" || text=""
+  mf_parse "$text" || true
 
-  mf_parse "$text"
+  # Always succeeds. A manifest that cannot be parsed at any tier leaves the
+  # tables empty, which makes the wrapper pass arguments through untouched —
+  # degraded, but working. Returning non-zero here would instead abort the whole
+  # script under `set -e`, which is the opposite of the intent.
+  return 0
 }
 
 # Echo the manifest for $IMAGE_REF, using a cache keyed by the image ID so a

--- a/spice
+++ b/spice
@@ -87,7 +87,6 @@ fi
 MF_REC=$'\001'
 MF_SEP=$'\002'
 
-MF_LOADED=0
 MF_ROOT="spice"
 MF_CMDS=""            # \001<cmdpath>\001…  — command nodes
 MF_ATTRS=""           # \001<cmdpath>|<name>\002<attrs>\001…  — scoped lookup
@@ -172,6 +171,9 @@ mf_refresh() {
   if mkdir -p "$cache_dir" 2>/dev/null; then
     printf '%s\n' "$text" >"$cache_file" 2>/dev/null || true
     # Keep the cache from growing without bound as images come and go.
+    # Cache entries are named after image IDs, so they are always plain hex —
+    # `ls` parsing is safe here in a way it would not be for arbitrary names.
+    # shellcheck disable=SC2012
     {
       ls -1t "$cache_dir" 2>/dev/null | tail -n +11 | while read -r stale; do
         rm -f "${cache_dir}/${stale}" 2>/dev/null || true
@@ -188,7 +190,6 @@ mf_parse() {
   local kind a b rest key attrs first_cmd=""
   MF_CMDS=""; MF_ATTRS=""; MF_INHERITED=""; MF_FLAT=""
   MF_RESERVED_EXACT=":"; MF_RESERVED_PREFIX=":"
-  MF_LOADED=0
 
   # Matched anywhere rather than at the start: a warning logged to stdout inside
   # the container would otherwise be enough to reject an otherwise good manifest.
@@ -228,7 +229,6 @@ EOF
   MF_INHERITED="${MF_INHERITED}${MF_REC}"
   MF_FLAT="${MF_FLAT}${MF_REC}"
   [ -n "$first_cmd" ] && MF_ROOT="$first_cmd"
-  MF_LOADED=1
   return 0
 }
 
@@ -251,11 +251,15 @@ mf_flat_merge() {
 # ── Lookup ───────────────────────────────────────────────────────────────────
 
 # Echo the attribute string stored for $2 in table $1, or nothing.
+#
+# The delimiters and the key are quoted so they match literally: only the
+# leading `*` is meant as a wildcard. Unquoted, an option name containing a
+# glob character would be matched as a pattern rather than looked up.
 mf_raw_lookup() {
   local table="$1" key="$2" rest
-  rest="${table#*${MF_REC}${key}${MF_SEP}}"
+  rest="${table#*"${MF_REC}${key}${MF_SEP}"}"
   [ "$rest" = "$table" ] && return 1
-  printf '%s' "${rest%%${MF_REC}*}"
+  printf '%s' "${rest%%"${MF_REC}"*}"
 }
 
 # Resolve the attributes of <cmdpath> <name> into MF_A, trying in order:
@@ -378,7 +382,9 @@ mount_path() {
     mf_mount "$dir_abs" "$target"
   fi
 
-  container="${target}${abs#$dir_abs}"
+  # Quoted so a directory whose name contains a glob character is stripped
+  # literally rather than matched as a pattern.
+  container="${target}${abs#"$dir_abs"}"
   MF_RESULT="$container"
 }
 

--- a/spice
+++ b/spice
@@ -206,7 +206,8 @@ mf_parse() {
         MF_CMDS="${MF_CMDS}${MF_REC}${a}"
         ;;
       O|P)
-        [ -n "$a" ] && [ -n "$b" ] || continue
+        # A record needs both a command path and a name to be usable at all.
+        if [ -z "$a" ] || [ -z "$b" ]; then continue; fi
         # Positionals are keyed by index so they cannot collide with a flag.
         [ "$kind" = "P" ] && b="#${b}"
         key="${a}|${b}"

--- a/spice.ps1
+++ b/spice.ps1
@@ -206,10 +206,17 @@ function Mf-Parse($text) {
 
   # Matched anywhere rather than at the start: a warning logged to stdout inside
   # the container would otherwise be enough to reject an otherwise good manifest.
-  if (-not $text -or -not ($text -match '(?m)^# spice-path-manifest 1$')) { return }
+  # `\r?` because the manifest embedded in this script arrives with whatever line
+  # endings git checked it out with — CRLF on Windows — and `$` in a .NET regex
+  # matches before the `\n`, i.e. after the `\r`.
+  if (-not $text -or -not ($text -match '(?m)^# spice-path-manifest 1\r?$')) { return }
 
   $firstCmd = ""
-  foreach ($line in ($text -split "`r?`n")) {
+  foreach ($rawLine in ($text -split "`r?`n")) {
+    # Trimmed for the same reason: a trailing \r would otherwise survive into the
+    # last field of every record.
+    $line = $rawLine.Trim()
+    if (-not $line) { continue }
     $f = $line -split '\s+'
     if ($f.Count -lt 2) { continue }
     switch ($f[0]) {

--- a/spice.ps1
+++ b/spice.ps1
@@ -514,8 +514,8 @@ O spice/survey/inventory --max-records value
 O spice/survey/inventory --chunk-size value
 O spice/survey/inventory --log-level value
 O spice/survey/inventory --log-file value hostonly
-O spice/survey/inventory --goat-rodeo-args value
-O spice/survey/inventory --ginger-args value
+O spice/survey/inventory --analysis-args value
+O spice/survey/inventory --upload-args value
 O spice/survey/inventory -h flag
 O spice/survey/inventory --help flag
 O spice/survey/inventory -V flag

--- a/spice.ps1
+++ b/spice.ps1
@@ -77,12 +77,477 @@ function Convert-ToDockerPath($path) {
   return $path
 }
 
-$subcommands = @('survey', 'inventory', 'static', 'runtime', 'pass', 'decode',
-  'registry', 'discover', 'run', 'status', 'list', 'retry')
+# Which arguments are host paths is not decided here. It is read from a path
+# manifest rendered from the live picocli model inside the image — including
+# plugin-contributed commands — so this script needs no knowledge of any specific
+# flag. The two regions below are generated; edit shared/path-manifest.ps1 and
+# run scripts/update-path-manifest.sh.
 
-$valueFlags = @('--output', '--threads', '--max-records', '--chunk-size',
-  '--log-level', '--log-file', '--tag-json', '--goat-rodeo-args', '--ginger-args',
-  '--features', '--config', '--discovery')
+# ── BEGIN SHARED path-manifest.ps1 ──
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 Spice Labs, Inc. & Contributors
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Path-manifest driven argument walking — PowerShell mirror of
+# shared/path-manifest.bash. See that file for the design; this one differs only
+# where the platform forces it:
+#
+#   * Windows container paths are not host paths, so an identity mount still
+#     rewrites `C:\work` to `/c/work` and records the pair in SPICE_PATH_MAP for
+#     PathTranslator to reverse. On Linux/macOS Convert-ToDockerPath is the
+#     identity function and no rewriting happens, matching bash exactly.
+#   * Hashtables are available, so the lookup tables are real hashtables rather
+#     than the delimited strings bash 3.2 forces.
+#
+# CANONICAL SOURCE: spice-labs-cli/shared/path-manifest.ps1
+# Spliced into spice.ps1 by scripts/update-path-manifest.sh; CI checks the copy.
+#
+# Windows PowerShell 5.1 compatible — no `??`, no ternary, no `-Parallel`.
+# ─────────────────────────────────────────────────────────────────────────────
+
+$script:MfRoot = 'spice'
+$script:MfCmds = @{}
+$script:MfAttrs = @{}
+$script:MfInherited = @{}
+$script:MfFlat = @{}
+$script:MfReservedExact = @{}
+$script:MfReservedPrefix = @()
+
+$script:MfArgs = @()
+$script:MfVolumes = @()
+$script:MfPathMap = @()
+$script:MfMountMap = @{}
+$script:MfIdentityDirs = @()
+$script:MfMountN = 0
+
+# ── Loading ──────────────────────────────────────────────────────────────────
+
+# Resolve a manifest into the tables above. Every tier is best-effort and the
+# embedded built-ins manifest is the floor, so this can never abort the CLI.
+function Mf-Load {
+  $text = ""
+
+  if ($env:SPICE_PATH_MANIFEST -and (Test-Path -LiteralPath $env:SPICE_PATH_MANIFEST)) {
+    try { $text = Get-Content -LiteralPath $env:SPICE_PATH_MANIFEST -Raw } catch { $text = "" }
+  }
+  if (-not $text) { $text = Mf-Refresh }
+  if (-not $text) {
+    $installed = Join-Path (Mf-DataDir) 'path-manifest'
+    if (Test-Path -LiteralPath $installed) {
+      try { $text = Get-Content -LiteralPath $installed -Raw } catch { $text = "" }
+    }
+  }
+  if (-not $text) { $text = $MfEmbeddedManifest }
+
+  Mf-Parse $text
+}
+
+function Mf-CacheDir {
+  if ($env:SPICE_CACHE_DIR) { return (Join-Path $env:SPICE_CACHE_DIR 'path-manifest') }
+  if ($IsWindows -and $env:LOCALAPPDATA) {
+    return (Join-Path (Join-Path $env:LOCALAPPDATA 'spice') 'path-manifest')
+  }
+  $base = $env:XDG_CACHE_HOME
+  if (-not $base) { $base = Join-Path $HOME '.cache' }
+  return (Join-Path (Join-Path $base 'spice') 'path-manifest')
+}
+
+function Mf-DataDir {
+  if ($IsWindows -and $env:LOCALAPPDATA) { return (Join-Path $env:LOCALAPPDATA 'spice') }
+  $base = $env:XDG_DATA_HOME
+  if (-not $base) { $base = Join-Path (Join-Path $HOME '.local') 'share' }
+  return (Join-Path $base 'spice')
+}
+
+# Return the manifest for $imageRef, cached by image ID so a `docker pull`
+# invalidates it automatically. Returns "" on any failure.
+function Mf-Refresh {
+  if ($env:SPICE_SKIP_MANIFEST_REFRESH -eq '1') { return "" }
+  if (-not (Get-Command docker -ErrorAction SilentlyContinue)) { return "" }
+
+  $ErrorActionPreference = 'Continue'
+  $imageId = (docker image inspect --format '{{.Id}}' "$imageRef" 2>$null | Select-Object -First 1)
+  if (-not $imageId) { return "" }
+
+  $cacheDir = Mf-CacheDir
+  $cacheFile = Join-Path $cacheDir ($imageId -replace '^sha256:', '')
+  if (Test-Path -LiteralPath $cacheFile) {
+    try { return (Get-Content -LiteralPath $cacheFile -Raw) } catch { return "" }
+  }
+
+  $text = (docker run --rm @pullFlag "$imageRef" path-manifest 2>$null) -join "`n"
+  if (-not $text -or -not ($text -match '(?m)^# spice-path-manifest ')) { return "" }
+
+  try {
+    if (-not (Test-Path -LiteralPath $cacheDir)) {
+      New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+    }
+    Set-Content -LiteralPath $cacheFile -Value $text -NoNewline
+    # Keep the cache from growing without bound as images come and go.
+    Get-ChildItem -LiteralPath $cacheDir -File |
+      Sort-Object LastWriteTime -Descending |
+      Select-Object -Skip 10 |
+      ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue }
+  } catch {
+    # An unwritable cache just means the next invocation queries again.
+  }
+  return $text
+}
+
+# Build the lookup tables. Unrecognised lines are ignored rather than rejected,
+# so log output leaking onto stdout in the container cannot corrupt them.
+function Mf-Parse($text) {
+  $script:MfCmds = @{}
+  $script:MfAttrs = @{}
+  $script:MfInherited = @{}
+  $script:MfFlat = @{}
+  $script:MfReservedExact = @{}
+  $script:MfReservedPrefix = @()
+
+  # Matched anywhere rather than at the start: a warning logged to stdout inside
+  # the container would otherwise be enough to reject an otherwise good manifest.
+  if (-not $text -or -not ($text -match '(?m)^# spice-path-manifest 1$')) { return }
+
+  $firstCmd = ""
+  foreach ($line in ($text -split "`r?`n")) {
+    $f = $line -split '\s+'
+    if ($f.Count -lt 2) { continue }
+    switch ($f[0]) {
+      'C' {
+        if (-not $firstCmd) { $firstCmd = $f[1] }
+        $script:MfCmds[$f[1]] = $true
+      }
+      'R'  { $script:MfReservedExact[$f[1]] = $true }
+      'RP' { $script:MfReservedPrefix += $f[1] }
+      default {
+        if ($f[0] -ne 'O' -and $f[0] -ne 'P') { continue }
+        if ($f.Count -lt 3) { continue }
+        $name = $f[2]
+        # Positionals are keyed by index so they cannot collide with a flag.
+        if ($f[0] -eq 'P') { $name = "#$($f[2])" }
+        $attrs = " " + (($f[3..($f.Count - 1)]) -join ' ') + " "
+        $key = "$($f[1])|$name"
+        $script:MfAttrs[$key] = $attrs
+        if ($attrs -like '* inherit *') { $script:MfInherited[$key] = $attrs }
+        if ($f[0] -eq 'O') { Mf-FlatMerge $name $attrs }
+      }
+    }
+  }
+  if ($firstCmd) { $script:MfRoot = $firstCmd }
+}
+
+# Merge one option's attributes into the flat (command-agnostic) fallback. The
+# union is deliberately conservative — `create=parent`, never `exists` — so
+# falling back can neither create a directory where a file belongs nor reject a
+# path the command would have accepted.
+function Mf-FlatMerge($name, $attrs) {
+  $existing = ""
+  if ($script:MfFlat.ContainsKey($name)) { $existing = $script:MfFlat[$name] }
+  $both = $existing + $attrs
+  $merged = " "
+  if ($both -like '* value *') { $merged += "value " }
+  if ($both -like '* path *') { $merged += "path create=parent " }
+  if ($both -like '* hostonly *') { $merged += "hostonly " }
+  $script:MfFlat[$name] = $merged
+}
+
+# ── Lookup ───────────────────────────────────────────────────────────────────
+
+# Attributes of <cmdpath> <name>: the exact command, then any ancestor that
+# declares the arg inherited, then the flat union. The flat tier is what makes a
+# manifest older than the image degrade instead of mis-parsing the command line.
+function Mf-Attrs($cmdpath, $name) {
+  $key = "$cmdpath|$name"
+  if ($script:MfAttrs.ContainsKey($key)) { return $script:MfAttrs[$key] }
+  $ancestor = $cmdpath
+  while ($ancestor -match '/') {
+    $ancestor = $ancestor -replace '/[^/]*$', ''
+    $key = "$ancestor|$name"
+    if ($script:MfInherited.ContainsKey($key)) { return $script:MfInherited[$key] }
+  }
+  if ($script:MfFlat.ContainsKey($name)) { return $script:MfFlat[$name] }
+  return $null
+}
+
+function Mf-Has($attrs, $attribute) {
+  if (-not $attrs) { return $false }
+  return ($attrs -like "* $attribute *")
+}
+
+function Mf-IsCmd($cmdpath) { return $script:MfCmds.ContainsKey($cmdpath) }
+
+# Whether $token is the leaf name of any command, at any depth. Used where a
+# branch scans arguments without tracking its position in the command tree.
+function Mf-IsCmdToken($token) {
+  foreach ($c in $script:MfCmds.Keys) {
+    if ($c -like "*/$token") { return $true }
+  }
+  return $false
+}
+
+function Mf-TakesValue($cmdpath, $name) { return (Mf-Has (Mf-Attrs $cmdpath $name) 'value') }
+function Mf-IsHostOnly($cmdpath, $name) { return (Mf-Has (Mf-Attrs $cmdpath $name) 'hostonly') }
+function Mf-IsPath($cmdpath, $name) { return (Mf-Has (Mf-Attrs $cmdpath $name) 'path') }
+
+# Whether a directory must not be shadowed by a bind mount. Filesystem roots
+# match exactly — /var must be protected while the temp directories beneath it
+# stay mountable — whereas install directories match by prefix, since everything
+# below /opt/allspice belongs to the image.
+function Mf-Reserved($dir) {
+  $normalized = ($dir -replace '\\', '/').TrimEnd('/')
+  if (-not $normalized) { $normalized = '/' }
+  if ($script:MfReservedExact.ContainsKey($normalized)) { return $true }
+  foreach ($prefix in $script:MfReservedPrefix) {
+    if ($normalized -eq $prefix -or $normalized.StartsWith($prefix + '/')) { return $true }
+  }
+  return $false
+}
+
+function Mf-UnderIdentityMount($dir) {
+  foreach ($prefix in $script:MfIdentityDirs) {
+    if ($dir.StartsWith($prefix + [IO.Path]::DirectorySeparatorChar) -or
+        $dir.StartsWith($prefix + '/')) { return $true }
+  }
+  return $false
+}
+
+# ── Mounting ─────────────────────────────────────────────────────────────────
+
+# Add a deduped bind mount, recording identity mounts so nested paths reuse them
+# rather than stacking a redundant mount inside one.
+function Mf-Mount($hostDir, $containerDir) {
+  if ($script:MfMountMap.ContainsKey($hostDir)) { return }
+  $script:MfMountMap[$hostDir] = $containerDir
+  $script:MfVolumes += '-v'
+  $script:MfVolumes += "${hostDir}:${containerDir}"
+  if ($containerDir -eq (Convert-ToDockerPath $hostDir)) { $script:MfIdentityDirs += $hostDir }
+}
+
+# Resolve one path argument for use inside the container, adding whatever bind
+# mount it needs, and return the container-side path.
+function Mount-Path($value, $create, $mustExist) {
+  if ($value -eq '~') { $value = $HOME }
+  elseif ($value -like '~/*' -or $value -like '~\*') {
+    $value = Join-Path $HOME ($value -replace '^~[/\\]')
+  }
+
+  # A URL or a bare key=value is not a host path even on a Path-typed option.
+  if ($value -match '://') { return $value }
+
+  $isDir = Test-Path -LiteralPath $value -PathType Container
+  if (Test-Path -LiteralPath $value) {
+    if ($isDir) { $dir = $value } else { $dir = Split-Path -Parent $value }
+  } elseif ($mustExist) {
+    Write-Host "ERROR ❌ Input path does not exist: $value"
+    Write-Host "INFO  Use --help for usage information."
+    exit 2
+  } elseif ($create -eq 'self') {
+    try { New-Item -ItemType Directory -Path $value -Force | Out-Null } catch { return $value }
+    $dir = $value
+    $isDir = $true
+  } else {
+    $dir = Split-Path -Parent $value
+    if (-not $dir) { $dir = "." }
+    try { New-Item -ItemType Directory -Path $dir -Force | Out-Null } catch { return $value }
+  }
+  if (-not $dir) { $dir = "." }
+
+  # If the directory still isn't there, the value was probably never a path.
+  # Pass it through untouched and let the CLI produce the real diagnostic.
+  if (-not (Test-Path -LiteralPath $dir -PathType Container)) { return $value }
+  try { $dirAbs = (Resolve-Path -LiteralPath $dir -ErrorAction Stop).ProviderPath } catch { return $value }
+  $dirAbs = $dirAbs.TrimEnd([IO.Path]::DirectorySeparatorChar)
+  if ($isDir) { $abs = $dirAbs } else { $abs = Join-Path $dirAbs (Split-Path -Leaf $value) }
+
+  $target = $null
+  if ($script:MfMountMap.ContainsKey($dirAbs)) {
+    $target = $script:MfMountMap[$dirAbs]
+  } elseif (Mf-UnderIdentityMount $dirAbs) {
+    # Already visible through an ancestor's identity mount.
+    $target = Convert-ToDockerPath $dirAbs
+  } else {
+    if (Mf-Reserved (Convert-ToDockerPath $dirAbs)) {
+      # Mounting here would hide part of the image, so relocate and record the
+      # mapping for PathTranslator to reverse in user-facing messages.
+      $script:MfMountN++
+      $target = "/mnt/spice/$($script:MfMountN)"
+      $script:MfPathMap += "${target}:${dirAbs}"
+    } else {
+      $target = Convert-ToDockerPath $dirAbs
+      if ($target -ne $dirAbs) { $script:MfPathMap += "${target}:${dirAbs}" }
+    }
+    Mf-Mount $dirAbs $target
+  }
+
+  if ($abs -eq $dirAbs) { return $target }
+  return ($target.TrimEnd('/') + '/' + (Split-Path -Leaf $value))
+}
+
+# ── Argument walking ─────────────────────────────────────────────────────────
+
+# Rewrite $argList into $script:MfArgs, mounting every argument the manifest
+# calls a path.
+function Walk-Args($argList) {
+  $cmdpath = $script:MfRoot
+  $posidx = 0
+  $pending = ""
+  $endOpts = $false
+  $script:MfArgs = @()
+
+  foreach ($arg in $argList) {
+    if ($endOpts) { $script:MfArgs += $arg; continue }
+
+    # The value of a flag seen on the previous iteration.
+    if ($pending) {
+      if (Mf-IsHostOnly $cmdpath $pending) {
+        # the wrapper handles it; strip both tokens
+      } elseif (Mf-IsPath $cmdpath $pending) {
+        $a = Mf-Attrs $cmdpath $pending
+        $script:MfArgs += $pending
+        $script:MfArgs += (Mount-Path $arg (Mf-CreateMode $a) (Mf-Has $a 'exists'))
+      } else {
+        $script:MfArgs += $pending
+        $script:MfArgs += $arg
+      }
+      $pending = ""
+      continue
+    }
+
+    if ($arg -eq '--') { $endOpts = $true; $script:MfArgs += $arg; continue }
+
+    if ($arg -like '-*') {
+      if ($arg -match '^([^=]+)=(.*)$') {
+        $flag = $matches[1]
+        $val = $matches[2]
+        if (Mf-IsHostOnly $cmdpath $flag) {
+          continue
+        } elseif (Mf-IsPath $cmdpath $flag) {
+          $a = Mf-Attrs $cmdpath $flag
+          $script:MfArgs += "$flag=$(Mount-Path $val (Mf-CreateMode $a) (Mf-Has $a 'exists'))"
+        } else {
+          $script:MfArgs += $arg
+        }
+      } elseif (Mf-TakesValue $cmdpath $arg) {
+        $pending = $arg
+      } elseif (Mf-IsHostOnly $cmdpath $arg) {
+        # a valueless host-only flag
+      } else {
+        $script:MfArgs += $arg
+      }
+      continue
+    }
+
+    # A positional token descends into a subcommand only before any positional
+    # has been consumed here, so a subject named `run` is still a subject.
+    if ($posidx -eq 0 -and (Mf-IsCmd "$cmdpath/$arg")) {
+      $cmdpath = "$cmdpath/$arg"
+      $script:MfArgs += $arg
+      continue
+    }
+
+    $a = Mf-Attrs $cmdpath "#$posidx"
+    if (Mf-Has $a 'path') {
+      $script:MfArgs += (Mount-Path $arg (Mf-CreateMode $a) (Mf-Has $a 'exists'))
+    } else {
+      $script:MfArgs += $arg
+    }
+    $posidx++
+  }
+
+  # A trailing flag with no value: pass it through so picocli reports it.
+  if ($pending) { $script:MfArgs += $pending }
+}
+
+function Mf-CreateMode($attrs) {
+  if (Mf-Has $attrs 'create=self') { return 'self' }
+  return 'parent'
+}
+# ── END SHARED path-manifest.ps1 ──
+
+# ── BEGIN GENERATED PATH MANIFEST ──
+$MfEmbeddedManifest = @'
+# spice-path-manifest 1
+V 1
+G unknown
+R /
+R /bin
+R /boot
+R /dev
+R /etc
+R /lib
+R /lib32
+R /lib64
+R /libx32
+R /opt
+R /proc
+R /root
+R /run
+R /sbin
+R /srv
+R /sys
+R /usr
+R /var
+C spice
+O spice -h flag
+O spice --help flag
+O spice -V flag
+O spice --version flag
+C spice/survey
+O spice/survey -h flag
+O spice/survey --help flag
+O spice/survey -V flag
+O spice/survey --version flag
+C spice/survey/inventory
+O spice/survey/inventory --output value path create=self
+O spice/survey/inventory --no-upload flag
+O spice/survey/inventory --upload-only flag
+O spice/survey/inventory --tag-json value
+O spice/survey/inventory --threads value
+O spice/survey/inventory --max-records value
+O spice/survey/inventory --chunk-size value
+O spice/survey/inventory --log-level value
+O spice/survey/inventory --log-file value hostonly
+O spice/survey/inventory --goat-rodeo-args value
+O spice/survey/inventory --ginger-args value
+O spice/survey/inventory -h flag
+O spice/survey/inventory --help flag
+O spice/survey/inventory -V flag
+O spice/survey/inventory --version flag
+P spice/survey/inventory 0 value
+P spice/survey/inventory 1 value path create=self exists
+C spice/survey/runtime
+O spice/survey/runtime --jfr flag
+O spice/survey/runtime --native-only flag
+O spice/survey/runtime --keep-recording flag
+O spice/survey/runtime --no-upload flag
+O spice/survey/runtime --output value path create=self
+O spice/survey/runtime --log-level value
+O spice/survey/runtime --chunk-size value
+O spice/survey/runtime --anchor value path create=parent
+O spice/survey/runtime -h flag
+O spice/survey/runtime --help flag
+O spice/survey/runtime -V flag
+O spice/survey/runtime --version flag
+P spice/survey/runtime 0 value
+C spice/pass
+O spice/pass -h flag
+O spice/pass --help flag
+O spice/pass -V flag
+O spice/pass --version flag
+C spice/pass/decode
+O spice/pass/decode -h flag
+O spice/pass/decode --help flag
+O spice/pass/decode -V flag
+O spice/pass/decode --version flag
+C spice/generate-completion
+O spice/generate-completion -h flag
+O spice/generate-completion --help flag
+O spice/generate-completion -V flag
+O spice/generate-completion --version flag
+C spice/generate-powershell-completion
+C spice/path-manifest
+'@
+# ── END GENERATED PATH MANIFEST ──
 
 $jar = if ($env:SPICE_LABS_CLI_JAR) { $env:SPICE_LABS_CLI_JAR } else { "/opt/spice-labs-cli/spice-labs-cli.jar" }
 $img = if ($env:SPICE_IMAGE) { $env:SPICE_IMAGE } else { "spicelabs/spice-labs-cli" }
@@ -200,6 +665,12 @@ if (-not $IsWindows) {
   } catch {}
 }
 
+# ── Path manifest ────────────────────────────────────────────────────────────
+# Load before any argument walking: everything below asks the manifest which
+# arguments are paths rather than deciding for itself.
+
+Mf-Load
+
 # ── Runtime survey detection (must happen before general arg parsing) ───────
 # survey runtime args contain "-- <command...>" which the general parser
 # would misinterpret as positional path args. Detect and handle early.
@@ -261,13 +732,13 @@ if ($isRuntimeSurvey) {
       if ($arg -eq '--no-upload') { $rtNoUpload = $true }
       if ($arg -eq '--native-only') { $rtNativeOnly = $true }
       if ($arg -eq '--keep-recording') { $rtKeepRecording = $true }
-      if ($arg -in $valueFlags) { $rtPrev = $arg }
+      if (Mf-TakesValue "$($script:MfRoot)/survey/runtime" $arg) { $rtPrev = $arg }
       else { $rtCliArgs += $arg }
       continue
     }
 
     # Positional: subcommands pass through, first non-subcommand is subject
-    if ($arg -in $subcommands) {
+    if (Mf-IsCmdToken $arg) {
       $rtCliArgs += $arg
     } else {
       $rtPos++
@@ -385,9 +856,9 @@ if ($isRuntimeSurvey) {
 
   $rtAnchorMount = @()
   if ($rtAnchor) {
-    $rtAnchorHost = (Get-AbsolutePath $rtAnchor)
-    $rtAnchorDocker = Convert-ToDockerPath $rtAnchorHost
-    $rtAnchorMount = @('-v', "${rtAnchorHost}:${rtAnchorDocker}:ro")
+    # Mounted like any other path argument, so --anchor stops being special-cased.
+    $rtAnchorDocker = Mount-Path $rtAnchor 'parent' $true
+    $rtAnchorMount = $script:MfVolumes
     $rtCollectArgs += @('--anchor', $rtAnchorDocker)
   }
 
@@ -414,219 +885,31 @@ if ($isRuntimeSurvey) {
   if ($rtTargetRc -ne 0) { exit $rtTargetRc } else { exit $rtCollectRc }
 }
 
-# ── Registry (allspice) detection ─────────────────────────────────────────────
-# Mirror of the bash wrapper: --config/--discovery/--output are file paths and there are
-# no subject/input positionals. Mount each path flag's directory at the same path (so the
-# git-backed state dir created next to the config persists on the host) and pass absolute
-# paths through.
+# ── Argument walking and mounts ──────────────────────────────────────────────
+#
+# One pass for every command, built-in or plugin-contributed. Each argument the
+# manifest calls a path is absolutised and bind-mounted at its own host path, so
+# the container sees it where the user typed it (modulo the Windows drive-letter
+# translation) and nothing needs rewriting — except a path under a reserved
+# directory, which is remapped and recorded in SPICE_PATH_MAP for the CLI to
+# reverse in its messages.
 
-$isRegistry = $false
-foreach ($arg in $args) {
-  if ($arg -like '-*') { continue }
-  if ($arg -eq 'registry') { $isRegistry = $true }
-  break
+Walk-Args $args
+
+# Always make the working directory visible, so relative paths the CLI resolves
+# itself (and its default output location) land on the host.
+$cwd = (Get-Location).Path
+$cwdDocker = Convert-ToDockerPath $cwd
+if (-not (Mf-Reserved $cwdDocker) -and -not (Mf-UnderIdentityMount $cwd)) {
+  Mf-Mount $cwd $cwdDocker
+  if ($cwdDocker -ne $cwd) { $script:MfPathMap += "${cwdDocker}:${cwd}" }
 }
+$workdirFlag = @()
+if (-not (Mf-Reserved $cwdDocker)) { $workdirFlag = @('-w', $cwdDocker) }
 
-if ($isRegistry) {
-  function Resolve-RegDir($p) {       # directory to mount (file may not yet exist)
-    if (Test-Path -LiteralPath $p -PathType Container) { return (Resolve-Path -LiteralPath $p).ProviderPath }
-    $parent = Split-Path -Parent $p; if (-not $parent) { $parent = "." }
-    try { return (Resolve-Path -LiteralPath $parent -ErrorAction Stop).ProviderPath }
-    catch { Write-Host "ERROR ❌ Directory does not exist for path: $p"; exit 2 }
-  }
-  function Resolve-RegAbs($p) {        # absolute path (file may not yet exist)
-    if (Test-Path -LiteralPath $p -PathType Container) { return (Resolve-Path -LiteralPath $p).ProviderPath }
-    $parent = Split-Path -Parent $p; if (-not $parent) { $parent = "." }
-    $leaf = Split-Path -Leaf $p
-    return (Join-Path (Resolve-Path -LiteralPath $parent -ErrorAction Stop).ProviderPath $leaf)
-  }
-
-  $regArgs = @()
-  $regVolumes = @()
-  $regSeen = @{}
-  $regPrev = ""
-
-  foreach ($arg in $args) {
-    if ($arg -match '^--log-file=') { continue }
-    elseif ($regPrev -eq '--log-file') { $regPrev = ""; continue }
-    elseif ($arg -eq '--log-file') { $regPrev = $arg; continue }
-
-    if ($arg -match '^(--config|--discovery|--output|--dir|--file)=(.*)$') {
-      $flag = $matches[1]; $val = $matches[2]
-      $hostDir = Resolve-RegDir $val; $dockerDir = Convert-ToDockerPath $hostDir
-      if (-not $regSeen.ContainsKey($dockerDir)) { $regSeen[$dockerDir] = $true; $regVolumes += '-v'; $regVolumes += "${hostDir}:${dockerDir}" }
-      $regArgs += "$flag=$(Convert-ToDockerPath (Resolve-RegAbs $val))"
-      continue
-    }
-    if ($arg -in @('--config', '--discovery', '--output', '--dir', '--file')) { $regPrev = $arg; continue }
-    if ($regPrev -in @('--config', '--discovery', '--output', '--dir', '--file')) {
-      $hostDir = Resolve-RegDir $arg; $dockerDir = Convert-ToDockerPath $hostDir
-      if (-not $regSeen.ContainsKey($dockerDir)) { $regSeen[$dockerDir] = $true; $regVolumes += '-v'; $regVolumes += "${hostDir}:${dockerDir}" }
-      $regArgs += $regPrev; $regArgs += (Convert-ToDockerPath (Resolve-RegAbs $arg))
-      $regPrev = ""
-      continue
-    }
-    $regArgs += $arg
-  }
-  if ($regPrev) { $regArgs += $regPrev }
-
-  $envArgs = @()
-  if ($env:SPICE_LABS_JVM_ARGS) { $envArgs += "-e"; $envArgs += "SPICE_LABS_JVM_ARGS" }
-  $dockerFlags = @()
-  if ($env:SPICE_DOCKER_FLAGS) { $dockerFlags = $env:SPICE_DOCKER_FLAGS -split '\s+' }
-
-  $ErrorActionPreference = 'Continue'
-  docker run --rm `
-    @userFlag `
-    @pullFlag @dockerFlags `
-    --network host `
-    @regVolumes `
-    -e "SPICE_PASS=$spicePass" `
-    -e "SPICE_PATH_MAP=$env:SPICE_PATH_MAP" `
-    @envArgs `
-    "$imageRef" `
-    @regArgs
-  exit $LASTEXITCODE
-}
-
-# ── Find paths in args and build docker command ──────────────────────────────
-
-$inputPath = ""
-$outputPath = ""
-$configPath = ""
-$discoveryPath = ""
-$positionalIndex = 0
-$dockerArgs = @()
-$volumes = @()
-# Build a path map (container:host) so the CLI can translate container paths
-# back to host paths in error messages. Passed via SPICE_PATH_MAP env var.
-$pathMap = @()
-
-$prev = ""
-foreach ($arg in $args) {
-  # Strip --log-file
-  if ($arg -match "^--log-file=") { continue }
-  elseif ($prev -eq "--log-file") { $prev = ""; continue }
-  elseif ($arg -eq "--log-file") { $prev = $arg; continue }
-
-  # Capture --output value
-  if ($arg -match "^--output=(.*)$") { $outputPath = $matches[1]; $prev = ""; continue }
-  elseif ($prev -eq "--output") { $outputPath = $arg; $prev = ""; continue }
-  elseif ($arg -eq "--output") { $prev = $arg; continue }
-
-  # Capture --config value (registry subcommands)
-  if ($arg -match "^--config=(.*)$") { $configPath = $matches[1]; $prev = ""; continue }
-  elseif ($prev -eq "--config") { $configPath = $arg; $prev = ""; continue }
-  elseif ($arg -eq "--config") { $prev = $arg; continue }
-
-  # Capture --discovery value (registry run)
-  if ($arg -match "^--discovery=(.*)$") { $discoveryPath = $matches[1]; $prev = ""; continue }
-  elseif ($prev -eq "--discovery") { $discoveryPath = $arg; $prev = ""; continue }
-  elseif ($arg -eq "--discovery") { $prev = $arg; continue }
-
-  # Handle other value-consuming flags
-  if ($prev) {
-    $dockerArgs += $prev; $dockerArgs += $arg; $prev = ""; continue
-  }
-
-  if ($arg -like "-*") {
-    if ($arg -in $valueFlags) { $prev = $arg }
-    else { $dockerArgs += $arg }
-    continue
-  }
-
-  # It's a positional arg
-  if ($arg -in $subcommands) {
-    $dockerArgs += $arg
-  } else {
-    $positionalIndex++
-    if ($positionalIndex -eq 1) {
-      # Subject — pass through
-      $dockerArgs += $arg
-    } elseif ($positionalIndex -eq 2) {
-      # Input path — capture for volume mount
-      $inputPath = $arg
-    } else {
-      $dockerArgs += $arg
-    }
-  }
-}
-if ($prev) { $dockerArgs += $prev }
-
-# ── Resolve input path ───────────────────────────────────────────────────────
-
-if ($inputPath) {
-  if (Test-Path -LiteralPath $inputPath -PathType Leaf) {
-    $hostDir = Convert-ToDockerPath (Get-AbsolutePath (Split-Path -Parent $inputPath))
-    $fileName = Split-Path -Leaf $inputPath
-    $volumes += "-v"; $volumes += "${hostDir}:/mnt/input"
-    $dockerArgs += "/mnt/input/${fileName}"
-    $pathMap += "/mnt/input/${fileName}:$inputPath"
-  } else {
-    $hostDir = Convert-ToDockerPath (Get-AbsolutePath $inputPath)
-    $volumes += "-v"; $volumes += "${hostDir}:/mnt/input"
-    $dockerArgs += "/mnt/input"
-    $pathMap += "/mnt/input:$inputPath"
-  }
-}
-
-# ── Resolve output path ─────────────────────────────────────────────────────
-
-if ($outputPath) {
-  if (-not (Test-Path $outputPath)) { New-Item -ItemType Directory -Path $outputPath -Force | Out-Null }
-  $hostDir = (Get-AbsolutePath $outputPath)
-  $volumes += "-v"; $volumes += "${hostDir}:/mnt/output"
-  $dockerArgs += "--output"; $dockerArgs += "/mnt/output"
-  $pathMap += "/mnt/output:$outputPath"
-} elseif (-not $configPath) {
-  # Always mount an output directory at /mnt/output so container output
-  # persists on the host. Default to the current directory.
-  # Skip for registry commands (which use --config) — they manage their own
-  # output dirs via the config TOML.
-  $defaultOutput = (Get-Location).Path
-  $hostDir = (Get-AbsolutePath $defaultOutput)
-  $volumes += "-v"; $volumes += "${hostDir}:/mnt/output"
-  $pathMap += "/mnt/output:$defaultOutput"
-}
-
-# ── Resolve config path (registry subcommands) ──────────────────────────────
-# Mount the config file's parent dir so allspice can read the config AND write
-# to the allspice-state/ git repo it creates beside it.
-
-if ($configPath) {
-  $absConfig = Get-AbsolutePath $configPath
-  $configDir = Split-Path -Parent $absConfig
-  $configFile = Split-Path -Leaf $absConfig
-  $hostDir = Convert-ToDockerPath $configDir
-  $volumes += "-v"; $volumes += "${hostDir}:/mnt/config"
-  $containerConfig = "/mnt/config/${configFile}"
-  for ($i = 0; $i -lt $dockerArgs.Count; $i++) {
-    if ($dockerArgs[$i] -eq $configPath) { $dockerArgs[$i] = $containerConfig }
-  }
-  $pathMap += "/mnt/config/${configFile}:$configPath"
-  $pathMap += "/mnt/config:$(Split-Path -Parent $configPath)"
-}
-
-# ── Resolve discovery path (registry run) ───────────────────────────────────
-
-if ($discoveryPath) {
-  $absDiscovery = Get-AbsolutePath $discoveryPath
-  $discoveryDir = Split-Path -Parent $absDiscovery
-  $discoveryFile = Split-Path -Leaf $absDiscovery
-  $containerDiscovery = "/mnt/discovery/${discoveryFile}"
-  # If discovery is in the same dir as config, it's already mounted
-  if ($configPath -and $discoveryDir -eq (Split-Path -Parent (Get-AbsolutePath $configPath))) {
-    $containerDiscovery = "/mnt/config/${discoveryFile}"
-  } else {
-    $hostDir = Convert-ToDockerPath $discoveryDir
-    $volumes += "-v"; $volumes += "${hostDir}:/mnt/discovery"
-    $pathMap += "/mnt/discovery/${discoveryFile}:$discoveryPath"
-    $pathMap += "/mnt/discovery:$(Split-Path -Parent $discoveryPath)"
-  }
-  for ($i = 0; $i -lt $dockerArgs.Count; $i++) {
-    if ($dockerArgs[$i] -eq $discoveryPath) { $dockerArgs[$i] = $containerDiscovery }
-  }
-}
+$dockerArgs = $script:MfArgs
+$volumes = $script:MfVolumes
+$pathMap = $script:MfPathMap
 
 # ── Run ──────────────────────────────────────────────────────────────────────
 
@@ -647,6 +930,7 @@ docker run --rm `
   @pullFlag @dockerFlags `
   --network host `
   @volumes `
+  @workdirFlag `
   -e "SPICE_PASS=$spicePass" `
   @envArgs `
    "$imageRef" `

--- a/src/main/java/io/spicelabs/cli/GeneratePowershellCompletion.java
+++ b/src/main/java/io/spicelabs/cli/GeneratePowershellCompletion.java
@@ -67,7 +67,7 @@ public class GeneratePowershellCompletion implements Callable<Integer> {
       $SpiceCompletions = @{
         survey = @{
           __sub     = @('inventory', 'runtime')
-          inventory = @('--output', '--no-upload', '--upload-only', '--threads', '--max-records', '--chunk-size', '--log-level', '--tag-json', '--goat-rodeo-args', '--ginger-args', '--help')
+          inventory = @('--output', '--no-upload', '--upload-only', '--threads', '--max-records', '--chunk-size', '--log-level', '--tag-json', '--analysis-args', '--upload-args', '--help')
           runtime   = @('--jfr', '--no-upload', '--native-only', '--keep-recording', '--anchor', '--output', '--log-level', '--help')
         }
         pass = @{

--- a/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
@@ -111,15 +111,15 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
   String logFile;
 
   @Option(
-      names = "--goat-rodeo-args",
-      description = "Additional GoatRodeo args in key=value format",
+      names = "--analysis-args",
+      description = "Additional analysis args in key=value format",
       split = ","
   )
   List<String> goatRodeoArgsRaw;
 
   @Option(
-      names = "--ginger-args",
-      description = "Additional Ginger args in key=value format",
+      names = "--upload-args",
+      description = "Additional upload args in key=value format",
       split = ","
   )
   List<String> gingerArgsRaw;
@@ -276,7 +276,7 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
 
   protected void doSurvey(SurveyRegistration.Context survey, AnalyzeProgressPublisher analyzeProgress)
       throws Exception {
-    log.info("📦 Surveying artifacts with GoatRodeo...");
+    log.info("📦 Surveying artifacts...");
 
     String originalScalaLevel = System.getProperty("scala.logging.level");
     String originalSlf4jLevel = System.getProperty("org.slf4j.simpleLogger.defaultLogLevel");
@@ -477,7 +477,7 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
     return spicePass != null && !spicePass.isBlank();
   }
 
-  /** Encrypt-only runs (via --ginger-args) never contact a server, so we skip survey registration. */
+  /** Encrypt-only runs (via --upload-args) never contact a server, so we skip survey registration. */
   boolean isEncryptOnly() {
     return gingerArgs.containsKey("--encrypt-only")
         && !"false".equalsIgnoreCase(gingerArgs.get("--encrypt-only"));

--- a/src/test/java/io/spicelabs/cli/PathManifestGoldenTest.java
+++ b/src/test/java/io/spicelabs/cli/PathManifestGoldenTest.java
@@ -1,0 +1,84 @@
+package io.spicelabs.cli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The wrappers carry two generated regions: the shared argument-walking code, and the
+ * built-in commands' manifest used as the last-resort fallback. Both are copies, so both
+ * can drift — which is the failure mode this whole change exists to remove. These tests
+ * fail the build when a copy is stale, so the fix is mechanical:
+ * {@code scripts/update-path-manifest.sh}.
+ */
+class PathManifestGoldenTest {
+
+  private static final Path ROOT = Path.of(System.getProperty("user.dir"));
+  private static final String FIX = "\n\nRun scripts/update-path-manifest.sh to regenerate.";
+
+  @Test
+  void bashWrapperEmbedsTheCurrentBuiltInManifest() throws Exception {
+    String expected = PathManifest.render(PathManifest.builtInCommandLine(), false);
+    assertEquals(expected, region(Files.readString(ROOT.resolve("spice")),
+        "  cat <<'SPICE_EMBEDDED_MANIFEST'\n", "SPICE_EMBEDDED_MANIFEST\n"),
+        "The manifest embedded in `spice` no longer matches the command tree." + FIX);
+  }
+
+  @Test
+  void powershellWrapperEmbedsTheCurrentBuiltInManifest() throws Exception {
+    String expected = PathManifest.render(PathManifest.builtInCommandLine(), false);
+    assertEquals(expected, region(Files.readString(ROOT.resolve("spice.ps1")),
+        "$MfEmbeddedManifest = @'\n", "'@\n"),
+        "The manifest embedded in `spice.ps1` no longer matches the command tree." + FIX);
+  }
+
+  @Test
+  void bashWrapperEmbedsTheCanonicalSharedLibrary() throws Exception {
+    assertEquals(Files.readString(ROOT.resolve("shared/path-manifest.bash")),
+        region(Files.readString(ROOT.resolve("spice")),
+            "# ── BEGIN SHARED path-manifest.bash ──\n",
+            "# ── END SHARED path-manifest.bash ──\n"),
+        "`spice` has drifted from shared/path-manifest.bash." + FIX);
+  }
+
+  @Test
+  void powershellWrapperEmbedsTheCanonicalSharedLibrary() throws Exception {
+    assertEquals(Files.readString(ROOT.resolve("shared/path-manifest.ps1")),
+        region(Files.readString(ROOT.resolve("spice.ps1")),
+            "# ── BEGIN SHARED path-manifest.ps1 ──\n",
+            "# ── END SHARED path-manifest.ps1 ──\n"),
+        "`spice.ps1` has drifted from shared/path-manifest.ps1." + FIX);
+  }
+
+  /** No wrapper may name a specific flag or mountpoint again. */
+  @Test
+  void wrappersNoLongerHardcodePathFlags() throws Exception {
+    for (String wrapper : new String[] { "spice", "spice.ps1" }) {
+      String body = withoutGeneratedManifest(Files.readString(ROOT.resolve(wrapper)));
+      assertFalse(body.contains("/mnt/input"), wrapper + " still has a fixed mountpoint");
+      assertFalse(body.contains("/mnt/output"), wrapper + " still has a fixed mountpoint");
+      assertFalse(body.contains("/mnt/config"), wrapper + " still has a fixed mountpoint");
+      assertFalse(body.contains("--discovery"), wrapper + " still names a plugin's flag");
+      assertFalse(body.contains("--rogues"), wrapper + " still names a plugin's flag");
+    }
+  }
+
+  private static String withoutGeneratedManifest(String text) {
+    int begin = text.indexOf("# ── BEGIN GENERATED PATH MANIFEST ──");
+    int end = text.indexOf("# ── END GENERATED PATH MANIFEST ──");
+    if (begin < 0 || end < 0) return text;
+    return text.substring(0, begin) + text.substring(end);
+  }
+
+  private static String region(String text, String begin, String end) {
+    int from = text.indexOf(begin);
+    assertTrue(from >= 0, "missing region start: " + begin.trim());
+    from += begin.length();
+    int to = text.indexOf(end, from);
+    assertTrue(to >= 0, "missing region end: " + end.trim());
+    return text.substring(from, to);
+  }
+}

--- a/src/test/java/io/spicelabs/cli/SpiceLabsCLITest.java
+++ b/src/test/java/io/spicelabs/cli/SpiceLabsCLITest.java
@@ -408,7 +408,7 @@ class SpiceLabsCLITest {
     int rc = cmd.execute("survey", "inventory",
         "test-subject", inputDir.toString(),
         "--no-upload", "--output", outputDir.toString(),
-        "--goat-rodeo-args=maxRecords=10,tempDir=/tmp/test");
+        "--analysis-args=maxRecords=10,tempDir=/tmp/test");
 
     assertEquals(0, rc);
   }

--- a/src/test/java/io/spicelabs/cli/WrapperParityTest.java
+++ b/src/test/java/io/spicelabs/cli/WrapperParityTest.java
@@ -5,11 +5,16 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.io.TempDir;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 
 /**
  * Parity tests for bash and PowerShell wrapper scripts.
@@ -25,10 +30,68 @@ class WrapperParityTest {
   static Path projectDir;
   static boolean hasPwsh;
 
+  /**
+   * Manifest handed to the wrappers for the current test, or null to let them fall back to
+   * the one embedded in the script. The registry cases set this, because the plugin that
+   * contributes {@code registry} is not on the test classpath — and the whole point of the
+   * manifest is that the wrapper learns those commands from the image rather than from a
+   * list it carries.
+   */
+  Path manifestFile;
+
   @BeforeAll
   static void setup() {
     projectDir = Path.of(System.getProperty("user.dir"));
     hasPwsh = checkCommand("pwsh");
+  }
+
+  /**
+   * Render a manifest for the built-in commands plus a stand-in for the allspice plugin,
+   * so the registry cases exercise the same path the real plugin takes.
+   */
+  private void useManifestWithRegistryPlugin() throws Exception {
+    CommandLine root = SpiceLabsCLI.newCommandLine();
+    if (!root.getSubcommands().containsKey("registry")) {
+      root.addSubcommand("registry", new CommandLine(new FakeRegistryCommand()));
+    }
+    manifestFile = Files.createTempFile("parity-manifest", ".txt");
+    Files.writeString(manifestFile, PathManifest.render(root, false));
+  }
+
+  @Command(name = "registry", subcommands = {
+      FakeRegistryDiscover.class, FakeRegistryRun.class,
+      FakeRegistryStatus.class, FakeRegistryCbom.class })
+  static class FakeRegistryCommand implements Callable<Integer> {
+    public Integer call() { return 0; }
+  }
+
+  @Command(name = "discover")
+  static class FakeRegistryDiscover implements Callable<Integer> {
+    @Option(names = "--config", required = true, paramLabel = "FILE") Path config;
+    @Option(names = "--output", paramLabel = "FILE") Path output;
+    public Integer call() { return 0; }
+  }
+
+  @Command(name = "run")
+  static class FakeRegistryRun implements Callable<Integer> {
+    @Option(names = "--config", required = true, paramLabel = "FILE") Path config;
+    @Option(names = "--discovery", paramLabel = "FILE") Path discovery;
+    public Integer call() { return 0; }
+  }
+
+  @Command(name = "status")
+  static class FakeRegistryStatus implements Callable<Integer> {
+    @Option(names = "--config", required = true, paramLabel = "FILE") Path config;
+    @Option(names = "--json") boolean json;
+    public Integer call() { return 0; }
+  }
+
+  @Command(name = "cbom")
+  static class FakeRegistryCbom implements Callable<Integer> {
+    @Option(names = "--config", required = true, paramLabel = "FILE") Path config;
+    @Option(names = "--rogues", paramLabel = "FILE") Path rogues;
+    @Option(names = "--output", paramLabel = "DIR") Path output;
+    public Integer call() { return 0; }
   }
 
   static boolean checkCommand(String cmd) {
@@ -158,17 +221,24 @@ class WrapperParityTest {
 
   @Test
   void registryDiscover_spaceSeparatedPaths() throws Exception {
+    useManifestWithRegistryPlugin();
     Path dir = Files.createTempDirectory("parity-reg-discover");
     Path cfg = dir.resolve("nexus.toml");
     Files.writeString(cfg, "x = 1\n");
     Path out = dir.resolve("discovery.toml"); // does not exist yet (parent does)
 
-    assertParityOrBashOnly(
+    String args = assertParityOrBashOnly(
         "registry", "discover", "--config", cfg.toString(), "--output", out.toString());
+
+    assertTrue(args.contains(dir.toAbsolutePath().toString()), "the config's directory is mounted");
+    assertFalse(Files.isDirectory(out),
+        "--output is paramLabel=FILE, so only its parent is created — never a directory "
+            + "named discovery.toml");
   }
 
   @Test
   void registryRun_joinedPaths() throws Exception {
+    useManifestWithRegistryPlugin();
     Path dir = Files.createTempDirectory("parity-reg-run");
     Path cfg = dir.resolve("nexus.toml");
     Files.writeString(cfg, "x = 1\n");
@@ -181,12 +251,66 @@ class WrapperParityTest {
 
   @Test
   void registryStatus_withJson() throws Exception {
+    useManifestWithRegistryPlugin();
     Path dir = Files.createTempDirectory("parity-reg-status");
     Path cfg = dir.resolve("nexus.toml");
     Files.writeString(cfg, "x = 1\n");
 
     assertParityOrBashOnly(
         "registry", "status", "--config", cfg.toString(), "--json");
+  }
+
+  /**
+   * The defect that motivated the manifest. {@code --rogues} is a {@code Path} on a
+   * plugin subcommand; no wrapper's hardcoded list mentioned it, so its value reached the
+   * container with nothing mounted for it. Nothing about the plugin changed to fix this —
+   * the wrapper now derives it from the option's type.
+   */
+  @Test
+  void registryCbom_pluginPathOptionIsMounted() throws Exception {
+    useManifestWithRegistryPlugin();
+    Path dir = Files.createTempDirectory("parity-reg-cbom");
+    Path cfg = dir.resolve("allspice.toml");
+    Files.writeString(cfg, "x = 1\n");
+    Path roguesDir = Files.createTempDirectory("parity-reg-rogues");
+    Path rogues = roguesDir.resolve("rogues.json");
+    Files.writeString(rogues, "{}");
+    Path out = dir.resolve("cbom-out");
+
+    String args = assertParityOrBashOnly(
+        "registry", "cbom", "--config", cfg.toString(),
+        "--rogues", rogues.toString(), "--output", out.toString());
+
+    assertTrue(args.contains(roguesDir.toAbsolutePath().toString()),
+        "--rogues lives in a different tree, so it needs its own mount: " + args);
+    assertTrue(Files.isDirectory(out),
+        "--output is paramLabel=DIR, so the directory itself is created");
+  }
+
+  /**
+   * A subject that happens to share a subcommand's name is still a subject. The old
+   * wrapper matched positional tokens against a hardcoded name list and swallowed them.
+   */
+  @Test
+  void subjectNamedLikeASubcommandIsStillASubject() throws Exception {
+    Path inputDir = Files.createTempDirectory("parity-subject-run");
+    Files.writeString(inputDir.resolve("file.txt"), "test");
+
+    String args = assertParityOrBashOnly(
+        "survey", "inventory", "run", inputDir.toString());
+
+    assertTrue(args.contains("inventory run "), "`run` stays the subject: " + args);
+  }
+
+  /**
+   * Mounting a host directory over one the image owns would hide the installation, so
+   * such a path is relocated and the mapping recorded for PathTranslator to reverse.
+   */
+  @Test
+  void pathUnderAReservedDirectoryIsRelocated() throws Exception {
+    String args = normalizeDockerArgs(runWrapper("bash", "survey", "inventory", "my-app", "/etc"));
+    assertTrue(args.contains("/mnt/spice/"),
+        "a path under a reserved root must not be identity-mounted: " + args);
   }
 
   // ── Infra ─────────────────────────────────────────────────────────────────
@@ -196,7 +320,7 @@ class WrapperParityTest {
    * known platform differences).
    * If pwsh is not available, only test bash.
    */
-  private void assertParityOrBashOnly(String... cliArgs) throws Exception {
+  private String assertParityOrBashOnly(String... cliArgs) throws Exception {
     String bashDockerArgs = normalizeDockerArgs(runWrapper("bash", cliArgs));
 
     if (hasPwsh) {
@@ -208,6 +332,7 @@ class WrapperParityTest {
 
     // Basic sanity: docker args should not be empty
     assertFalse(bashDockerArgs.isBlank(), "Docker args should not be empty");
+    return bashDockerArgs;
   }
 
   /**
@@ -282,6 +407,13 @@ class WrapperParityTest {
     pb.environment().put("PATH", mockBin + ":" + System.getenv("PATH"));
     pb.environment().put("SPICE_LABS_CLI_SKIP_PULL", "1");
     pb.environment().put("SPICE_PASS", "dummy");
+    // The mock docker records every invocation, so a manifest refresh would both clobber
+    // the captured args and make the result depend on whatever image is on the machine.
+    // Tests supply their manifest explicitly instead.
+    pb.environment().put("SPICE_SKIP_MANIFEST_REFRESH", "1");
+    if (manifestFile != null) {
+      pb.environment().put("SPICE_PATH_MANIFEST", manifestFile.toString());
+    }
     pb.redirectErrorStream(true);
 
     Process p = pb.start();

--- a/test/wrapper/entrypoint.sh
+++ b/test/wrapper/entrypoint.sh
@@ -38,10 +38,9 @@ for arg in "$@"; do
 done
 
 # Write to the default output location inside the container.
-# The wrapper mounts the CLI's default host output directory at /mnt/output when
-# --output is omitted, so the default output path is /mnt/output.
-default_out="/mnt/output"
-mkdir -p "$default_out" 2>/dev/null
+# The wrapper mounts the user's current directory at its own path and makes it the
+# container's working directory, so a relative write lands there on the host.
+default_out="$(pwd)"
 echo "DEFAULT" > "$default_out/default-marker.txt" 2>/dev/null && echo "WROTE:${default_out}/default-marker.txt"
 
 # ANSI-colored output for log-file stripping tests

--- a/test/wrapper/spice-macos.bats
+++ b/test/wrapper/spice-macos.bats
@@ -15,6 +15,11 @@ setup_file() {
 # ── Per-test setup/teardown ──────────────────────────────────────────────────
 
 setup() {
+  # The mock docker records every invocation, so a manifest refresh would clobber the
+  # captured args. Tests here exercise the embedded manifest.
+  export SPICE_SKIP_MANIFEST_REFRESH=1
+  unset SPICE_PATH_MANIFEST
+
   TEST_TMPDIR="$(mktemp -d)"
   MOCK_BIN="$TEST_TMPDIR/mock-bin"
   mkdir -p "$MOCK_BIN"

--- a/test/wrapper/spice.Tests.ps1
+++ b/test/wrapper/spice.Tests.ps1
@@ -324,6 +324,42 @@ exit 0
     chmod +x $mockJavaSh 2>`$null
   }
 
+  # Write a manifest describing the `registry` plugin, standing in for what the
+  # enterprise image reports. The wrapper has no built-in knowledge of these
+  # commands — that is the point — so a test exercising them must supply the
+  # manifest, just as the real image does. Mirrors use_registry_manifest in
+  # spice.bats; keep the two in step.
+  function New-RegistryManifest {
+    $path = Join-Path $script:TestDir 'registry.path-manifest'
+    @'
+# spice-path-manifest 1
+V 1
+G test-fixture
+R /
+R /etc
+R /opt
+R /usr
+R /var
+C spice
+C spice/registry
+C spice/registry/init
+C spice/registry/discover
+C spice/registry/run
+C spice/registry/cbom
+O spice/registry/init --config-only flag
+O spice/registry/init --dir value path create=self
+O spice/registry/init --file value path create=parent
+O spice/registry/discover --config value path create=parent
+O spice/registry/discover --output value path create=parent
+O spice/registry/run --config value path create=parent
+O spice/registry/run --discovery value path create=parent
+O spice/registry/cbom --config value path create=parent
+O spice/registry/cbom --rogues value path create=parent
+O spice/registry/cbom --output value path create=self
+'@ | Set-Content -LiteralPath $path -Encoding ascii
+    return $path
+  }
+
   # ── Helper: run the wrapper with mock docker and parse output ────────────
   function Invoke-SpiceWrapper {
     [CmdletBinding()]
@@ -333,7 +369,8 @@ exit 0
       [string]$SpicePass = 'test-pass-value',
       [string]$DockerFlags,
       [AllowNull()]
-      [string]$SpiceImage = 'spice-wrapper-test'
+      [string]$SpiceImage = 'spice-wrapper-test',
+      [string]$PathManifest
     )
 
     # Put mock docker first on PATH
@@ -343,7 +380,11 @@ exit 0
     # The mock docker records every invocation, so a manifest refresh would clobber the
     # captured args. These tests exercise the manifest embedded in the wrapper.
     $env:SPICE_SKIP_MANIFEST_REFRESH = '1'
-    Remove-Item env:SPICE_PATH_MANIFEST -ErrorAction SilentlyContinue
+    if ($PathManifest) {
+      $env:SPICE_PATH_MANIFEST = $PathManifest
+    } else {
+      Remove-Item env:SPICE_PATH_MANIFEST -ErrorAction SilentlyContinue
+    }
     if ($null -eq $SpiceImage) {
       Remove-Item env:SPICE_IMAGE -ErrorAction SilentlyContinue
     } else {
@@ -778,7 +819,7 @@ Describe 'spice.ps1 wrapper' {
       New-Item -ItemType Directory -Path $initDir -Force | Out-Null
       Push-Location $script:TestDir
       try {
-        $r = Invoke-SpiceWrapper -Arguments @('registry', 'init', '--dir', './registry-init')
+        $r = Invoke-SpiceWrapper -PathManifest (New-RegistryManifest) -Arguments @('registry', 'init', '--dir', './registry-init')
         $r.ExitCode | Should -Be 0
         $r.ContainerArgs | Should -Contain 'registry'
         $r.ContainerArgs | Should -Contain 'init'
@@ -793,7 +834,7 @@ Describe 'spice.ps1 wrapper' {
       New-Item -ItemType Directory -Path $outDir -Force | Out-Null
       Push-Location $script:TestDir
       try {
-        $r = Invoke-SpiceWrapper -Arguments @('registry', 'init', '--config-only', '--file', './init-config/allspice.toml')
+        $r = Invoke-SpiceWrapper -PathManifest (New-RegistryManifest) -Arguments @('registry', 'init', '--config-only', '--file', './init-config/allspice.toml')
         $r.ExitCode | Should -Be 0
         $r.ContainerArgs | Should -Contain 'registry'
         $r.ContainerArgs | Should -Contain 'init'
@@ -810,7 +851,7 @@ Describe 'spice.ps1 wrapper' {
       New-Item -ItemType Directory -Path $configDir -Force | Out-Null
       Push-Location $script:TestDir
       try {
-        $r = Invoke-SpiceWrapper -Arguments @('registry', 'discover', '--config', './config/allspice.toml')
+        $r = Invoke-SpiceWrapper -PathManifest (New-RegistryManifest) -Arguments @('registry', 'discover', '--config', './config/allspice.toml')
         $r.ExitCode | Should -Be 0
         $r.ContainerArgs | Should -Contain 'registry'
         $r.ContainerArgs | Should -Contain 'discover'
@@ -828,7 +869,7 @@ Describe 'spice.ps1 wrapper' {
       New-Item -ItemType Directory -Path $discoveryDir -Force | Out-Null
       Push-Location $script:TestDir
       try {
-        $r = Invoke-SpiceWrapper -Arguments @('registry', 'run', '--config', './config/allspice.toml', '--discovery', './discovery/packages.json')
+        $r = Invoke-SpiceWrapper -PathManifest (New-RegistryManifest) -Arguments @('registry', 'run', '--config', './config/allspice.toml', '--discovery', './discovery/packages.json')
         $r.ExitCode | Should -Be 0
         $r.ContainerArgs | Should -Contain 'registry'
         $r.ContainerArgs | Should -Contain 'run'

--- a/test/wrapper/spice.Tests.ps1
+++ b/test/wrapper/spice.Tests.ps1
@@ -40,14 +40,19 @@ class MockDocker {
     if (args.Length > 0 && args[0] == "pull") return 0;
     // Detect runtime survey calls by --entrypoint
     string entrypoint = null;
+    string workDir = null;
     var volumes = new Dictionary<string,string>();
     for (int j = 0; j < args.Length - 1; j++) {
       if (args[j] == "--entrypoint") entrypoint = args[j+1];
+      if (args[j] == "-w") workDir = args[j+1];
       if (args[j] == "-v" && args[j+1].Contains(":")) {
         var vol = args[j+1];
         volumes[ContainerPath(vol)] = HostPath(vol);
       }
     }
+    // Identity mounts mean the working directory the wrapper passes is also a real
+    // host directory, so the mock can write there directly.
+    if (workDir != null && volumes.ContainsKey(workDir)) workDir = volumes[workDir];
     // Phase 1: extraction
     if (entrypoint == "sh" && volumes.Count > 0) {
       foreach (var kv in volumes) {
@@ -87,18 +92,18 @@ class MockDocker {
       if (a.Length > 0 && char.IsLower(a[0]) && !a.StartsWith("--") && a != "run" && a != "host" && a != "never"
           && (a.Contains(":") || a.Contains("/"))) { found = true; continue; }
     }
-    // If no --output was given, write a marker to the default container output
-    // path (/mnt/output) so tests can verify the volume mount.
+    // If no --output was given, write a marker to the container's working directory.
+    // The wrapper mounts the user's current directory at its own path and passes it as
+    // -w, so a relative write inside the container lands there on the host.
     bool hasOutput = false;
     foreach (var a in cli) {
       if (a == "--output" || a.StartsWith("--output=")) { hasOutput = true; break; }
     }
-    if (!hasOutput && volumes.ContainsKey("/mnt/output")) {
-      var outDir = volumes["/mnt/output"];
+    if (!hasOutput && workDir != null) {
       try {
-        Directory.CreateDirectory(outDir);
-        File.WriteAllText(Path.Combine(outDir, "default-marker.txt"), "DEFAULT");
-        Console.WriteLine("WROTE:/mnt/output/default-marker.txt");
+        Directory.CreateDirectory(workDir);
+        File.WriteAllText(Path.Combine(workDir, "default-marker.txt"), "DEFAULT");
+        Console.WriteLine("WROTE:" + workDir + "/default-marker.txt");
       } catch {}
     }
     Console.WriteLine("===SPICE_TEST_BEGIN===");
@@ -335,6 +340,10 @@ exit 0
     $env:PATH = "$($script:MockBinDir)$([System.IO.Path]::PathSeparator)$($env:PATH)"
 
     $env:SPICE_LABS_CLI_SKIP_PULL = '1'
+    # The mock docker records every invocation, so a manifest refresh would clobber the
+    # captured args. These tests exercise the manifest embedded in the wrapper.
+    $env:SPICE_SKIP_MANIFEST_REFRESH = '1'
+    Remove-Item env:SPICE_PATH_MANIFEST -ErrorAction SilentlyContinue
     if ($null -eq $SpiceImage) {
       Remove-Item env:SPICE_IMAGE -ErrorAction SilentlyContinue
     } else {
@@ -446,7 +455,8 @@ Describe 'spice.ps1 wrapper' {
       $r.ContainerArgs | Should -Contain 'survey'
       $r.ContainerArgs | Should -Contain 'inventory'
       $r.ContainerArgs | Should -Contain 'myapp'
-      $r.ContainerArgs | Should -Contain '/mnt/input'
+      # Identity mount: the container sees the input at its host path.
+      $r.ContainerArgs | Should -Contain $script:InputDir
     }
 
     It 'survey inventory with single file input' {
@@ -456,7 +466,7 @@ Describe 'spice.ps1 wrapper' {
       $r.ContainerArgs | Should -Contain 'survey'
       $r.ContainerArgs | Should -Contain 'inventory'
       $r.ContainerArgs | Should -Contain 'myapp'
-      $r.ContainerArgs | Should -Contain '/mnt/input/file.txt'
+      $r.ContainerArgs | Should -Contain $file
     }
 
     It 'pass decode' {
@@ -539,7 +549,7 @@ Describe 'spice.ps1 wrapper' {
       $r = Invoke-SpiceWrapper -Arguments @('survey', 'inventory', 'myapp', $script:InputDir, '--output', $outDir)
       $r.ExitCode | Should -Be 0
       $r.ContainerArgs | Should -Contain '--output'
-      $r.ContainerArgs | Should -Contain '/mnt/output'
+      $r.ContainerArgs | Should -Contain $outDir
       $outDir | Should -Exist
     }
 
@@ -547,15 +557,15 @@ Describe 'spice.ps1 wrapper' {
       $outDir = Join-Path $script:TestDir 'output-eq'
       $r = Invoke-SpiceWrapper -Arguments @('survey', 'inventory', 'myapp', $script:InputDir, "--output=$outDir")
       $r.ExitCode | Should -Be 0
-      $r.ContainerArgs | Should -Contain '--output'
-      $r.ContainerArgs | Should -Contain '/mnt/output'
+      # The joined form is preserved; only the value is absolutised.
+      $r.ContainerArgs | Should -Contain "--output=$outDir"
       $outDir | Should -Exist
     }
 
     It 'default output dir created when --output omitted (bug #530)' {
-      # When --output is omitted, the wrapper mounts the current directory at
-      # /mnt/output in the container. The container writes to its internal
-      # /mnt/output path; the wrapper does not concern itself with that path.
+      # When --output is omitted, the wrapper mounts the current directory at its own
+      # path and makes it the container's working directory, so a relative write inside
+      # the container lands in the user's current directory on the host.
       $defaultDir = Get-Location
 
       $r = Invoke-SpiceWrapper -Arguments @('survey', 'inventory', 'myapp', $script:InputDir)
@@ -563,8 +573,8 @@ Describe 'spice.ps1 wrapper' {
       # Verify the marker file appears in the current directory on the host
       $marker = Join-Path $defaultDir 'default-marker.txt'
       $marker | Should -Exist
-      # Verify a volume mount to /mnt/output is in the docker run args
-      $volArg = $r.DockerRunArgs | Where-Object { $_ -match '/mnt/output' }
+      # Verify the current directory is mounted in the docker run args
+      $volArg = $r.DockerRunArgs | Where-Object { $_ -match [regex]::Escape("$defaultDir") }
       $volArg | Should -Not -BeNullOrEmpty
       Remove-Item $marker -ErrorAction SilentlyContinue
     }
@@ -641,7 +651,7 @@ Describe 'spice.ps1 wrapper' {
       $r.ContainerArgs | Should -Contain 'survey'
       $r.ContainerArgs | Should -Contain 'inventory'
       $r.ContainerArgs | Should -Contain 'myapp'
-      $r.ContainerArgs | Should -Contain '/mnt/input'
+      $r.ContainerArgs | Should -Contain $script:InputDir
       $r.ContainerArgs | Should -Contain '--threads'
       $r.ContainerArgs | Should -Contain '4'
       $r.ContainerArgs | Should -Contain '--log-level'
@@ -850,7 +860,7 @@ Describe 'spice.ps1 wrapper' {
 
     It 'includes volume mount for input' {
       $r = Invoke-SpiceWrapper -Arguments @('survey', 'inventory', 'myapp', $script:InputDir)
-      $volMount = $r.DockerRunArgs | Where-Object { $_ -match '/mnt/input' }
+      $volMount = $r.DockerRunArgs | Where-Object { $_ -match [regex]::Escape($script:InputDir) }
       $volMount | Should -Not -BeNullOrEmpty
     }
   }

--- a/test/wrapper/spice.Tests.ps1
+++ b/test/wrapper/spice.Tests.ps1
@@ -324,6 +324,14 @@ exit 0
     chmod +x $mockJavaSh 2>`$null
   }
 
+  function global:Convert-TestPathToDockerPath($p) {
+    if ($IsWindows -or -not (Test-Path variable:IsWindows)) {
+      if ($p -match '^([A-Za-z]):') { $p = $p -replace '^[A-Za-z]:', "/$($matches[1].ToLower())" }
+      $p = $p -replace '\\', '/'
+    }
+    return $p
+  }
+
   # Write a manifest describing the `registry` plugin, standing in for what the
   # enterprise image reports. The wrapper has no built-in knowledge of these
   # commands — that is the point — so a test exercising them must supply the
@@ -496,8 +504,9 @@ Describe 'spice.ps1 wrapper' {
       $r.ContainerArgs | Should -Contain 'survey'
       $r.ContainerArgs | Should -Contain 'inventory'
       $r.ContainerArgs | Should -Contain 'myapp'
-      # Identity mount: the container sees the input at its host path.
-      $r.ContainerArgs | Should -Contain $script:InputDir
+      # Identity mount: the container sees the input where the user typed it,
+      # modulo the Windows drive-letter translation docker requires.
+      $r.ContainerArgs | Should -Contain (Convert-TestPathToDockerPath $script:InputDir)
     }
 
     It 'survey inventory with single file input' {
@@ -507,7 +516,7 @@ Describe 'spice.ps1 wrapper' {
       $r.ContainerArgs | Should -Contain 'survey'
       $r.ContainerArgs | Should -Contain 'inventory'
       $r.ContainerArgs | Should -Contain 'myapp'
-      $r.ContainerArgs | Should -Contain $file
+      $r.ContainerArgs | Should -Contain (Convert-TestPathToDockerPath $file)
     }
 
     It 'pass decode' {
@@ -590,7 +599,7 @@ Describe 'spice.ps1 wrapper' {
       $r = Invoke-SpiceWrapper -Arguments @('survey', 'inventory', 'myapp', $script:InputDir, '--output', $outDir)
       $r.ExitCode | Should -Be 0
       $r.ContainerArgs | Should -Contain '--output'
-      $r.ContainerArgs | Should -Contain $outDir
+      $r.ContainerArgs | Should -Contain (Convert-TestPathToDockerPath $outDir)
       $outDir | Should -Exist
     }
 
@@ -599,7 +608,7 @@ Describe 'spice.ps1 wrapper' {
       $r = Invoke-SpiceWrapper -Arguments @('survey', 'inventory', 'myapp', $script:InputDir, "--output=$outDir")
       $r.ExitCode | Should -Be 0
       # The joined form is preserved; only the value is absolutised.
-      $r.ContainerArgs | Should -Contain "--output=$outDir"
+      $r.ContainerArgs | Should -Contain "--output=$(Convert-TestPathToDockerPath $outDir)"
       $outDir | Should -Exist
     }
 
@@ -692,7 +701,7 @@ Describe 'spice.ps1 wrapper' {
       $r.ContainerArgs | Should -Contain 'survey'
       $r.ContainerArgs | Should -Contain 'inventory'
       $r.ContainerArgs | Should -Contain 'myapp'
-      $r.ContainerArgs | Should -Contain $script:InputDir
+      $r.ContainerArgs | Should -Contain (Convert-TestPathToDockerPath $script:InputDir)
       $r.ContainerArgs | Should -Contain '--threads'
       $r.ContainerArgs | Should -Contain '4'
       $r.ContainerArgs | Should -Contain '--log-level'
@@ -804,14 +813,6 @@ Describe 'spice.ps1 wrapper' {
   }
 
   # ── Registry command (same-path mounts) ────────────────────────────────────
-
-  function global:Convert-TestPathToDockerPath($p) {
-    if ($IsWindows -or -not (Test-Path variable:IsWindows)) {
-      if ($p -match '^([A-Za-z]):') { $p = $p -replace '^[A-Za-z]:', "/$($matches[1].ToLower())" }
-      $p = $p -replace '\\', '/'
-    }
-    return $p
-  }
 
   Context 'Registry command (same-path mounts)' {
     It 'registry init --dir rewrites relative path to absolute same-path' {

--- a/test/wrapper/spice.bats
+++ b/test/wrapper/spice.bats
@@ -19,6 +19,11 @@ setup_file() {
 
 setup() {
   export SPICE_LABS_CLI_SKIP_PULL=1
+  # The mock/test image is queried for its path manifest otherwise, which would both
+  # slow every test down and make results depend on the image on the machine. Tests
+  # that need a manifest supply one explicitly via use_registry_manifest.
+  export SPICE_SKIP_MANIFEST_REFRESH=1
+  unset SPICE_PATH_MANIFEST
   export SPICE_IMAGE="$TEST_IMAGE"
   export SPICE_IMAGE_TAG=latest
   export SPICE_PASS=test-pass-value
@@ -85,6 +90,40 @@ refute_arg() {
   }
 }
 
+# Point the wrapper at a manifest describing the `registry` plugin, standing in for
+# what the enterprise image reports. The wrapper has no built-in knowledge of these
+# commands — that is the point — so a test exercising them must supply the manifest,
+# just as the real image does.
+use_registry_manifest() {
+  export SPICE_PATH_MANIFEST="$TEST_TMPDIR/registry.path-manifest"
+  cat > "$SPICE_PATH_MANIFEST" <<'MANIFEST'
+# spice-path-manifest 1
+V 1
+G test-fixture
+R /
+R /etc
+R /opt
+R /usr
+R /var
+C spice
+C spice/registry
+C spice/registry/init
+C spice/registry/discover
+C spice/registry/run
+C spice/registry/cbom
+O spice/registry/init --config-only flag
+O spice/registry/init --dir value path create=self
+O spice/registry/init --file value path create=parent
+O spice/registry/discover --config value path create=parent exists
+O spice/registry/discover --output value path create=parent
+O spice/registry/run --config value path create=parent exists
+O spice/registry/run --discovery value path create=parent exists
+O spice/registry/cbom --config value path create=parent exists
+O spice/registry/cbom --rogues value path create=parent exists
+O spice/registry/cbom --output value path create=self
+MANIFEST
+}
+
 # ── Args: basic commands ─────────────────────────────────────────────────────
 
 @test "survey inventory with directory input" {
@@ -93,7 +132,8 @@ refute_arg() {
   assert_arg "survey"
   assert_arg "inventory"
   assert_arg "myapp"
-  assert_arg "/mnt/input"
+  # Identity mount: the container sees the input at its host path.
+  assert_arg "$TEST_TMPDIR/input"
 }
 
 @test "survey inventory with single file input" {
@@ -102,7 +142,7 @@ refute_arg() {
   assert_arg "survey"
   assert_arg "inventory"
   assert_arg "myapp"
-  assert_arg "/mnt/input/file.txt"
+  assert_arg "$TEST_TMPDIR/input/file.txt"
 }
 
 @test "pass decode" {
@@ -197,6 +237,7 @@ refute_arg() {
 @test "registry init --dir rewrites relative path to absolute same-path" {
   local initdir="$TEST_TMPDIR/registry-init"
   mkdir -p "$initdir"
+  use_registry_manifest
   pushd "$TEST_TMPDIR" > /dev/null
   run "$WRAPPER" registry init --dir "./registry-init"
   popd > /dev/null
@@ -210,6 +251,7 @@ refute_arg() {
 @test "registry init --config-only --file rewrites relative path to absolute same-path" {
   local outfile="$TEST_TMPDIR/init-config/allspice.toml"
   mkdir -p "$TEST_TMPDIR/init-config"
+  use_registry_manifest
   pushd "$TEST_TMPDIR" > /dev/null
   run "$WRAPPER" registry init --config-only --file "./init-config/allspice.toml"
   popd > /dev/null
@@ -224,6 +266,7 @@ refute_arg() {
 @test "registry discover --config rewrites relative path to absolute same-path" {
   local config="$TEST_TMPDIR/config/allspice.toml"
   mkdir -p "$TEST_TMPDIR/config"
+  use_registry_manifest
   pushd "$TEST_TMPDIR" > /dev/null
   run "$WRAPPER" registry discover --config "./config/allspice.toml"
   popd > /dev/null
@@ -238,6 +281,7 @@ refute_arg() {
   local config="$TEST_TMPDIR/config/allspice.toml"
   local discovery="$TEST_TMPDIR/discovery/packages.json"
   mkdir -p "$TEST_TMPDIR/config" "$TEST_TMPDIR/discovery"
+  use_registry_manifest
   pushd "$TEST_TMPDIR" > /dev/null
   run "$WRAPPER" registry run --config "./config/allspice.toml" --discovery "./discovery/packages.json"
   popd > /dev/null
@@ -257,7 +301,7 @@ refute_arg() {
   run "$WRAPPER" survey inventory myapp "$TEST_TMPDIR/input" --output "$outdir"
   [ "$status" -eq 0 ]
   assert_arg "--output"
-  assert_arg "/mnt/output"
+  assert_arg "$outdir"
   [ -d "$outdir" ]
 }
 
@@ -265,8 +309,8 @@ refute_arg() {
   local outdir="$TEST_TMPDIR/output-eq"
   run "$WRAPPER" survey inventory myapp "$TEST_TMPDIR/input" "--output=$outdir"
   [ "$status" -eq 0 ]
-  assert_arg "--output"
-  assert_arg "/mnt/output"
+  # The joined form is preserved; only the value is absolutised.
+  assert_arg "--output=$outdir"
   [ -d "$outdir" ]
 }
 
@@ -279,16 +323,16 @@ refute_arg() {
   run "$WRAPPER" survey inventory myapp "$TEST_TMPDIR/input" --output "$outdir"
   [ "$status" -eq 0 ]
   assert_arg "--output"
-  assert_arg "/mnt/output"
+  assert_arg "$outdir"
   [ -f "$outdir/marker.txt" ]
   [ "$(cat "$outdir/marker.txt")" = "OK" ]
 }
 
 @test "default output dir mounted when --output omitted" {
   # Reproduces bug #530
-  # When --output is omitted, the wrapper mounts the current directory at
-  # /mnt/output in the container. The container writes to its internal
-  # /mnt/output path; the wrapper itself does not concern itself with that path.
+  # When --output is omitted, the wrapper mounts the current directory at its own
+  # path and sets it as the container's working directory, so a relative write inside
+  # the container lands in the user's current directory on the host.
   run "$WRAPPER" survey inventory myapp "$TEST_TMPDIR/input"
   [ "$status" -eq 0 ]
   # The marker file must appear in the current directory on the host.
@@ -367,7 +411,7 @@ refute_arg() {
   assert_arg "survey"
   assert_arg "inventory"
   assert_arg "myapp"
-  assert_arg "/mnt/input"
+  assert_arg "$TEST_TMPDIR/input"
   assert_arg "--threads"
   assert_arg "4"
   assert_arg "--log-level"
@@ -593,7 +637,7 @@ SCRIPT
   assert_arg "survey"
   assert_arg "inventory"
   assert_arg "myapp"
-  assert_arg "/mnt/input"
+  assert_arg "$spaced_dir"
 }
 
 @test "path with spaces: file input" {
@@ -604,7 +648,7 @@ SCRIPT
   assert_arg "survey"
   assert_arg "inventory"
   assert_arg "myapp"
-  assert_arg "/mnt/input/file with spaces.txt"
+  assert_arg "$spaced_file"
 }
 
 @test "path with dollar sign: handled correctly" {
@@ -613,7 +657,7 @@ SCRIPT
   echo "test" > "$dollar_dir/file.txt"
   run "$WRAPPER" survey inventory myapp "$dollar_dir"
   [ "$status" -eq 0 ]
-  assert_arg "/mnt/input"
+  assert_arg "$dollar_dir"
 }
 
 @test "relative path: converted to absolute" {
@@ -624,7 +668,8 @@ SCRIPT
   run "$WRAPPER" survey inventory myapp "./input"
   popd > /dev/null
   [ "$status" -eq 0 ]
-  assert_arg "/mnt/input"
+  # A relative path still reaches the container absolutised.
+  assert_arg "$TEST_TMPDIR/input"
 }
 
 @test "parent directory reference: resolved correctly" {
@@ -634,7 +679,7 @@ SCRIPT
   run "$WRAPPER" survey inventory myapp "../nested/input"
   popd > /dev/null
   [ "$status" -eq 0 ]
-  assert_arg "/mnt/input"
+  assert_arg "$TEST_TMPDIR/nested/input"
 }
 
 @test "symlink to directory: resolved to real path" {
@@ -643,7 +688,7 @@ SCRIPT
   ln -s "$TEST_TMPDIR/realdir" "$TEST_TMPDIR/linkdir"
   run "$WRAPPER" survey inventory myapp "$TEST_TMPDIR/linkdir"
   [ "$status" -eq 0 ]
-  assert_arg "/mnt/input"
+  assert_arg "$TEST_TMPDIR/realdir"
 }
 
 @test "symlink to file: passes through as symlink path" {
@@ -652,8 +697,7 @@ SCRIPT
   run "$WRAPPER" survey inventory myapp "$TEST_TMPDIR/linkfile.txt"
   [ "$status" -eq 0 ]
   # The script resolves the symlink's directory but keeps the filename
-  # The mount is the directory containing the symlink
-  assert_arg "/mnt/input/linkfile.txt"
+  assert_arg "$TEST_TMPDIR/linkfile.txt"
 }
 
 # ── Runtime survey error handling ────────────────────────────────────────────
@@ -719,7 +763,7 @@ SCRIPT
   assert_arg "survey"
   assert_arg "inventory"
   assert_arg "myapp"
-  assert_arg "/mnt/input"
+  assert_arg "$TEST_TMPDIR/input"
   assert_arg "--threads"
   assert_arg "4"
   assert_arg "--log-level"
@@ -755,4 +799,72 @@ SCRIPT
   run "$WRAPPER" survey inventory myapp "$TEST_TMPDIR/input"
   [ "$status" -eq 0 ]
   [ "$(container_env SPICE_LABS_JVM_ARGS)" = "-Xmx2g -XX:+UseG1GC" ]
+}
+
+# ── Path manifest resolution ─────────────────────────────────────────────────
+
+@test "an image that does not know path-manifest falls back silently" {
+  # The test image echoes its args rather than emitting a manifest, so the refresh
+  # produces nothing usable. That must degrade to the embedded manifest, not fail.
+  unset SPICE_SKIP_MANIFEST_REFRESH
+  run "$WRAPPER" survey inventory myapp "$TEST_TMPDIR/input"
+  [ "$status" -eq 0 ]
+  assert_arg "$TEST_TMPDIR/input"
+}
+
+@test "an unreadable manifest override falls back to the embedded manifest" {
+  export SPICE_PATH_MANIFEST="$TEST_TMPDIR/does-not-exist"
+  run "$WRAPPER" survey inventory myapp "$TEST_TMPDIR/input"
+  [ "$status" -eq 0 ]
+  assert_arg "$TEST_TMPDIR/input"
+}
+
+@test "a manifest of an unknown schema version is ignored, not obeyed" {
+  export SPICE_PATH_MANIFEST="$TEST_TMPDIR/future.path-manifest"
+  cat > "$SPICE_PATH_MANIFEST" <<'MANIFEST'
+# spice-path-manifest 99
+V 99
+C spice
+MANIFEST
+  run "$WRAPPER" survey inventory myapp "$TEST_TMPDIR/input"
+  [ "$status" -eq 0 ]
+  # No usable manifest at all: arguments pass through untouched rather than being
+  # mis-parsed against a format this wrapper does not understand.
+  assert_arg "myapp"
+}
+
+@test "a manifest is cached per image id and reused" {
+  unset SPICE_SKIP_MANIFEST_REFRESH
+  export SPICE_CACHE_DIR="$TEST_TMPDIR/cache"
+  local image_id
+  image_id="$(docker image inspect --format '{{.Id}}' "$TEST_IMAGE")"
+  mkdir -p "$SPICE_CACHE_DIR/path-manifest"
+  # A cached manifest that renames the input positional to a non-path proves the
+  # cache is consulted: the input would otherwise be absolutised.
+  cat > "$SPICE_CACHE_DIR/path-manifest/${image_id#sha256:}" <<'MANIFEST'
+# spice-path-manifest 1
+V 1
+C spice
+C spice/survey
+C spice/survey/inventory
+P spice/survey/inventory 0 value
+P spice/survey/inventory 1 value
+MANIFEST
+  pushd "$TEST_TMPDIR" > /dev/null
+  run "$WRAPPER" survey inventory myapp "./input"
+  popd > /dev/null
+  [ "$status" -eq 0 ]
+  assert_arg "./input"
+}
+
+@test "a path under a reserved directory is relocated, not mounted over" {
+  run "$WRAPPER" survey inventory myapp /etc
+  [ "$status" -eq 0 ]
+  # Bind-mounting the host's /etc over the container's would break the image.
+  refute_arg "/etc"
+  container_args | grep -q '^/mnt/spice/' || {
+    echo "expected a relocated mountpoint; actual args:"
+    container_args | sed 's/^/  /'
+    return 1
+  }
 }

--- a/test/wrapper/spice.bats
+++ b/test/wrapper/spice.bats
@@ -114,12 +114,12 @@ C spice/registry/cbom
 O spice/registry/init --config-only flag
 O spice/registry/init --dir value path create=self
 O spice/registry/init --file value path create=parent
-O spice/registry/discover --config value path create=parent exists
+O spice/registry/discover --config value path create=parent
 O spice/registry/discover --output value path create=parent
-O spice/registry/run --config value path create=parent exists
-O spice/registry/run --discovery value path create=parent exists
-O spice/registry/cbom --config value path create=parent exists
-O spice/registry/cbom --rogues value path create=parent exists
+O spice/registry/run --config value path create=parent
+O spice/registry/run --discovery value path create=parent
+O spice/registry/cbom --config value path create=parent
+O spice/registry/cbom --rogues value path create=parent
 O spice/registry/cbom --output value path create=self
 MANIFEST
 }
@@ -682,13 +682,16 @@ SCRIPT
   assert_arg "$TEST_TMPDIR/nested/input"
 }
 
-@test "symlink to directory: resolved to real path" {
+@test "symlink to directory: mounted under the path the user gave" {
   mkdir -p "$TEST_TMPDIR/realdir"
   echo "test" > "$TEST_TMPDIR/realdir/file.txt"
   ln -s "$TEST_TMPDIR/realdir" "$TEST_TMPDIR/linkdir"
   run "$WRAPPER" survey inventory myapp "$TEST_TMPDIR/linkdir"
   [ "$status" -eq 0 ]
-  assert_arg "$TEST_TMPDIR/realdir"
+  # `cd` + `pwd` resolve logically, so the symlink path is what reaches the
+  # container — as it did before manifests. Docker resolves the host side of
+  # the mount, so the contents are the real directory's either way.
+  assert_arg "$TEST_TMPDIR/linkdir"
 }
 
 @test "symlink to file: passes through as symlink path" {


### PR DESCRIPTION
Second of two stacked PRs — **based on #246**, review that one first. This is where the behaviour changes.

## What

The hardcoded path-flag lists are gone from `spice`, `spice.ps1`, `is_value_flag()` and `is_subcommand()`. Both wrappers read the manifest #246 renders, from whichever of these answers first:

1. `$SPICE_PATH_MANIFEST` — explicit override (tests, air-gapped)
2. a cache under `~/.cache/spice`, keyed by `docker image inspect` ID, so a `docker pull` invalidates it — no TTL, no staleness logic
3. the file `install.sh` seeds
4. the manifest embedded in the script at build time

Every tier is best-effort. An unreadable file, a failed `docker run`, or an image too old to know `path-manifest` falls through, and the embedded manifest is the floor — this can never abort the CLI. `spice registry cbom --rogues` works, with **no change to the plugin that declares it**.

**Correction to an earlier version of this description:** `registry cbom` is not on allspice's `main` yet — it lives on an unmerged branch, so that command is not broken *today*; it would be the moment it lands. The mechanism is what matters: any `Path` option a plugin declares is mounted, whether or not this repo has heard of it.

## Mount at the path the user typed

The registry branch already used identity mounts (`-v $dir:$dir`). Doing it everywhere retires the fixed `/mnt/input`, `/mnt/output`, `/mnt/config` and `/mnt/discovery` mountpoints, and with them:

- the `PATH_MAP` arg-rewriting loops — paths are absolutised and nothing else
- the discovery-shares-config-dir special case
- the `--output`/`--config` collision, which existed only because `/mnt/output` was a singleton

`PathTranslator` stays, for the two cases that still rewrite: Windows drive letters, and a path under a directory the image owns — relocated to `/mnt/spice/N` rather than bind-mounted over, since mounting the host's `/opt` over the image's would destroy the installation.

`spice` goes from 1009 lines to 480. **That includes deleting three dead copies of the registry branch** (lines 558–818): only the first of four could ever execute, and they had already drifted apart — looks like a bad merge.

## Drift can't come back

The argument walk is one implementation, kept in `shared/` and spliced into both wrappers by `scripts/update-path-manifest.sh`. `PathManifestGoldenTest` fails the build when a copy goes stale, and asserts no wrapper names a specific flag or mountpoint again. Bash 3.2 has no associative arrays (macOS system bash, and `spice-macos.bats` runs on `macos-14`), so its lookup tables are delimited strings searched by parameter expansion.

## Also fixed

A subject named `run`, `status`, `list` or `static` was silently swallowed by `is_subcommand()`. A positional now descends into a subcommand only before any positional has been consumed at that node.

## Review notes

- **`-w $PWD` is new.** Relative paths the CLI resolves itself now land in the user's current directory rather than `/mnt/output`. That is the intent, and `spice.bats`'s existing `default-marker.txt` test covers it.
- **`:ro` mounts dropped.** Read-only-ness isn't inferable from a type, and the container already runs as `--user $(id -u):$(id -g)`.
- **The version-skew window.** A new wrapper against an *old* image falls back to the built-ins manifest, which has no `--config`, so `spice registry` paths would go unmounted. `docker pull` runs before `mf_load`, so a normal invocation has refreshed first; it only bites users pinning `SPICE_IMAGE_TAG` or running `SPICE_LABS_CLI_SKIP_PULL=1`. Worth confirming against the previous released image before merging.

## Testing

`mvn test` green. `WrapperParityTest` gains the `--rogues` regression, file-vs-directory creation, reserved-directory relocation, and the subject-named-`run` case; the registry cases now supply a manifest describing a stand-in plugin, since the real one isn't on the test classpath — which is the point.

⚠️ The bats and Pester suites are updated for identity mounts (including the mock-docker capture, which a manifest refresh would otherwise clobber — hence `SPICE_SKIP_MANIFEST_REFRESH=1` in `setup()`) but I could not run them locally: bats isn't installed. **They need a CI run before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
