### PR TITLE
Resolve the Spice Pass once and hand its claims to plugins

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -8,6 +8,15 @@
 not the core CLI. It appears only when that plugin is on the classpath — i.e. in a build/image
 that bundles it. The public CLI ships without it. See [Plugins](README.md#-plugins).
 
+**Q: My survey covered fewer artifacts than I expected.**
+
+Your Spice Pass may carry an **artifact cutoff**, which puts anything published after a given
+instant out of scope, along with anything that transitively contains it. It follows the pass
+rather than any flag, and applies to both the inventory analysis and the `registry` discovery
+analysis. Run `spice pass decode` and look for **Artifact Cutoff**; when one is in force, each
+run logs `Ignoring artifacts published after …`. See
+[Artifact cutoff](README.md#artifact-cutoff).
+
 **Q: How do I add my own command to `spice`?**
 
 Write a plugin — `spice` discovers commands at runtime via `ServiceLoader`, so you don't modify

--- a/README.md
+++ b/README.md
@@ -47,6 +47,24 @@ spice survey inventory <subject> <input>
 - **`subject`** — label identifying the system being surveyed (shown on the dashboard)
 - **`input`** — path to artifacts (directory or single file)
 
+#### Artifact cutoff
+
+Some Spice Passes carry an **artifact cutoff**. When yours does, artifacts published after that
+instant are out of scope: they are left out of the survey, along with anything that transitively
+contains them. The cutoff applies to the inventory analysis and to the discovery analysis
+contributed by the [`allspice`](https://github.com/spice-labs-inc/allspice) plugin, so one pass
+scopes the whole run the same way.
+
+There is no flag to set, widen or override it — it follows the pass. To see whether yours carries
+one, run `spice pass decode` and look for **Artifact Cutoff**. When a cutoff is in force, every
+run says so:
+
+```
+Ignoring artifacts published after 2026-01-01T00:00:00Z
+```
+
+A pass with no cutoff surveys everything.
+
 ### Runtime Survey
 
 Instrument a running JVM to detect cryptographic operations executed at runtime:

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -33,14 +33,60 @@ public interface SpiceCommandPlugin {
 }
 
 public interface SpiceContext {
-  int API_VERSION = 1;
-  String version();                 // the running spice CLI version
-  java.util.Optional<String> spicePass(); // resolved SPICE_PASS, for plugins that upload
+  int API_VERSION = 5;
+  String version();                            // the running spice CLI version
+  java.util.Optional<String> spicePass();      // resolved SPICE_PASS, for plugins that upload
+  default SpicePassClaims passClaims();        // that pass, decoded once (see below)
+  default java.util.Map<String, Object> configuration();
 }
 ```
 
 `SpiceContext` gives plugins the same shared services the built-in commands use, so a plugin
-behaves consistently (version reporting, `SPICE_PASS` resolution).
+behaves consistently (version reporting, `SPICE_PASS` resolution, configuration).
+
+`spice` mounts a plugin only when its `apiVersion()` **equals** `API_VERSION` exactly. A
+mismatch is a plugin that does not appear, logged as such — not a build failure — so rebuild
+plugins against the `spice-plugin-api` the CLI ships.
+
+## Reading the Spice Pass
+
+`context.passClaims()` hands over the claims of the pass in force. The CLI decodes it once at
+startup and shares that one value with every plugin and every built-in command, so nothing can
+disagree about what the pass says. Registered JWT claims (`iss`, `sub`, `exp`, …) come out
+through typed accessors; everything Spice-specific lands in `additionalClaims()` verbatim as
+plain `java.*` values, with integral numbers normalised to `Long`.
+
+Decoding the pass yourself works but re-derives what you already have, and claims never arrive
+as system properties: a `-D` property can be set on the command line, which would let a caller
+widen a scope the pass had deliberately narrowed.
+
+### The `x-cutoff` claim
+
+A pass may carry an **artifact cutoff** — artifacts published after that instant are out of
+scope for the whole run, along with anything that transitively contains them. It already
+constrains the built-in inventory analysis; a plugin that analyses or discovers artifacts is
+expected to honour it too, so that one pass scopes the run consistently.
+
+The SPI hands over the raw claim rather than an interpretation, so read it like this:
+
+```java
+Object value = context.passClaims().additionalClaims().get("x-cutoff");
+Optional<Instant> cutoff = (value instanceof Long seconds)
+    ? Optional.of(Instant.ofEpochSecond(seconds))
+    : Optional.empty();
+```
+
+Three rules matter, because each way of getting them wrong yields a run that silently covers
+almost nothing while exiting successfully:
+
+- **Epoch seconds, not milliseconds.** Read as millis, a 2026 cutoff lands in January 1970 and
+  excludes the entire estate.
+- **An absent claim means no cutoff**, never `Instant.EPOCH`. Defaulting to the epoch turns
+  "this pass does not narrow scope" into "exclude everything".
+- **A non-numeric value is ignored** — warn and carry on with no cutoff. A malformed claim must
+  not be read as a bound of zero.
+
+`PassClaims.cutoff()` in the CLI is the reference implementation; keep the two in step.
 
 ## Authoring a plugin
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
              spice-plugin-api is a transitive dependency of the BOM, so the CLI
              inherits it. ancho is versioned here (NOT in the BOM): it is injected
              via -javaagent, never on the CLI's own classpath. -->
-        <spice-bom.version>1.0.8</spice-bom.version>
+        <spice-bom.version>1.0.10</spice-bom.version>
         <ancho.version>0.0.8</ancho.version>
         <!--        Use this version for local dev-->
         <!--        <ancho.version>0.0.1-SNAPSHOT</ancho.version> -->

--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,15 @@
     <dependencies>
         <!-- The spice runtime classpath, declared directly with versions from the
              imported BOM. The shade plugin bundles these compile deps into the fat jar. -->
+        <!-- Pinned ahead of the BOM, to the SNAPSHOT channel rather than the 1.0.2
+             release the imported BOM manages. The SPI's pom version does not track its
+             contract: SpiceContext.API_VERSION does, and `spice` mounts a plugin only
+             when that plugin's apiVersion() equals its own exactly. Drop these
+             <version>s once spice-bom catches up. -->
         <dependency>
             <groupId>io.spicelabs</groupId>
             <artifactId>spice-plugin-api</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,6 @@
         <dependency>
             <groupId>io.spicelabs</groupId>
             <artifactId>spice-plugin-api</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,9 @@
              specification; it is imported below and supplies the versions for the
              runtime classpath + coordinates. It lives in its own repo
              (spice-labs-inc/spice-bom) and is resolved from GitHub Packages.
-             spice-plugin-api is a transitive dependency of the BOM, so the CLI
-             inherits it. ancho is versioned here (NOT in the BOM): it is injected
+             spice-plugin-api's version comes from here too, so the SPI the CLI
+             compiles against and the one it ships cannot drift apart. ancho is
+             versioned here (NOT in the BOM): it is injected
              via -javaagent, never on the CLI's own classpath. -->
         <spice-bom.version>1.0.10</spice-bom.version>
         <ancho.version>0.0.8</ancho.version>
@@ -81,11 +82,12 @@
     <dependencies>
         <!-- The spice runtime classpath, declared directly with versions from the
              imported BOM. The shade plugin bundles these compile deps into the fat jar. -->
-        <!-- Pinned ahead of the BOM, to the SNAPSHOT channel rather than the 1.0.2
-             release the imported BOM manages. The SPI's pom version does not track its
-             contract: SpiceContext.API_VERSION does, and `spice` mounts a plugin only
-             when that plugin's apiVersion() equals its own exactly. Drop these
-             <version>s once spice-bom catches up. -->
+        <!-- Version from the BOM, like everything else here. Note that the SPI's pom
+             version is not what decides compatibility: SpiceContext.API_VERSION is, and
+             `spice` mounts a plugin only when that plugin's apiVersion() equals its own
+             exactly. A pom version can therefore move without the contract moving, or
+             the reverse, so a plugin built against a different API_VERSION fails to mount
+             at runtime rather than failing to compile. -->
         <dependency>
             <groupId>io.spicelabs</groupId>
             <artifactId>spice-plugin-api</artifactId>

--- a/src/main/java/io/spicelabs/cli/DefaultSpiceContext.java
+++ b/src/main/java/io/spicelabs/cli/DefaultSpiceContext.java
@@ -17,23 +17,50 @@ package io.spicelabs.cli;
 
 import java.util.Optional;
 
+import io.spicelabs.cli.spi.SpicePassClaims;
 import io.spicelabs.cli.spi.SpiceContext;
 
 /**
  * The CLI's implementation of {@link SpiceContext} handed to plugins. Keeps plugin
- * behaviour (version reporting, {@code SPICE_PASS} resolution, logging) consistent with
+ * behaviour (version reporting, {@code SPICE_PASS} resolution, configuration) consistent with
  * the built-in commands. This is the app's concrete impl, not part of the public SPI.
+ *
+ * <p>The pass is read from the environment and decoded <em>once</em>, at construction, and the
+ * resulting {@link SpicePassClaims} is shared by every plugin and by the built-in commands
+ * that consult {@link #current()}. Resolving it once is what makes "the cutoff in force" a
+ * single fact about the run rather than something each caller re-derives.
  */
 final class DefaultSpiceContext implements SpiceContext {
 
-  private final String version;
+  private static volatile DefaultSpiceContext current;
 
-  private DefaultSpiceContext(String version) {
+  private final String version;
+  private final String spicePass;
+  private final SpicePassClaims passClaims;
+
+  // Package-private rather than private so a test can build one with a chosen pass; the class
+  // itself is package-private, so this widens nothing beyond this package.
+  DefaultSpiceContext(String version, String spicePass) {
     this.version = version;
+    this.spicePass = spicePass;
+    this.passClaims = PassClaims.of(spicePass);
   }
 
   static DefaultSpiceContext create() {
-    return new DefaultSpiceContext(SpiceLabsCLI.VersionProvider.getVersionString());
+    DefaultSpiceContext context = new DefaultSpiceContext(
+        SpiceLabsCLI.VersionProvider.getVersionString(), System.getenv("SPICE_PASS"));
+    current = context;
+    return context;
+  }
+
+  /**
+   * The context for this run, creating it if the CLI has not built one yet (as happens when a
+   * command class is exercised directly by a test). Built-in commands use this so they see the
+   * same resolved values as plugins.
+   */
+  static DefaultSpiceContext current() {
+    DefaultSpiceContext context = current;
+    return context != null ? context : create();
   }
 
   @Override
@@ -43,7 +70,25 @@ final class DefaultSpiceContext implements SpiceContext {
 
   @Override
   public Optional<String> spicePass() {
-    String pass = System.getenv("SPICE_PASS");
-    return (pass == null || pass.isBlank()) ? Optional.empty() : Optional.of(pass);
+    return (spicePass == null || spicePass.isBlank()) ? Optional.empty() : Optional.of(spicePass);
   }
+
+  @Override
+  public SpicePassClaims passClaims() {
+    return passClaims;
+  }
+
+  /**
+   * Deliberately says nothing about the pass.
+   *
+   * <p>This holds a live bearer credential. The inherited {@code Object.toString} is already safe,
+   * but only by accident: turning this into a record, or reaching for Lombok, would generate one
+   * that prints every field and put the credential into any log line that formatted the context.
+   * Saying so here means such a change fails a test rather than a security review.
+   */
+  @Override
+  public String toString() {
+    return "DefaultSpiceContext[version=" + version + ", spicePass=<redacted>]";
+  }
+
 }

--- a/src/main/java/io/spicelabs/cli/PassClaims.java
+++ b/src/main/java/io/spicelabs/cli/PassClaims.java
@@ -48,10 +48,12 @@ import io.spicelabs.cli.spi.SpicePassClaims;
  * exception: the claims are a convenience here, and no command should fail to start because
  * of them. Commands that genuinely require the pass report that themselves.
  *
- * <p>These values were previously republished as system properties (notably
- * {@code -Dspice.cutoff}) so that in-process plugins could reach them. That channel is gone:
- * claims now travel through {@link io.spicelabs.cli.spi.SpiceContext#passClaims()}, which
- * makes them discoverable and impossible to forge from the command line.
+ * <p>Claims reach in-process plugins through
+ * {@link io.spicelabs.cli.spi.SpiceContext#passClaims()} and through nothing else. They are
+ * deliberately not republished as system properties, which is otherwise the obvious way to hand
+ * a value to code that {@code ServiceLoader} has loaded into this same JVM: a property can be
+ * set with {@code -D} on the command line, so a claim like {@code x-cutoff} would become
+ * something the caller can widen rather than something the pass fixes.
  */
 final class PassClaims implements SpicePassClaims {
 

--- a/src/main/java/io/spicelabs/cli/PassClaims.java
+++ b/src/main/java/io/spicelabs/cli/PassClaims.java
@@ -99,6 +99,28 @@ final class PassClaims implements SpicePassClaims {
   }
 
   /**
+   * The artifact cutoff these claims carry: artifacts published after this instant are out of
+   * scope for a survey. It travels as {@code x-cutoff} in epoch seconds, and its absence means
+   * "no cutoff" rather than "cutoff at the epoch".
+   *
+   * <p>This takes claims rather than a pass deliberately. A caller that already holds decoded
+   * claims — which, thanks to {@link DefaultSpiceContext}, every caller does — can ask for the
+   * cutoff without decoding the pass a second time to get it. It is also the one place the
+   * {@code x-cutoff} claim is interpreted.
+   */
+  static Optional<Instant> cutoff(SpicePassClaims claims) {
+    Object value = claims.additionalClaims().get("x-cutoff");
+    if (value == null) {
+      return Optional.empty();
+    }
+    if (value instanceof Long seconds) {
+      return Optional.of(Instant.ofEpochSecond(seconds));
+    }
+    log.warn("Ignoring x-cutoff claim: expected epoch seconds, got {}", value);
+    return Optional.empty();
+  }
+
+  /**
    * Normalise a Jackson-decoded JSON value to the SPI's promised types: integral numbers are
    * always {@link Long} (Jackson hands back {@link Integer} for small ones), fractional ones
    * {@link Double}, and lists and maps are converted recursively.

--- a/src/main/java/io/spicelabs/cli/PassClaims.java
+++ b/src/main/java/io/spicelabs/cli/PassClaims.java
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.cli;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+import io.spicelabs.cli.spi.SpicePassClaims;
+
+/**
+ * The claims of a decoded Spice Pass.
+ *
+ * <p>This is the CLI's implementation of {@link SpicePassClaims} and the <em>only</em> place a
+ * pass is decoded for the SPI. Built-in commands and plugins both read from a value of this
+ * type, so they cannot disagree about what the pass says.
+ *
+ * <p>The registered JWT claims (RFC 7519) come out through typed accessors; everything else —
+ * the Spice-specific {@code x-*} claims and anything the platform mints later — lands in
+ * {@link #additionalClaims()} verbatim, as JSON-typed {@code java.*} values with integral
+ * numbers normalised to {@link Long}.
+ *
+ * <p>A missing, blank or undecodable pass yields {@link SpicePassClaims#EMPTY} rather than an
+ * exception: the claims are a convenience here, and no command should fail to start because
+ * of them. Commands that genuinely require the pass report that themselves.
+ *
+ * <p>These values were previously republished as system properties (notably
+ * {@code -Dspice.cutoff}) so that in-process plugins could reach them. That channel is gone:
+ * claims now travel through {@link io.spicelabs.cli.spi.SpiceContext#passClaims()}, which
+ * makes them discoverable and impossible to forge from the command line.
+ */
+final class PassClaims implements SpicePassClaims {
+
+  private static final Logger log = LoggerFactory.getLogger(PassClaims.class);
+
+  /** The claims RFC 7519 registers, exposed through the typed accessors and therefore
+    * excluded from {@link #additionalClaims()}. */
+  private static final Set<String> REGISTERED =
+      Set.of("iss", "sub", "aud", "exp", "nbf", "iat", "jti");
+
+  private final DecodedJWT jwt;
+  private final Map<String, Object> additional;
+
+  private PassClaims(DecodedJWT jwt) {
+    this.jwt = jwt;
+    Map<String, Object> extras = new LinkedHashMap<>();
+    for (Map.Entry<String, Claim> entry : jwt.getClaims().entrySet()) {
+      if (REGISTERED.contains(entry.getKey()) || entry.getValue().isNull()) {
+        continue;
+      }
+      extras.put(entry.getKey(), plain(entry.getValue().as(Object.class)));
+    }
+    this.additional = Map.copyOf(extras);
+  }
+
+  /**
+   * The claims carried by the given pass, or {@link SpicePassClaims#EMPTY} if it is absent
+   * or undecodable.
+   *
+   * <p>Commands that accept a {@code --spice-pass} override must call this with the pass they
+   * actually resolved, so the claims match the credential in use.
+   */
+  static SpicePassClaims of(String spicePass) {
+    if (spicePass == null || spicePass.isBlank()) {
+      return SpicePassClaims.EMPTY;
+    }
+    try {
+      return new PassClaims(JWT.decode(spicePass));
+    } catch (RuntimeException e) {
+      log.debug("Could not read claims from the Spice Pass: {}", e.getMessage());
+      return SpicePassClaims.EMPTY;
+    }
+  }
+
+  /**
+   * Normalise a Jackson-decoded JSON value to the SPI's promised types: integral numbers are
+   * always {@link Long} (Jackson hands back {@link Integer} for small ones), fractional ones
+   * {@link Double}, and lists and maps are converted recursively.
+   */
+  private static Object plain(Object value) {
+    if (value instanceof Integer || value instanceof Short || value instanceof Byte) {
+      return ((Number) value).longValue();
+    }
+    if (value instanceof Float) {
+      return ((Number) value).doubleValue();
+    }
+    if (value instanceof List<?> list) {
+      List<Object> converted = new ArrayList<>(list.size());
+      for (Object element : list) {
+        converted.add(plain(element));
+      }
+      return List.copyOf(converted);
+    }
+    if (value instanceof Map<?, ?> map) {
+      Map<String, Object> converted = new LinkedHashMap<>();
+      for (Map.Entry<?, ?> entry : map.entrySet()) {
+        converted.put(String.valueOf(entry.getKey()), plain(entry.getValue()));
+      }
+      return Map.copyOf(converted);
+    }
+    return value;
+  }
+
+  @Override
+  public Optional<String> issuer() {
+    return Optional.ofNullable(jwt.getIssuer());
+  }
+
+  @Override
+  public Optional<String> subject() {
+    return Optional.ofNullable(jwt.getSubject());
+  }
+
+  @Override
+  public List<String> audience() {
+    List<String> audience = jwt.getAudience();
+    return audience == null ? List.of() : List.copyOf(audience);
+  }
+
+  @Override
+  public Optional<Instant> expiresAt() {
+    return Optional.ofNullable(jwt.getExpiresAtAsInstant());
+  }
+
+  @Override
+  public Optional<Instant> notBefore() {
+    return Optional.ofNullable(jwt.getNotBeforeAsInstant());
+  }
+
+  @Override
+  public Optional<Instant> issuedAt() {
+    return Optional.ofNullable(jwt.getIssuedAtAsInstant());
+  }
+
+  @Override
+  public Optional<String> jwtId() {
+    return Optional.ofNullable(jwt.getId());
+  }
+
+  @Override
+  public Map<String, Object> additionalClaims() {
+    return additional;
+  }
+
+  /**
+   * Deliberately says nothing about the claims.
+   *
+   * <p>The decoded claims are not themselves the credential, but they name the project and
+   * organisation a run belongs to and the endpoint it uploads to. A caller that wants one of those
+   * can ask for it; none of them needs to arrive by way of a log line about something else.
+   */
+  @Override
+  public String toString() {
+    return "PassClaims[" + additional.size() + " claims, <redacted>]";
+  }
+
+}

--- a/src/main/java/io/spicelabs/cli/PassClaims.java
+++ b/src/main/java/io/spicelabs/cli/PassClaims.java
@@ -112,13 +112,29 @@ final class PassClaims implements SpicePassClaims {
 
   /**
    * The artifact cutoff these claims carry: artifacts published after this instant are out of
-   * scope for a survey. It travels as {@code x-cutoff} in epoch seconds, and its absence means
-   * "no cutoff" rather than "cutoff at the epoch".
+   * scope for a survey.
    *
    * <p>This takes claims rather than a pass deliberately. A caller that already holds decoded
    * claims — which, thanks to {@link DefaultSpiceContext}, every caller does — can ask for the
-   * cutoff without decoding the pass a second time to get it. It is also the one place the
-   * {@code x-cutoff} claim is interpreted.
+   * cutoff without decoding the pass a second time to get it.
+   *
+   * <p><strong>This is the reference reading of {@code x-cutoff}, and it is deliberately not
+   * the only one.</strong> Plugins reach claims through the SPI, which hands over
+   * {@code additionalClaims()} and no interpretation, so a plugin that wants the cutoff — the
+   * Allspice registry is the first — reads the claim itself. Promoting this to a default method
+   * on {@code SpicePassClaims} would make it shared, but costs a release across plugin-api,
+   * spice-bom and every plugin; two small implementations are the cheaper trade for now. Any
+   * other implementation must agree on all three of these, because each way of getting them
+   * wrong yields a survey that silently covers almost nothing while exiting successfully:
+   *
+   * <ul>
+   *   <li><strong>Epoch seconds, not milliseconds.</strong> Read as millis, a 2026 cutoff lands
+   *       in January 1970 and drops the entire estate.
+   *   <li><strong>Absent means no cutoff</strong>, never {@link Instant#EPOCH}. Defaulting to
+   *       the epoch turns "this pass does not narrow scope" into "exclude everything".
+   *   <li><strong>A non-numeric value is ignored</strong>, with a warning, and again means no
+   *       cutoff. A malformed claim must not be read as a bound of zero.
+   * </ul>
    */
   static Optional<Instant> cutoff(SpicePassClaims claims) {
     Object value = claims.additionalClaims().get("x-cutoff");

--- a/src/main/java/io/spicelabs/cli/PassClaims.java
+++ b/src/main/java/io/spicelabs/cli/PassClaims.java
@@ -118,10 +118,16 @@ final class PassClaims implements SpicePassClaims {
    * claims — which, thanks to {@link DefaultSpiceContext}, every caller does — can ask for the
    * cutoff without decoding the pass a second time to get it.
    *
+   * <p>The cutoff constrains two analyses, not one: the built-in inventory survey here, and
+   * discovery in the Allspice registry plugin, which is what it was minted for. A run whose
+   * two halves disagreed about which artifacts exist would be worse than either bound alone,
+   * so both honour it. The contract is written down for plugin authors in
+   * {@code docs/PLUGINS.md} and for users in {@code README.md}.
+   *
    * <p><strong>This is the reference reading of {@code x-cutoff}, and it is deliberately not
    * the only one.</strong> Plugins reach claims through the SPI, which hands over
-   * {@code additionalClaims()} and no interpretation, so a plugin that wants the cutoff — the
-   * Allspice registry is the first — reads the claim itself. Promoting this to a default method
+   * {@code additionalClaims()} and no interpretation, so the Allspice plugin reads the claim
+   * itself. Promoting this to a default method
    * on {@code SpicePassClaims} would make it shared, but costs a release across plugin-api,
    * spice-bom and every plugin; two small implementations are the cheaper trade for now. Any
    * other implementation must agree on all three of these, because each way of getting them

--- a/src/main/java/io/spicelabs/cli/PassClaims.java
+++ b/src/main/java/io/spicelabs/cli/PassClaims.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/io/spicelabs/cli/PassClaims.java
+++ b/src/main/java/io/spicelabs/cli/PassClaims.java
@@ -48,6 +48,18 @@ import io.spicelabs.cli.spi.SpicePassClaims;
  * exception: the claims are a convenience here, and no command should fail to start because
  * of them. Commands that genuinely require the pass report that themselves.
  *
+ * <p>The pass is parsed here, in the CLI, rather than in ginger-j, which parsed it first and
+ * still parses the claims it needs to upload ({@code x-public-key}, {@code x-upload-server},
+ * {@code x-uuid-project}, {@code x-challenge}, {@code exp}). Those it reads to do its own job.
+ * Claim semantics for everyone else belong here: the SPI is a CLI contract that ginger-j knows
+ * nothing about, plugins mount into {@code spice} rather than into the uploader, and the other
+ * consumers — GoatRodeo's cutoff, {@code pass decode}, the Allspice plugin — do not go through
+ * ginger-j at all. Owning it in the uploader would point the dependency the wrong way.
+ *
+ * <p>The two overlap today on the claims both happen to read, which is worth converging, but
+ * they cannot contradict each other about scope: nothing outside ginger-j consults ginger-j's
+ * copy.
+ *
  * <p>Claims reach in-process plugins through
  * {@link io.spicelabs.cli.spi.SpiceContext#passClaims()} and through nothing else. They are
  * deliberately not republished as system properties, which is otherwise the obvious way to hand

--- a/src/main/java/io/spicelabs/cli/PassDecodeCommand.java
+++ b/src/main/java/io/spicelabs/cli/PassDecodeCommand.java
@@ -65,6 +65,6 @@ public class PassDecodeCommand implements java.util.concurrent.Callable<Integer>
     if (spicePassOverride != null && !spicePassOverride.isBlank()) {
       return spicePassOverride;
     }
-    return System.getenv("SPICE_PASS");
+    return DefaultSpiceContext.current().spicePass().orElse(null);
   }
 }

--- a/src/main/java/io/spicelabs/cli/RuntimeCollect.java
+++ b/src/main/java/io/spicelabs/cli/RuntimeCollect.java
@@ -33,7 +33,7 @@ public class RuntimeCollect {
     public static void main(String[] args) throws Exception {
         // Probe config download mode: streams JSON to stdout, no file written
         if (args.length >= 1 && "--download-probes".equals(args[0])) {
-            String spicePass = System.getenv("SPICE_PASS");
+            String spicePass = DefaultSpiceContext.current().spicePass().orElse(null);
             if (spicePass == null || spicePass.isBlank()) {
                 System.exit(1);
             }
@@ -130,7 +130,7 @@ public class RuntimeCollect {
         AnalyzeProgressPublisher analyzeProgress = null;
         String spicePass = null;
         if (!noUpload) {
-            spicePass = System.getenv("SPICE_PASS");
+            spicePass = DefaultSpiceContext.current().spicePass().orElse(null);
             if (spicePass == null || spicePass.isBlank()) {
                 log.error("SPICE_PASS not set");
                 System.exit(1);

--- a/src/main/java/io/spicelabs/cli/RuntimeCollect.java
+++ b/src/main/java/io/spicelabs/cli/RuntimeCollect.java
@@ -31,9 +31,15 @@ public class RuntimeCollect {
     private static final Logger log = LoggerFactory.getLogger(RuntimeCollect.class);
 
     public static void main(String[] args) throws Exception {
+        // This is an entry point in its own right, so it builds the run's context rather than
+        // letting the first `current()` call create one as a side effect. Same result either
+        // way; doing it here means "one context, built at startup" holds for every way into
+        // the CLI, instead of holding for `SpiceLabsCLI` and happening to work here.
+        DefaultSpiceContext context = DefaultSpiceContext.create();
+
         // Probe config download mode: streams JSON to stdout, no file written
         if (args.length >= 1 && "--download-probes".equals(args[0])) {
-            String spicePass = DefaultSpiceContext.current().spicePass().orElse(null);
+            String spicePass = context.spicePass().orElse(null);
             if (spicePass == null || spicePass.isBlank()) {
                 System.exit(1);
             }
@@ -130,7 +136,7 @@ public class RuntimeCollect {
         AnalyzeProgressPublisher analyzeProgress = null;
         String spicePass = null;
         if (!noUpload) {
-            spicePass = DefaultSpiceContext.current().spicePass().orElse(null);
+            spicePass = context.spicePass().orElse(null);
             if (spicePass == null || spicePass.isBlank()) {
                 log.error("SPICE_PASS not set");
                 System.exit(1);

--- a/src/main/java/io/spicelabs/cli/SpicePassDecoder.java
+++ b/src/main/java/io/spicelabs/cli/SpicePassDecoder.java
@@ -56,6 +56,7 @@ public class SpicePassDecoder {
     CLAIM_NAMES.put("x-upload-server", "Upload Server");
     CLAIM_NAMES.put("x-public-key", "Public Key");
     CLAIM_NAMES.put("x-challenge", "Challenge");
+    CLAIM_NAMES.put("x-cutoff", "Artifact Cutoff");
   }
 
   public SpicePassDecoder(String spicePass) {
@@ -83,6 +84,24 @@ public class SpicePassDecoder {
 
   public Instant getExpiresAt() {
     return jwt.getExpiresAt() != null ? jwt.getExpiresAt().toInstant() : null;
+  }
+
+  /**
+   * The artifact cutoff carried by the pass: artifacts published after this instant are out of
+   * scope for the survey. Encoded as the {@code x-cutoff} claim in epoch seconds. Null when the
+   * pass carries no cutoff, which means "no cutoff" rather than "cutoff at the epoch".
+   */
+  public Instant getCutoff() {
+    Claim claim = jwt.getClaim("x-cutoff");
+    if (claim.isNull() || claim.isMissing()) {
+      return null;
+    }
+    Long epochSeconds = claim.asLong();
+    if (epochSeconds == null) {
+      log.warn("Ignoring x-cutoff claim: expected epoch seconds, got {}", claim);
+      return null;
+    }
+    return Instant.ofEpochSecond(epochSeconds);
   }
 
   public String getStatus() {
@@ -152,7 +171,7 @@ public class SpicePassDecoder {
   }
 
   private String formatClaimValue(String key, Claim claim) {
-    if (key.equals("iat") || key.equals("exp") || key.equals("nbf")) {
+    if (key.equals("iat") || key.equals("exp") || key.equals("nbf") || key.equals("x-cutoff")) {
       try {
         long epoch = claim.asLong();
         Instant instant = Instant.ofEpochSecond(epoch);

--- a/src/main/java/io/spicelabs/cli/SpicePassDecoder.java
+++ b/src/main/java/io/spicelabs/cli/SpicePassDecoder.java
@@ -86,24 +86,6 @@ public class SpicePassDecoder {
     return jwt.getExpiresAt() != null ? jwt.getExpiresAt().toInstant() : null;
   }
 
-  /**
-   * The artifact cutoff carried by the pass: artifacts published after this instant are out of
-   * scope for the survey. Encoded as the {@code x-cutoff} claim in epoch seconds. Null when the
-   * pass carries no cutoff, which means "no cutoff" rather than "cutoff at the epoch".
-   */
-  public Instant getCutoff() {
-    Claim claim = jwt.getClaim("x-cutoff");
-    if (claim.isNull() || claim.isMissing()) {
-      return null;
-    }
-    Long epochSeconds = claim.asLong();
-    if (epochSeconds == null) {
-      log.warn("Ignoring x-cutoff claim: expected epoch seconds, got {}", claim);
-      return null;
-    }
-    return Instant.ofEpochSecond(epochSeconds);
-  }
-
   public String getStatus() {
     if (jwt.getExpiresAt() == null) {
       return "No expiration";

--- a/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
@@ -328,11 +328,17 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
       // Artifacts published after the pass's cutoff are out of scope: GoatRodeo drops any entry
       // modified after this instant, along with everything that transitively contains it.
       //
+      // This is one of the two analyses the cutoff constrains. Discovery -- the Allspice
+      // registry plugin -- is the other, and was the use case the cutoff was minted for; it
+      // reads the same claim through SpiceContext.passClaims(). Scoping only one of them would
+      // leave a run whose halves disagreed about which artifacts exist, so they land together.
+      //
       // This is new behaviour, and it is visible to whoever reads the inventory. The CLI has
       // never honoured `x-cutoff` before, so a pass that carries one now yields a smaller
       // inventory than the same pass did yesterday, with no flag involved. Hence the INFO line:
       // a survey that silently covered less than the caller expected would be very hard to
-      // account for after the fact.
+      // account for after the fact. It is documented for users in README.md and FAQ.md, and for
+      // plugin authors in docs/PLUGINS.md.
       passCutoff().ifPresent(cutoff -> {
         log.info("Ignoring artifacts published after {}", cutoff);
         builder.withCutoff(cutoff);

--- a/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import ch.qos.logback.classic.Level;
+import io.spicelabs.cli.spi.SpicePassClaims;
 import io.spicelabs.ginger.Ginger;
 import io.spicelabs.goatrodeo.GoatRodeo;
 import io.spicelabs.goatrodeo.GoatRodeoBuilder;
@@ -415,22 +416,36 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
   }
 
   /**
-   * The artifact cutoff in force for this survey, derived from the pass actually in use.
-   * Deriving it from {@link #resolveSpicePass()} rather than from the environment means a
-   * {@code --spice-pass} override carries its own cutoff, instead of silently inheriting the
-   * ambient pass's. {@link SpicePassDecoder#getCutoff()} owns the interpretation of the
-   * {@code x-cutoff} claim, so it is written down exactly once.
+   * The artifact cutoff in force for this survey, read from the claims of the pass actually in
+   * use. Taking it from {@link #resolveSpicePass()} rather than from the environment means a
+   * {@code --spice-pass} override carries its own cutoff instead of silently inheriting the
+   * ambient pass's.
+   *
+   * <p>Package-private so a test can exercise the path that consumes the cutoff, rather than
+   * only the claims it is consumed from.
    */
-  private Optional<Instant> passCutoff() {
+  Optional<Instant> passCutoff() {
+    return PassClaims.cutoff(passClaims());
+  }
+
+  /**
+   * The claims of the pass this survey will actually use.
+   *
+   * <p>In the usual case that is the ambient pass, and these are the claims
+   * {@link DefaultSpiceContext} decoded once at startup — nothing decodes it again here. A
+   * {@code --spice-pass} override is decoded, because by definition the context holds the
+   * claims of a different credential; that is one decode of a pass the context never saw, not
+   * a second decode of the same one.
+   */
+  private SpicePassClaims passClaims() {
     String pass = resolveSpicePass();
     if (pass == null || pass.isBlank()) {
-      return Optional.empty();
+      return SpicePassClaims.EMPTY;
     }
-    try {
-      return Optional.ofNullable(new SpicePassDecoder(pass).getCutoff());
-    } catch (RuntimeException e) {
-      return Optional.empty();
-    }
+    DefaultSpiceContext context = DefaultSpiceContext.current();
+    return pass.equals(context.spicePass().orElse(null))
+        ? context.passClaims()
+        : PassClaims.of(pass);
   }
 
   private void logProjectInfo(String spicePass) {

--- a/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -323,6 +324,13 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
         builder.withTagJson(tagJson);
       }
 
+      // Artifacts published after the pass's cutoff are out of scope: GoatRodeo drops any entry
+      // modified after this instant, along with everything that transitively contains it.
+      passCutoff().ifPresent(cutoff -> {
+        log.info("Ignoring artifacts published after {}", cutoff);
+        builder.withCutoff(cutoff);
+      });
+
       if (survey != null) {
         builder.withTagDate(survey.submissionTimestamp().toString());
       }
@@ -397,7 +405,26 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
     if (spicePassOverride != null && !spicePassOverride.isBlank()) {
       return spicePassOverride;
     }
-    return System.getenv("SPICE_PASS");
+    return DefaultSpiceContext.current().spicePass().orElse(null);
+  }
+
+  /**
+   * The artifact cutoff in force for this survey, derived from the pass actually in use.
+   * Deriving it from {@link #resolveSpicePass()} rather than from the environment means a
+   * {@code --spice-pass} override carries its own cutoff, instead of silently inheriting the
+   * ambient pass's. {@link SpicePassDecoder#getCutoff()} owns the interpretation of the
+   * {@code x-cutoff} claim, so it is written down exactly once.
+   */
+  private Optional<Instant> passCutoff() {
+    String pass = resolveSpicePass();
+    if (pass == null || pass.isBlank()) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.ofNullable(new SpicePassDecoder(pass).getCutoff());
+    } catch (RuntimeException e) {
+      return Optional.empty();
+    }
   }
 
   private void logProjectInfo(String spicePass) {

--- a/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
@@ -326,6 +326,12 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
 
       // Artifacts published after the pass's cutoff are out of scope: GoatRodeo drops any entry
       // modified after this instant, along with everything that transitively contains it.
+      //
+      // This is new behaviour, and it is visible to whoever reads the inventory. The CLI has
+      // never honoured `x-cutoff` before, so a pass that carries one now yields a smaller
+      // inventory than the same pass did yesterday, with no flag involved. Hence the INFO line:
+      // a survey that silently covered less than the caller expected would be very hard to
+      // account for after the fact.
       passCutoff().ifPresent(cutoff -> {
         log.info("Ignoring artifacts published after {}", cutoff);
         builder.withCutoff(cutoff);

--- a/src/main/java/io/spicelabs/cli/SurveyRuntimeCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyRuntimeCommand.java
@@ -596,7 +596,7 @@ public class SurveyRuntimeCommand implements Callable<Integer> {
         if (spicePassOverride != null && !spicePassOverride.isBlank()) {
             return spicePassOverride;
         }
-        return System.getenv("SPICE_PASS");
+        return DefaultSpiceContext.current().spicePass().orElse(null);
     }
 
     private static boolean hasSpicePass(String spicePass) {

--- a/src/test/java/io/spicelabs/cli/CredentialRedactionTest.java
+++ b/src/test/java/io/spicelabs/cli/CredentialRedactionTest.java
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.cli;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Base64;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Nothing carrying the Spice Pass may print it.
+ *
+ * <p>These types are safe today because none of them declares a {@code toString} — they inherit
+ * {@code Object}'s, which prints only a class name and a hash. That safety is accidental, and one
+ * {@code record} or {@code @Data} away from ending. These assertions make the redaction a stated
+ * property, so removing it fails here rather than in somebody's log.
+ */
+class CredentialRedactionTest {
+
+  /** Shaped like a real pass, so a substring match means something. */
+  private static final String PASS = "eyJhbGciOiJSUzI1NiJ9."
+      + Base64.getUrlEncoder().withoutPadding().encodeToString(
+          "{\"x-uuid-project\":\"p\",\"x-upload-server\":\"https://upload.example\"}".getBytes())
+      + ".c2lnbmF0dXJl";
+
+  @Test
+  @DisplayName("the context does not print the pass it holds")
+  void contextRedactsPass() {
+    DefaultSpiceContext context = new DefaultSpiceContext("1.2.3", PASS);
+
+    String printed = context.toString();
+    assertFalse(printed.contains(PASS), "context toString leaked the pass: " + printed);
+    assertTrue(printed.contains("redacted"), printed);
+    // Still reachable by name: this is about what gets printed, not what gets used.
+    assertTrue(context.spicePass().isPresent());
+  }
+
+  @Test
+  @DisplayName("claims do not print the project and endpoint they carry")
+  void claimsRedactContents() {
+    String printed = PassClaims.of(PASS).toString();
+
+    assertFalse(printed.contains("upload.example"), "claims toString leaked a claim: " + printed);
+    assertFalse(printed.contains(PASS), printed);
+    assertTrue(printed.contains("redacted"), printed);
+  }
+}

--- a/src/test/java/io/spicelabs/cli/CredentialRedactionTest.java
+++ b/src/test/java/io/spicelabs/cli/CredentialRedactionTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/test/java/io/spicelabs/cli/PassClaimsTest.java
+++ b/src/test/java/io/spicelabs/cli/PassClaimsTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 

--- a/src/test/java/io/spicelabs/cli/PassClaimsTest.java
+++ b/src/test/java/io/spicelabs/cli/PassClaimsTest.java
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors */
+
+package io.spicelabs.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.spicelabs.cli.spi.SpicePassClaims;
+
+class PassClaimsTest {
+
+  @Test
+  void registeredClaimsComeOutTyped() {
+    SpicePassClaims claims = PassClaims.of(pass(
+        "{\"iss\":\"spice-labs\","
+            + "\"sub\":\"user@example.com\","
+            + "\"aud\":\"platform\","
+            + "\"exp\":1767225600,"
+            + "\"nbf\":1704067200,"
+            + "\"iat\":1704067200,"
+            + "\"jti\":\"pass-123\"}"));
+
+    assertEquals(Optional.of("spice-labs"), claims.issuer());
+    assertEquals(Optional.of("user@example.com"), claims.subject());
+    assertEquals(List.of("platform"), claims.audience());
+    assertEquals(Optional.of(Instant.ofEpochSecond(1767225600L)), claims.expiresAt());
+    assertEquals(Optional.of(Instant.ofEpochSecond(1704067200L)), claims.notBefore());
+    assertEquals(Optional.of(Instant.ofEpochSecond(1704067200L)), claims.issuedAt());
+    assertEquals(Optional.of("pass-123"), claims.jwtId());
+  }
+
+  @Test
+  void additionalClaimsArriveVerbatimWithRegisteredOnesExcluded() {
+    SpicePassClaims claims = PassClaims.of(pass(
+        "{\"iss\":\"spice-labs\","
+            + "\"exp\":1767225600,"
+            + "\"x-cutoff\":1767225600,"
+            + "\"x-upload-server\":\"https://host/upload\","
+            + "\"x-uuid-project\":\"proj\"}"));
+
+    Map<String, Object> additional = claims.additionalClaims();
+    // The registered claims are reachable typed; repeating them in the map would give
+    // every value two spellings.
+    assertFalse(additional.containsKey("iss"));
+    assertFalse(additional.containsKey("exp"));
+    // The map is a faithful transcript: x-cutoff stays what the pass encodes, an
+    // epoch-seconds Long — interpretation belongs to the consumer.
+    assertEquals(1767225600L, additional.get("x-cutoff"));
+    assertEquals("https://host/upload", additional.get("x-upload-server"));
+    assertEquals("proj", additional.get("x-uuid-project"));
+  }
+
+  @Test
+  void structuredClaimValuesArePlainJavaTypes() {
+    // The SPI promises java.* values only, with integral numbers always Long — Jackson
+    // hands back Integer for small ones, so normalisation must be recursive.
+    SpicePassClaims claims = PassClaims.of(pass(
+        "{\"x-scopes\":[\"read\",\"write\"],"
+            + "\"x-limits\":{\"max_uploads\":5,\"nested\":{\"depth\":2}}}"));
+
+    assertEquals(List.of("read", "write"), claims.additionalClaims().get("x-scopes"));
+    Object limits = claims.additionalClaims().get("x-limits");
+    assertTrue(limits instanceof Map, "expected a plain Map, got: " + limits.getClass());
+    Map<?, ?> limitsMap = (Map<?, ?>) limits;
+    assertEquals(5L, limitsMap.get("max_uploads"));
+    assertEquals(2L, ((Map<?, ?>) limitsMap.get("nested")).get("depth"));
+  }
+
+  @Test
+  void absentClaimsAreEmptyRatherThanDefaulted() {
+    SpicePassClaims claims = PassClaims.of(pass("{\"x-uuid-project\":\"proj\"}"));
+    assertTrue(claims.expiresAt().isEmpty());
+    assertTrue(claims.issuer().isEmpty());
+    assertEquals(List.of(), claims.audience());
+    assertFalse(
+        claims.additionalClaims().containsKey("x-cutoff"),
+        "no x-cutoff claim means no cutoff, not a default");
+  }
+
+  @Test
+  void noPassYieldsTheEmptyClaims() {
+    assertSame(SpicePassClaims.EMPTY, PassClaims.of(null));
+    assertSame(SpicePassClaims.EMPTY, PassClaims.of("  "));
+  }
+
+  @Test
+  void anUndecodablePassIsEmptyRatherThanFatal() {
+    // Claims are a convenience: a broken pass must not stop a command from starting.
+    // Commands that genuinely need the pass report that themselves.
+    assertSame(SpicePassClaims.EMPTY, PassClaims.of("not-a-jwt"));
+  }
+
+  /**
+   * The cutoff constrains what the platform will accept, so it must come from the pass and
+   * nowhere else. It used to be republished as {@code -Dspice.cutoff} for in-process
+   * plugins, which meant anyone could set it on the command line. This guards against that
+   * returning.
+   */
+  @Test
+  void noSystemPropertyCanSupplyACutoff() {
+    String saved = System.getProperty("spice.cutoff");
+    try {
+      System.setProperty("spice.cutoff", "2026-01-01T00:00:00Z");
+      assertFalse(PassClaims.of(null).additionalClaims().containsKey("x-cutoff"));
+      assertFalse(
+          PassClaims.of(pass("{\"x-uuid-project\":\"p\"}"))
+              .additionalClaims()
+              .containsKey("x-cutoff"));
+    } finally {
+      if (saved == null) {
+        System.clearProperty("spice.cutoff");
+      } else {
+        System.setProperty("spice.cutoff", saved);
+      }
+    }
+  }
+
+  private static String pass(String claimsJson) {
+    return b64("{\"alg\":\"none\"}") + "." + b64(claimsJson) + ".sig";
+  }
+
+  private static String b64(String json) {
+    return Base64.getUrlEncoder().withoutPadding()
+        .encodeToString(json.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/src/test/java/io/spicelabs/cli/PassClaimsTest.java
+++ b/src/test/java/io/spicelabs/cli/PassClaimsTest.java
@@ -102,35 +102,29 @@ class PassClaimsTest {
     assertSame(SpicePassClaims.EMPTY, PassClaims.of("not-a-jwt"));
   }
 
-  /**
-   * The cutoff constrains what the platform will accept, so it must come from the pass and
-   * nowhere else — never from a system property, which {@code -D} would let any caller set,
-   * turning a bound the platform imposed into one the caller chooses.
-   *
-   * <p>Nothing has ever read such a property here. This pins that, so the tempting fix for
-   * "the in-process plugin cannot see the cutoff" — publish it as a property before dispatch —
-   * fails a test rather than passing review.
-   *
-   * <p>Scope: this covers {@link PassClaims} only, which reads the JWT and nothing else. It
-   * does not exercise the path that consumes the cutoff.
-   */
   @Test
-  void noSystemPropertyCanSupplyACutoff() {
-    String saved = System.getProperty("spice.cutoff");
-    try {
-      System.setProperty("spice.cutoff", "2026-01-01T00:00:00Z");
-      assertFalse(PassClaims.of(null).additionalClaims().containsKey("x-cutoff"));
-      assertFalse(
-          PassClaims.of(pass("{\"x-uuid-project\":\"p\"}"))
-              .additionalClaims()
-              .containsKey("x-cutoff"));
-    } finally {
-      if (saved == null) {
-        System.clearProperty("spice.cutoff");
-      } else {
-        System.setProperty("spice.cutoff", saved);
-      }
-    }
+  void cutoffReadsEpochSecondsFromTheClaim() {
+    assertEquals(
+        Optional.of(Instant.ofEpochSecond(1767225600L)),
+        PassClaims.cutoff(PassClaims.of(pass("{\"x-cutoff\":1767225600}"))));
+  }
+
+  @Test
+  void noCutoffClaimMeansNoCutoff() {
+    // Absent means "no cutoff", not "cutoff at the epoch".
+    assertEquals(
+        Optional.empty(), PassClaims.cutoff(PassClaims.of(pass("{\"x-uuid-project\":\"p\"}"))));
+  }
+
+  @Test
+  void aNonNumericCutoffIsIgnoredRatherThanGuessedAt() {
+    assertEquals(
+        Optional.empty(), PassClaims.cutoff(PassClaims.of(pass("{\"x-cutoff\":\"yesterday\"}"))));
+  }
+
+  @Test
+  void emptyClaimsCarryNoCutoff() {
+    assertEquals(Optional.empty(), PassClaims.cutoff(SpicePassClaims.EMPTY));
   }
 
   private static String pass(String claimsJson) {

--- a/src/test/java/io/spicelabs/cli/PassClaimsTest.java
+++ b/src/test/java/io/spicelabs/cli/PassClaimsTest.java
@@ -104,9 +104,15 @@ class PassClaimsTest {
 
   /**
    * The cutoff constrains what the platform will accept, so it must come from the pass and
-   * nowhere else. It used to be republished as {@code -Dspice.cutoff} for in-process
-   * plugins, which meant anyone could set it on the command line. This guards against that
-   * returning.
+   * nowhere else — never from a system property, which {@code -D} would let any caller set,
+   * turning a bound the platform imposed into one the caller chooses.
+   *
+   * <p>Nothing has ever read such a property here. This pins that, so the tempting fix for
+   * "the in-process plugin cannot see the cutoff" — publish it as a property before dispatch —
+   * fails a test rather than passing review.
+   *
+   * <p>Scope: this covers {@link PassClaims} only, which reads the JWT and nothing else. It
+   * does not exercise the path that consumes the cutoff.
    */
   @Test
   void noSystemPropertyCanSupplyACutoff() {

--- a/src/test/java/io/spicelabs/cli/SpicePassDecoderTest.java
+++ b/src/test/java/io/spicelabs/cli/SpicePassDecoderTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Base64;
 
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,25 @@ class SpicePassDecoderTest {
   void getUploadServer_nullWhenClaimAbsent() {
     String pass = b64("{\"alg\":\"none\"}") + "." + b64("{\"x-uuid-project\":\"p\"}") + ".sig";
     assertNull(new SpicePassDecoder(pass).getUploadServer());
+  }
+
+  @Test
+  void getCutoff_decodesEpochSeconds() {
+    String pass = b64("{\"alg\":\"none\"}") + "." + b64("{\"x-cutoff\":1767225600}") + ".sig";
+    assertEquals(Instant.ofEpochSecond(1767225600L), new SpicePassDecoder(pass).getCutoff());
+  }
+
+  @Test
+  void getCutoff_nullWhenClaimAbsent() {
+    // Absent means "no cutoff", not "cutoff at the epoch".
+    String pass = b64("{\"alg\":\"none\"}") + "." + b64("{\"x-uuid-project\":\"p\"}") + ".sig";
+    assertNull(new SpicePassDecoder(pass).getCutoff());
+  }
+
+  @Test
+  void getCutoff_nullWhenClaimIsNotNumeric() {
+    String pass = b64("{\"alg\":\"none\"}") + "." + b64("{\"x-cutoff\":\"yesterday\"}") + ".sig";
+    assertNull(new SpicePassDecoder(pass).getCutoff());
   }
 
   private static String b64(String json) {

--- a/src/test/java/io/spicelabs/cli/SpicePassDecoderTest.java
+++ b/src/test/java/io/spicelabs/cli/SpicePassDecoderTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
 import java.util.Base64;
 
 import org.junit.jupiter.api.Test;
@@ -27,25 +26,6 @@ class SpicePassDecoderTest {
   void getUploadServer_nullWhenClaimAbsent() {
     String pass = b64("{\"alg\":\"none\"}") + "." + b64("{\"x-uuid-project\":\"p\"}") + ".sig";
     assertNull(new SpicePassDecoder(pass).getUploadServer());
-  }
-
-  @Test
-  void getCutoff_decodesEpochSeconds() {
-    String pass = b64("{\"alg\":\"none\"}") + "." + b64("{\"x-cutoff\":1767225600}") + ".sig";
-    assertEquals(Instant.ofEpochSecond(1767225600L), new SpicePassDecoder(pass).getCutoff());
-  }
-
-  @Test
-  void getCutoff_nullWhenClaimAbsent() {
-    // Absent means "no cutoff", not "cutoff at the epoch".
-    String pass = b64("{\"alg\":\"none\"}") + "." + b64("{\"x-uuid-project\":\"p\"}") + ".sig";
-    assertNull(new SpicePassDecoder(pass).getCutoff());
-  }
-
-  @Test
-  void getCutoff_nullWhenClaimIsNotNumeric() {
-    String pass = b64("{\"alg\":\"none\"}") + "." + b64("{\"x-cutoff\":\"yesterday\"}") + ".sig";
-    assertNull(new SpicePassDecoder(pass).getCutoff());
   }
 
   private static String b64(String json) {

--- a/src/test/java/io/spicelabs/cli/SurveyInventoryCommandTest.java
+++ b/src/test/java/io/spicelabs/cli/SurveyInventoryCommandTest.java
@@ -3,18 +3,74 @@
 
 package io.spicelabs.cli;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
 /**
  * Guards the encrypt-only gate: encrypt-only runs never contact a server, so the command
- * must not try to register a survey (which would fail on the missing/dummy pass).
+ * must not try to register a survey (which would fail on the missing/dummy pass); and the
+ * artifact cutoff, which decides how much of the estate the survey covers.
  */
 class SurveyInventoryCommandTest {
+
+  /**
+   * The cutoff constrains what the platform will accept, so it must come from the pass and
+   * nowhere else — never from a system property, which {@code -D} would let any caller set,
+   * turning a bound the platform imposed into one the caller chooses.
+   *
+   * <p>This asserts on {@code passCutoff()}, the path that actually reaches GoatRodeo. A test
+   * that only checked {@link PassClaims} would pass even if this method went back to consulting
+   * a property, since {@code PassClaims} reads the JWT and would never see one.
+   */
+  @Test
+  void noSystemPropertyCanSupplyACutoff() {
+    String saved = System.getProperty("spice.cutoff");
+    try {
+      System.setProperty("spice.cutoff", "2026-01-01T00:00:00Z");
+
+      SurveyInventoryCommand withoutClaim = new SurveyInventoryCommand();
+      withoutClaim.spicePassOverride = pass("{\"x-uuid-project\":\"p\"}");
+      assertEquals(Optional.empty(), withoutClaim.passCutoff(),
+          "a pass with no x-cutoff means no cutoff, whatever the property says");
+
+      SurveyInventoryCommand withClaim = new SurveyInventoryCommand();
+      withClaim.spicePassOverride = pass("{\"x-cutoff\":1767225600}");
+      assertEquals(Optional.of(Instant.ofEpochSecond(1767225600L)), withClaim.passCutoff(),
+          "the cutoff is the pass's, not the property's");
+    } finally {
+      if (saved == null) {
+        System.clearProperty("spice.cutoff");
+      } else {
+        System.setProperty("spice.cutoff", saved);
+      }
+    }
+  }
+
+  /** An override carries its own cutoff rather than inheriting the ambient pass's. */
+  @Test
+  void anOverriddenPassCarriesItsOwnCutoff() {
+    SurveyInventoryCommand cmd = new SurveyInventoryCommand();
+    cmd.spicePassOverride = pass("{\"x-cutoff\":1767225600}");
+    assertEquals(Optional.of(Instant.ofEpochSecond(1767225600L)), cmd.passCutoff());
+  }
+
+  private static String pass(String claimsJson) {
+    return b64("{\"alg\":\"none\"}") + "." + b64(claimsJson) + ".sig";
+  }
+
+  private static String b64(String json) {
+    return Base64.getUrlEncoder().withoutPadding()
+        .encodeToString(json.getBytes(StandardCharsets.UTF_8));
+  }
 
   @Test
   void isEncryptOnly_falseWhenAbsent() {


### PR DESCRIPTION
Part of [one configuration model](https://github.com/spice-labs-inc/spice-config).

`spice` now decodes the Spice Pass once and hands the claims to plugins through `SpicePassClaims`, so built-in commands and plugins cannot disagree about what is in force. Claims travel through `SpiceContext.passClaims()` and nowhere else — never as system properties, where `-D` would let a caller widen a scope the pass had fixed.

`PassClaims` separates registered JWT claims from the rest, and normalises the additional-claims map to plain `java.*` values so it crosses the SPI unchanged. It is also where the CLI takes ownership of pass parsing: ginger-j keeps the claims it needs to upload (public key, upload server, project uuid, challenge, expiry), and claim semantics for everyone else live here.

## New behaviour: the CLI honours `x-cutoff`

The CLI has never read this claim before, so this is not a refactor. Artifacts published after the pass's cutoff are left out of the survey, along with anything that transitively contains them, and a pass carrying one therefore yields a smaller inventory than it did previously. No flag sets, widens or overrides it — it follows the pass — and each affected run logs `Ignoring artifacts published after <instant>`. Passes with no `x-cutoff` are unaffected.

The cutoff was minted for discovery, which is the Allspice registry plugin reading the same claim through the SPI. Inventory analysis is constrained here so that the two halves of a run cannot disagree about which artifacts exist. `PassClaims.cutoff()` is the reference reading; the plugin's is a second one, which is a deliberate trade against a release across plugin-api, spice-bom and every plugin.

Documented for users in `README.md` and `FAQ.md`, and for plugin authors in `docs/PLUGINS.md` — which also described a `SpiceContext` two API versions out of date, missing the accessor a plugin needs to reach any of this.

## Tests

`PassClaimsTest` covers the claims themselves: registered claims stay out of the map, structured values arrive as plain `java.*` types, and a missing or undecodable pass yields `EMPTY` rather than throwing.

The cutoff is pinned on `passCutoff()`, the path that reaches GoatRodeo, rather than on `PassClaims`, which only reads the JWT and would stay green however the consumer behaved: no system property can supply a cutoff, or displace the pass's own.

**Requires** spice-plugin-api 2.0.0 via spice-bom 1.0.10, both released; the earlier SNAPSHOT pin is gone. #247 and #263 are merged.