### PR TITLE
Pin ShellCheck to v0.11.0 instead of the runner's version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,11 +60,18 @@ jobs:
         shell: pwsh
         run: Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
 
+      # Pinned to an explicit version rather than using the runner image's
+      # shellcheck, which tracks whatever ubuntu-24.04 currently ships (0.9.0)
+      # and changes under us when GitHub bumps the image. Versions differ in
+      # what they report, so an unpinned linter can fail a PR that touches
+      # nothing related, and can equally pass locally and fail in CI. One
+      # invocation for all files, so a single run reports every finding.
       - name: Run ShellCheck on shell scripts
         run: |
-          shellcheck install.sh
-          shellcheck test/wrapper/entrypoint.sh
-          shellcheck spice
+          docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck:v0.11.0 \
+            install.sh \
+            test/wrapper/entrypoint.sh \
+            spice
 
       - name: Run PSScriptAnalyzer on PowerShell scripts
         shell: pwsh
@@ -294,4 +301,5 @@ jobs:
           githubToken: "${{ secrets.GITHUB_TOKEN }}"
 
 # Requirements for builder machine
-# docker jq curl gh shellcheck powershell
+# docker jq curl gh powershell
+# (shellcheck is no longer needed on the machine — it runs from a pinned image)


### PR DESCRIPTION
## Why

I had some issues with my local shellcheck (0.11) catching fewer issues than the version used in CI, so this upgrades to a more recent version.

## What

Runs the official image at an explicit tag:

```yaml
docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck:v0.11.0 \
  install.sh \
  test/wrapper/entrypoint.sh \
  spice
```

v0.11.0 is the current release (Aug 2025). 0.9.0 predates it by two releases and about two and a half years.

Also collapses the three separate invocations into one, so a run reports every finding rather than stopping at the first file with a problem, and drops `shellcheck` from the builder-machine requirements at the bottom of the file — it comes from the image now.

## Verification

**No code changes** — every script this repo checks is already clean under 0.11.0.
