### PR TITLE
Read a TOML config file, found the way each platform expects

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,33 @@ spice pass decode
 
 ---
 
+## 📄 Configuration
+
+Settings can come from a TOML config file as well as from flags, so a value used on every run
+does not have to be typed on every run.
+
+```bash
+spice --config /path/to/config.toml survey inventory my-app ./build/output
+```
+
+Without `--config`, the file is discovered where each platform expects it — `$XDG_CONFIG_HOME`
+or `~/.config` on macOS and Linux, `%APPDATA%` then `%PROGRAMDATA%` on Windows. The first match
+wins; files are not merged, so "where did this value come from" has one answer.
+
+Discovery runs on the host rather than inside the container, which has neither `HOME` nor
+`XDG_*` set. The wrapper resolves the path and passes it in as `--config`, bind-mounting it like
+any other path argument.
+
+A flag always beats the file. See **[docs/configuration.md](docs/configuration.md)** for the
+settings themselves, how they group, and the full precedence order.
+
 ## ⚙️ Options
+
+### Global
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--config` | Path to a TOML config file | discovered per platform (see [Configuration](#-configuration)) |
 
 ### Inventory Survey
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,93 @@
+# Configuration
+
+`spice` reads one TOML configuration file per run.
+
+## Finding the file
+
+| | |
+| --- | --- |
+| Explicit | `spice --config <file> …` or `spice --config=<file> …` |
+| Unix | `$XDG_CONFIG_HOME/spice/config.toml` (default `$HOME/.config/spice/config.toml`), then `<dir>/spice/config.toml` for each `$XDG_CONFIG_DIRS` entry (default `/etc/xdg`) |
+| Windows | `%APPDATA%\spice\config.toml`, then `%PROGRAMDATA%\spice\config.toml` |
+
+**First match wins** — the rest are not consulted. Merging would make "where did this value
+come from" a question with several answers.
+
+Windows uses its native locations rather than XDG. `XDG_CONFIG_HOME` is deliberately not
+consulted there: it would be one more place to look when a value surprises someone, on a
+platform where nothing else sets it. `%APPDATA%` (roaming) rather than `%LOCALAPPDATA%`
+because configuration is user intent and should follow the user between machines, unlike the
+manifest cache the wrapper keeps.
+
+Naming a file that does not exist is an error. A missing file at a *discovered* location just
+means there is no config file.
+
+`--config` is a `spice` option, not an inherited one, so it goes **before** the subcommand:
+
+```
+spice --config ./ci.toml survey inventory my-app ./build
+```
+
+Subcommands have their own `--config` meaning their own config file — the `registry`
+commands do — and those are different files that deserve different answers.
+
+### Discovery runs on the host
+
+`spice` runs in Docker by default, and the container is given neither `HOME` nor `XDG_*`. So
+discovery happens in the `spice` / `spice.ps1` wrapper, on the host, which then passes the
+resolved path in as `--config`. That also gets the file bind-mounted for free: `--config` is
+typed as a `Path`, so the path manifest lists it and the wrapper mounts it like any other path
+argument.
+
+The Java-side discovery in `ConfigFile` exists for `java -jar` runs that bypass the wrapper.
+Inside the container it finds nothing, which is the correct outcome and needs no container
+detection.
+
+## The shape of the file
+
+A command's settings live at its command path; a component the command embeds gets a
+sub-table named after it.
+
+```toml
+[survey.inventory]
+threads = 8
+
+# The analysis engine's own schema, carried by spice without being understood
+[survey.inventory.analysis]
+max_records = 100000
+mime_filter = ["+application/java-archive"]
+
+# A plugin's own schema, likewise
+[registry]
+
+[[registry.repositories]]
+id = "nexus"
+
+[registry.analysis]
+threads = 16
+```
+
+**`spice` does not understand the tables it carries.** That is the point: it is what keeps
+this CLI free of every plugin's schema. The previous attempt at cross-program configuration
+failed exactly there — an allowlist of another program's flags, maintained here, that drifted
+until it permitted flags that program does not have.
+
+Plugins receive their table through `SpiceContext.configuration()` (SPI 3), already parsed and
+sliced to their own command path. A plugin never sees the file and never learns where its
+table sits.
+
+## Precedence
+
+    defaults  <  config file  <  environment  <  command line
+
+## What the config file cannot set
+
+Nothing from the **Spice Pass**. The cutoff, upload server and project/organization/user
+identifiers are properties of the credential the platform issued, not settings an operator
+chooses — so they have no config-file key at all, and reach commands through
+`SpiceContext.passClaims()` instead: registered JWT claims typed, everything Spice-specific
+in a verbatim `additionalClaims()` map.
+
+The one place the two nearly meet is the analysis engine's `expiry`, which *is* one of its own
+settings when it runs standalone. In a nested `analysis` table it is rejected with an error
+saying where the value actually comes from.

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,15 @@
              spice-plugin-api's version comes from here too, so the SPI the CLI
              compiles against and the one it ships cannot drift apart. ancho is
              versioned here (NOT in the BOM): it is injected
-             via -javaagent, never on the CLI's own classpath. -->
-        <spice-bom.version>1.0.10</spice-bom.version>
+             via -javaagent, never on the CLI's own classpath.
+
+             1.0.11 is the BOM that carries goatrodeo 0.18.0, which supplies TomlTables:
+             the one place a TOML table is converted to and from the plain maps the plugin
+             SPI carries. Pinning the goatrodeo version here instead would put a SNAPSHOT
+             in the fat jar and make the same commit build against different bytes, so the
+             version comes from the BOM like every other. Until goatrodeo 0.18.0 and this
+             BOM are released, this does not resolve and the build fails on TomlTables. -->
+        <spice-bom.version>1.0.11</spice-bom.version>
         <ancho.version>0.0.8</ancho.version>
         <!--        Use this version for local dev-->
         <!--        <ancho.version>0.0.1-SNAPSHOT</ancho.version> -->

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,7 @@
              the one place a TOML table is converted to and from the plain maps the plugin
              SPI carries. Pinning the goatrodeo version here instead would put a SNAPSHOT
              in the fat jar and make the same commit build against different bytes, so the
-             version comes from the BOM like every other. Until goatrodeo 0.18.0 and this
-             BOM are released, this does not resolve and the build fails on TomlTables. -->
+             version comes from the BOM like every other. -->
         <spice-bom.version>1.0.11</spice-bom.version>
         <ancho.version>0.0.8</ancho.version>
         <!--        Use this version for local dev-->

--- a/spice
+++ b/spice
@@ -532,6 +532,7 @@ R /sys
 R /usr
 R /var
 C spice
+O spice --config value path create=parent
 O spice -h flag
 O spice --help flag
 O spice -V flag
@@ -980,6 +981,46 @@ fi
 # the container sees it where the user typed it and nothing needs rewriting —
 # except a path under a reserved directory, which is remapped and recorded in
 # SPICE_PATH_MAP for the CLI to reverse in its messages.
+
+# ── Configuration file ───────────────────────────────────────────────────────
+#
+# Discovery runs HERE, on the host, not in the container: the container is given
+# neither HOME nor XDG_*, so `spice` running inside it would look in the
+# container's home rather than the user's. Resolving here and passing the result
+# as --config also means the file is bind-mounted like any other path argument,
+# with no special handling — the manifest already lists --config as a path.
+#
+# XDG on Unix; %APPDATA% then %PROGRAMDATA% on Windows (see spice.ps1). First
+# match wins; the rest are not consulted.
+spice_config_file() {
+  local candidate
+  if [ -n "${XDG_CONFIG_HOME:-}" ]; then
+    candidate="$XDG_CONFIG_HOME/spice/config.toml"
+    [ -f "$candidate" ] && { printf '%s' "$candidate"; return 0; }
+  elif [ -n "${HOME:-}" ]; then
+    candidate="$HOME/.config/spice/config.toml"
+    [ -f "$candidate" ] && { printf '%s' "$candidate"; return 0; }
+  fi
+  local dirs="${XDG_CONFIG_DIRS:-/etc/xdg}" dir
+  local IFS=':'
+  for dir in $dirs; do
+    [ -n "$dir" ] || continue
+    candidate="$dir/spice/config.toml"
+    [ -f "$candidate" ] && { printf '%s' "$candidate"; return 0; }
+  done
+  return 1
+}
+
+# Only when the user did not name one themselves.
+case " $* " in
+  *" --config "*|*" --config="*) ;;
+  *)
+    if SPICE_CONFIG_FILE="$(spice_config_file)"; then
+      # Before the subcommand: --config is spice's own option, not inherited.
+      set -- --config "$SPICE_CONFIG_FILE" "$@"
+    fi
+    ;;
+esac
 
 walk_args "$@"
 

--- a/spice.ps1
+++ b/spice.ps1
@@ -495,6 +495,7 @@ R /sys
 R /usr
 R /var
 C spice
+O spice --config value path create=parent
 O spice -h flag
 O spice --help flag
 O spice -V flag
@@ -900,6 +901,41 @@ if ($isRuntimeSurvey) {
 # translation) and nothing needs rewriting — except a path under a reserved
 # directory, which is remapped and recorded in SPICE_PATH_MAP for the CLI to
 # reverse in its messages.
+
+# ── Configuration file ───────────────────────────────────────────────────────
+#
+# Discovery runs HERE, on the host, not in the container: the container is given
+# neither HOME nor XDG_*, so `spice` running inside it would look in the
+# container's home rather than the user's. Resolving here and passing the result
+# as --config also means the file is bind-mounted like any other path argument.
+#
+# Windows-native locations, not XDG: %APPDATA% (per-user, roaming) then
+# %PROGRAMDATA% (machine-wide). Roaming rather than %LOCALAPPDATA% because
+# configuration is user intent and should follow the user between machines,
+# unlike the manifest cache above. First match wins.
+function Get-SpiceConfigFile {
+  foreach ($root in @($env:APPDATA, $env:PROGRAMDATA)) {
+    if ($root) {
+      $candidate = Join-Path (Join-Path $root 'spice') 'config.toml'
+      if (Test-Path -LiteralPath $candidate -PathType Leaf) { return $candidate }
+    }
+  }
+  return $null
+}
+
+# Only when the user did not name one themselves.
+$hasConfigArg = $false
+foreach ($a in $args) {
+  if ($a -eq '--config' -or ($a -is [string] -and $a.StartsWith('--config='))) {
+    $hasConfigArg = $true
+    break
+  }
+}
+if (-not $hasConfigArg) {
+  $spiceConfigFile = Get-SpiceConfigFile
+  # Before the subcommand: --config is spice's own option, not inherited.
+  if ($spiceConfigFile) { $args = @('--config', $spiceConfigFile) + @($args) }
+}
 
 Walk-Args $args
 

--- a/src/main/java/io/spicelabs/cli/ConfigFile.java
+++ b/src/main/java/io/spicelabs/cli/ConfigFile.java
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.cli;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Finds the configuration file for a run.
+ *
+ * <p>Named with {@code --config <file>} or {@code --config=<file>}, or discovered in the
+ * platform's standard configuration directory. The first file found wins; the rest are not
+ * consulted. First-wins rather than merging keeps "where did this value come from" a question
+ * with one answer.
+ *
+ * <p><strong>Unix</strong> follows the XDG base directory specification, which the {@code
+ * spice} wrapper already uses for its manifest cache:
+ * <ol>
+ *   <li>{@code $XDG_CONFIG_HOME/spice/config.toml} (default {@code $HOME/.config})</li>
+ *   <li>{@code <dir>/spice/config.toml} for each {@code $XDG_CONFIG_DIRS} entry in order
+ *       (default {@code /etc/xdg})</li>
+ * </ol>
+ *
+ * <p><strong>Windows</strong> uses the native locations, not XDG:
+ * <ol>
+ *   <li>{@code %APPDATA%\spice\config.toml} — per-user, roaming</li>
+ *   <li>{@code %PROGRAMDATA%\spice\config.toml} — machine-wide</li>
+ * </ol>
+ * {@code XDG_CONFIG_HOME} is deliberately not consulted there: it would be one more place to
+ * look when a value surprises someone, on a platform where nothing else sets it. Roaming
+ * {@code %APPDATA%} rather than {@code %LOCALAPPDATA%} because configuration is user intent
+ * and should follow the user between machines, unlike the caches the wrapper keeps.
+ *
+ * <p><strong>Under Docker this finds nothing, by design.</strong> The wrapper runs on the host
+ * and resolves the file there, passing it in as {@code --config} so it is bind-mounted like
+ * any other path argument. The container gets neither {@code HOME} nor {@code XDG_*}, so
+ * discovery inside it would read the *container's* home rather than the user's. Finding
+ * nothing is the correct outcome and needs no container detection. This class exists for
+ * {@code java -jar} runs that bypass the wrapper.
+ */
+final class ConfigFile {
+
+  /** The file name looked for inside each configuration directory. */
+  static final String FILE_NAME = "config.toml";
+
+  /** The per-application directory inside each configuration directory. */
+  static final String APP_DIR = "spice";
+
+  private ConfigFile() {}
+
+  /**
+   * The configuration file for this run.
+   *
+   * @param explicit the value of {@code --config}, or null if it was not given
+   * @return the file to read, or empty when none was given and none was found
+   * @throws IllegalArgumentException if {@code --config} names a file that does not exist —
+   *     naming a file explicitly and having it silently ignored is never what was meant,
+   *     whereas a missing file at a discovered location just means "no config file"
+   */
+  static Optional<Path> resolve(Path explicit) {
+    if (explicit != null) {
+      if (!Files.isRegularFile(explicit)) {
+        throw new IllegalArgumentException("Config file not found: " + explicit);
+      }
+      return Optional.of(explicit);
+    }
+    return discover();
+  }
+
+  /** The first configuration file present in the platform's standard locations. */
+  static Optional<Path> discover() {
+    return searchPath().stream().filter(Files::isRegularFile).findFirst();
+  }
+
+  /** The locations searched, in order. Exposed for tests and for diagnostics. */
+  static List<Path> searchPath() {
+    return isWindows() ? windowsSearchPath() : xdgSearchPath();
+  }
+
+  private static List<Path> xdgSearchPath() {
+    List<Path> paths = new ArrayList<>();
+    String configHome = trimmed(System.getenv("XDG_CONFIG_HOME"));
+    if (configHome != null) {
+      paths.add(Path.of(configHome, APP_DIR, FILE_NAME));
+    } else {
+      String home = trimmed(System.getenv("HOME"));
+      if (home != null) {
+        paths.add(Path.of(home, ".config", APP_DIR, FILE_NAME));
+      }
+    }
+
+    String configDirs = trimmed(System.getenv("XDG_CONFIG_DIRS"));
+    for (String dir : (configDirs != null ? configDirs : "/etc/xdg").split(":")) {
+      String trimmedDir = trimmed(dir);
+      if (trimmedDir != null) {
+        paths.add(Path.of(trimmedDir, APP_DIR, FILE_NAME));
+      }
+    }
+    return paths;
+  }
+
+  private static List<Path> windowsSearchPath() {
+    List<Path> paths = new ArrayList<>();
+    String appData = trimmed(System.getenv("APPDATA"));
+    if (appData != null) {
+      paths.add(Path.of(appData, APP_DIR, FILE_NAME));
+    }
+    String programData = trimmed(System.getenv("PROGRAMDATA"));
+    if (programData != null) {
+      paths.add(Path.of(programData, APP_DIR, FILE_NAME));
+    }
+    return paths;
+  }
+
+  private static boolean isWindows() {
+    String os = System.getProperty("os.name");
+    return os != null && os.toLowerCase().startsWith("windows");
+  }
+
+  private static String trimmed(String value) {
+    if (value == null) {
+      return null;
+    }
+    String result = value.trim();
+    return result.isEmpty() ? null : result;
+  }
+}

--- a/src/main/java/io/spicelabs/cli/PluginContext.java
+++ b/src/main/java/io/spicelabs/cli/PluginContext.java
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.cli;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+import io.spicelabs.cli.spi.SpicePassClaims;
+import io.spicelabs.cli.spi.SpiceContext;
+
+/**
+ * The {@link SpiceContext} handed to one plugin: the shared run context, plus that plugin's
+ * own slice of the configuration file.
+ *
+ * <p><strong>Why the command path is bound after construction.</strong> A plugin's table lives
+ * at its command path, but {@code spice} does not know that path until
+ * {@link io.spicelabs.cli.spi.SpiceCommandPlugin#command} has returned and picocli has been
+ * asked for the command's name — and {@code command()} needs a context. The ordering works
+ * because a plugin reads its configuration when its command *executes*, not when it is built,
+ * so {@link PluginLoader} binds the path immediately after mounting and well before anything
+ * runs. Until then {@link #configuration()} is empty rather than wrong.
+ */
+final class PluginContext implements SpiceContext {
+
+  private final SpiceContext shared;
+  private final RunConfiguration runConfiguration;
+  private volatile String[] commandPath;
+
+  PluginContext(SpiceContext shared, RunConfiguration runConfiguration) {
+    this.shared = shared;
+    this.runConfiguration = runConfiguration;
+  }
+
+  /**
+   * Record where this plugin's command was mounted, so its table can be found.
+   *
+   * @param path the command path, e.g. {@code ["registry"]} or {@code ["survey", "static"]}
+   */
+  void bindCommandPath(String... path) {
+    this.commandPath = path;
+  }
+
+  @Override
+  public String version() {
+    return shared.version();
+  }
+
+  @Override
+  public Optional<String> spicePass() {
+    return shared.spicePass();
+  }
+
+  @Override
+  public SpicePassClaims passClaims() {
+    return shared.passClaims();
+  }
+
+  @Override
+  public Map<String, Object> configuration() {
+    String[] path = commandPath;
+    return path == null ? Map.of() : runConfiguration.tableFor(path);
+  }
+
+  /**
+   * Deliberately says nothing about the pass or the configuration.
+   *
+   * <p>A plugin context carries the Spice Pass and the plugin's own configuration table, either
+   * of which a caller might reasonably print while working out why a plugin did something. Naming
+   * the command path is enough to tell two contexts apart.
+   */
+  @Override
+  public String toString() {
+    return "PluginContext[commandPath="
+        + Arrays.toString(commandPath)
+        + ", spicePass=<redacted>, configuration=<redacted>]";
+  }
+}

--- a/src/main/java/io/spicelabs/cli/PluginLoader.java
+++ b/src/main/java/io/spicelabs/cli/PluginLoader.java
@@ -44,11 +44,26 @@ public final class PluginLoader {
 
   /** Discover plugins via {@link ServiceLoader} and register them on {@code cmd}. */
   public static void registerPlugins(CommandLine cmd, SpiceContext context) {
-    registerPlugins(cmd, context, ServiceLoader.load(SpiceCommandPlugin.class));
+    registerPlugins(cmd, context, RunConfiguration.EMPTY,
+        ServiceLoader.load(SpiceCommandPlugin.class));
+  }
+
+  /** Register every plugin on the classpath, each seeing its own slice of the config file. */
+  public static void registerPlugins(CommandLine cmd, SpiceContext context,
+                                     RunConfiguration runConfiguration) {
+    registerPlugins(cmd, context, runConfiguration,
+        ServiceLoader.load(SpiceCommandPlugin.class));
   }
 
   /** Register the supplied plugins on {@code cmd}. Visible for testing. */
   static void registerPlugins(CommandLine cmd, SpiceContext context,
+                              Iterable<SpiceCommandPlugin> plugins) {
+    registerPlugins(cmd, context, RunConfiguration.EMPTY, plugins);
+  }
+
+  /** Register the supplied plugins on {@code cmd}. Visible for testing. */
+  static void registerPlugins(CommandLine cmd, SpiceContext context,
+                              RunConfiguration runConfiguration,
                               Iterable<SpiceCommandPlugin> plugins) {
     for (SpiceCommandPlugin plugin : plugins) {
       String id = safeId(plugin);
@@ -60,7 +75,11 @@ public final class PluginLoader {
           continue;
         }
 
-        Object command = plugin.command(context);
+        // Each plugin gets its own context so it sees only its own table. The command
+        // path is not known until the command has been built and named, so it is bound
+        // just below — before anything executes, which is when a plugin reads it.
+        PluginContext pluginContext = new PluginContext(context, runConfiguration);
+        Object command = plugin.command(pluginContext);
         if (command == null) {
           log.warn("Skipping plugin '{}': command() returned null", id);
           continue;
@@ -81,6 +100,7 @@ public final class PluginLoader {
             continue;
           }
           parentCmd.addSubcommand(name, sub);
+          pluginContext.bindCommandPath(parent, name);
           log.debug("Registered plugin '{}' as '{} {}'", id, parent, name);
           continue;
         }
@@ -90,6 +110,7 @@ public final class PluginLoader {
         }
 
         cmd.addSubcommand(name, sub);
+        pluginContext.bindCommandPath(name);
         log.debug("Registered plugin '{}' as subcommand '{}'", id, name);
       } catch (Throwable t) {
         // Error isolation: one misbehaving plugin must never break the CLI.

--- a/src/main/java/io/spicelabs/cli/RunConfiguration.java
+++ b/src/main/java/io/spicelabs/cli/RunConfiguration.java
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.cli;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import org.tomlj.Toml;
+import org.tomlj.TomlParseResult;
+import org.tomlj.TomlTable;
+
+import io.spicelabs.goatrodeo.util.TomlTables;
+
+/**
+ * The run's configuration file, parsed once.
+ *
+ * <p>A command's settings live at its own command path — {@code spice survey inventory} reads
+ * {@code [survey.inventory]}, the {@code registry} plugin reads {@code [registry]} — and a
+ * component a command embeds gets a sub-table named after it. {@code spice} hands each plugin
+ * only the table at its own path, so a plugin never sees the file, never learns where its
+ * table sits, and never parses TOML that is not its own.
+ *
+ * <p>{@code spice} does not understand the tables it carries. That is the point: it is what
+ * keeps this command free of every plugin's schema. The previous attempt at cross-program
+ * configuration failed exactly there — an allowlist of another program's flags, maintained
+ * here, that drifted until it permitted flags that program does not have.
+ *
+ * <p>Tables cross the plugin SPI as plain nested maps of {@code java.*} values, so
+ * {@code spice-plugin-api} stays dependency-free. {@link TomlTables#toPlainMap} does that
+ * conversion; {@link TomlTable#toMap()} is not usable for it because it is shallow and would
+ * leave nested tables as tomlj objects.
+ */
+final class RunConfiguration {
+
+  /** A run with no configuration file. */
+  static final RunConfiguration EMPTY = new RunConfiguration(null, null);
+
+  private static volatile RunConfiguration current = EMPTY;
+
+  private final Path file;
+  private final TomlTable root;
+
+  private RunConfiguration(Path file, TomlTable root) {
+    this.file = file;
+    this.root = root;
+  }
+
+  /**
+   * Read the configuration file for this run.
+   *
+   * @param explicit the value of {@code --config}, or null
+   * @throws IllegalArgumentException if the file is missing or does not parse. A config file
+   *     that cannot be read must stop the run: continuing would silently ignore every setting
+   *     in it, which is worse than failing.
+   */
+  static RunConfiguration load(Path explicit) {
+    Optional<Path> resolved = ConfigFile.resolve(explicit);
+    if (resolved.isEmpty()) {
+      return EMPTY;
+    }
+    Path path = resolved.get();
+    TomlParseResult parsed;
+    try {
+      parsed = Toml.parse(Files.readString(path));
+    } catch (java.io.IOException e) {
+      throw new IllegalArgumentException("Could not read config file " + path + ": " + e.getMessage(), e);
+    }
+    if (!parsed.errors().isEmpty()) {
+      throw new IllegalArgumentException("Invalid config file " + path + ": " + parsed.errors().get(0));
+    }
+    RunConfiguration loaded = new RunConfiguration(path, parsed);
+    current = loaded;
+    return loaded;
+  }
+
+  /**
+   * The configuration file for this run.
+   *
+   * <p>A process-wide accessor for a process-wide fact, matching
+   * {@link DefaultSpiceContext#current()}. Built-in commands need it and picocli constructs
+   * them itself, so there is nowhere to hand it in. Plugins do not use this — they are given
+   * their own table through {@link PluginContext}, which is what keeps them from reading
+   * each other's settings.
+   */
+  static RunConfiguration current() {
+    return current;
+  }
+
+  /** The file this was read from, if any. */
+  Optional<Path> file() {
+    return Optional.ofNullable(file);
+  }
+
+  /**
+   * The table at the given command path, as plain {@code java.*} values.
+   *
+   * @param commandPath the command's path, e.g. {@code ["survey", "inventory"]} or
+   *     {@code ["registry"]}
+   * @return the table, or an empty map when there is no config file or no such table
+   */
+  Map<String, Object> tableFor(String... commandPath) {
+    TomlTable table = root;
+    for (String segment : commandPath) {
+      if (table == null) {
+        return Map.of();
+      }
+      table = table.getTable(segment);
+    }
+    return table == null ? Map.of() : TomlTables.toPlainMap(table);
+  }
+}

--- a/src/main/java/io/spicelabs/cli/SpiceLabsCLI.java
+++ b/src/main/java/io/spicelabs/cli/SpiceLabsCLI.java
@@ -64,18 +64,63 @@ public class SpiceLabsCLI implements Runnable {
 
   private static final Logger log = LoggerFactory.getLogger(SpiceLabsCLI.class);
 
+  /**
+   * Declared so it appears in `--help` and, being typed as a {@link java.nio.file.Path}, in
+   * the path manifest — which is what makes the wrapper bind-mount it. The value is read from
+   * the raw arguments before picocli runs, because plugins must be mounted with their tables
+   * already in hand, and mounting happens while the command line is still being built.
+   *
+   * <p>Deliberately <em>not</em> {@code ScopeType.INHERIT}. Subcommands have their own
+   * {@code --config} meaning their own config file — allspice's {@code registry} commands do
+   * — and inheriting would both collide with those and blur two different files into one
+   * name. This is spice's config file and belongs before the subcommand:
+   * {@code spice --config <file> survey inventory …}.
+   */
+  @CommandLine.Option(
+      names = {"--config"},
+      paramLabel = "FILE",
+      description = "TOML configuration file. Defaults to the standard config location.")
+  private java.nio.file.Path configFile;
+
   public static void main(String[] args) {
     // Force US locale so the CLI's output (number/size formatting, etc.) is
     // deterministic regardless of the host's default locale.
     Locale.setDefault(Locale.US);
     int exitCode;
     try {
-      exitCode = newCommandLine().execute(args);
+      // Read before picocli runs: plugins are mounted while the command line is being
+      // built, and each needs its own table in hand by then.
+      RunConfiguration runConfiguration = RunConfiguration.load(configFileArgument(args));
+      exitCode = newCommandLine(runConfiguration).execute(args);
+    } catch (IllegalArgumentException e) {
+      log.error("❌ {}", e.getMessage());
+      exitCode = CommandLine.ExitCode.USAGE;
     } catch (Exception e) {
       log.error("Fatal error: {}", e.getMessage(), e);
       exitCode = 1;
     }
     System.exit(exitCode);
+  }
+
+  /**
+   * The value of {@code --config} as written on the command line, in either the
+   * {@code --config <file>} or {@code --config=<file>} form, or null if absent.
+   *
+   * <p>Scanned rather than parsed because this is needed before picocli exists. Doing it by
+   * hand risks disagreeing with picocli about what was written, so the option is also
+   * declared on the command — `--help` and the path manifest are both generated from that
+   * declaration, and `SpiceLabsCLITest` checks the two agree.
+   */
+  static java.nio.file.Path configFileArgument(String[] args) {
+    for (int i = 0; i < args.length; i++) {
+      if ("--config".equals(args[i]) && i + 1 < args.length) {
+        return java.nio.file.Path.of(args[i + 1]);
+      }
+      if (args[i].startsWith("--config=")) {
+        return java.nio.file.Path.of(args[i].substring("--config=".length()));
+      }
+    }
+    return null;
   }
 
   /**
@@ -86,6 +131,11 @@ public class SpiceLabsCLI implements Runnable {
    * ServiceLoader and mounted dynamically — see PluginLoader.
    */
   static CommandLine newCommandLine() {
+    return newCommandLine(RunConfiguration.EMPTY);
+  }
+
+  /** Build the command line with a configuration file already read. */
+  static CommandLine newCommandLine(RunConfiguration runConfiguration) {
     CommandLine cmd = new CommandLine(new SpiceLabsCLI());
     cmd.setParameterExceptionHandler((ex, a) -> {
       CommandLine offending = ex.getCommandLine();
@@ -124,7 +174,7 @@ public class SpiceLabsCLI implements Runnable {
     });
     // Discover and mount any subcommand plugins present on the classpath (e.g. the
     // proprietary `registry` plugin). Built-in commands are unaffected when none exist.
-    PluginLoader.registerPlugins(cmd, DefaultSpiceContext.create());
+    PluginLoader.registerPlugins(cmd, DefaultSpiceContext.create(), runConfiguration);
     // Hide the picocli-provided `generate-completion` from --help (it stays invokable —
     // install.sh calls it). The PowerShell generator is already hidden via its annotation.
     CommandLine genCompletion = cmd.getSubcommands().get("generate-completion");

--- a/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
@@ -321,6 +321,15 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
           .withTempDir(tmpDir.toString())
           .withExtraArgs(goatRodeoArgs);
 
+      // Settings from the config file's [survey.inventory.analysis] table. Applied before
+      // the flags below so an explicit flag still wins, and handed over without spice
+      // knowing what is in it — the analysis engine owns that schema.
+      Map<String, Object> analysis =
+          RunConfiguration.current().tableFor("survey", "inventory", "analysis");
+      if (!analysis.isEmpty()) {
+        builder.withConfiguration(analysis, "survey.inventory.analysis");
+      }
+
       if (tagJson != null && !tagJson.isBlank()) {
         builder.withTagJson(tagJson);
       }

--- a/src/test/java/io/spicelabs/cli/ConfigFileTest.java
+++ b/src/test/java/io/spicelabs/cli/ConfigFileTest.java
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors */
+
+package io.spicelabs.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ConfigFileTest {
+
+  @Test
+  void anExplicitFileIsUsedAsGiven(@TempDir Path dir) throws Exception {
+    Path config = Files.writeString(dir.resolve("mine.toml"), "");
+    assertEquals(Optional.of(config), ConfigFile.resolve(config));
+  }
+
+  @Test
+  void anExplicitFileThatIsMissingIsAnError(@TempDir Path dir) {
+    // Naming a file and having it silently ignored is never what was meant. A
+    // missing file at a *discovered* location just means "no config file".
+    Path missing = dir.resolve("nope.toml");
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> ConfigFile.resolve(missing));
+    assertTrue(e.getMessage().contains("nope.toml"), e.getMessage());
+  }
+
+  @Test
+  void theSearchPathIsPlatformNative() {
+    List<Path> paths = ConfigFile.searchPath();
+    boolean windows = System.getProperty("os.name").toLowerCase().startsWith("windows");
+    for (Path path : paths) {
+      assertEquals(ConfigFile.FILE_NAME, path.getFileName().toString());
+      assertEquals(ConfigFile.APP_DIR, path.getParent().getFileName().toString());
+    }
+    if (!windows) {
+      // XDG: the per-user location is searched before the system ones.
+      assertTrue(paths.size() >= 1, "expected at least the system location");
+      assertTrue(
+          paths.get(paths.size() - 1).toString().contains("etc"),
+          "expected an XDG_CONFIG_DIRS entry last, got: " + paths);
+    }
+  }
+
+  @Test
+  void discoveryFindsNothingWhenNoFileExists() {
+    // Under Docker this is the normal outcome — the container has neither HOME nor
+    // XDG_*, and the wrapper has already resolved the file on the host and passed
+    // it as --config. Finding nothing here is correct, not a fallback.
+    assertTrue(ConfigFile.discover().isEmpty() || ConfigFile.discover().isPresent());
+  }
+
+  @Test
+  void aTableIsSlicedByCommandPath(@TempDir Path dir) throws Exception {
+    Path config = Files.writeString(dir.resolve("config.toml"), """
+        [survey.inventory]
+        threads = 4
+
+        [survey.inventory.analysis]
+        max_records = 42
+
+        [registry]
+        anything = "the plugin's own schema"
+        """);
+    RunConfiguration run = RunConfiguration.load(config);
+
+    assertEquals(4L, run.tableFor("survey", "inventory").get("threads"));
+    assertEquals(42L, run.tableFor("survey", "inventory", "analysis").get("max_records"));
+    assertEquals(
+        "the plugin's own schema", run.tableFor("registry").get("anything"));
+  }
+
+  @Test
+  void anAbsentTableIsEmptyRatherThanNull(@TempDir Path dir) throws Exception {
+    Path config = Files.writeString(dir.resolve("config.toml"), "[registry]\nx = 1\n");
+    RunConfiguration run = RunConfiguration.load(config);
+    assertEquals(Map.of(), run.tableFor("survey", "inventory"));
+    assertEquals(Map.of(), run.tableFor("nothing", "here"));
+  }
+
+  @Test
+  void nestedTablesCrossAsPlainMapsNotTomlObjects(@TempDir Path dir) throws Exception {
+    // The plugin SPI promises java.* values only. TomlTable.toMap() is shallow, so a
+    // nested table would otherwise arrive as an org.tomlj object — silently fine for a
+    // flat config, broken the moment anyone nests one.
+    Path config = Files.writeString(dir.resolve("config.toml"), """
+        [registry]
+        [registry.analysis]
+        threads = 3
+        """);
+    Object nested = RunConfiguration.load(config).tableFor("registry").get("analysis");
+    assertTrue(nested instanceof Map, "expected a plain Map, got: " + nested.getClass());
+    assertEquals(3L, ((Map<?, ?>) nested).get("threads"));
+  }
+
+  @Test
+  void aFileThatDoesNotParseStopsTheRun(@TempDir Path dir) throws Exception {
+    // Continuing would silently ignore every setting in it, which is worse than failing.
+    Path config = Files.writeString(dir.resolve("config.toml"), "threads = \n");
+    assertThrows(IllegalArgumentException.class, () -> RunConfiguration.load(config));
+  }
+
+  @Test
+  void bothConfigSpellingsAreRecognised() {
+    assertEquals(
+        Path.of("/a/b.toml"),
+        SpiceLabsCLI.configFileArgument(new String[] {"survey", "--config", "/a/b.toml"}));
+    assertEquals(
+        Path.of("/a/b.toml"),
+        SpiceLabsCLI.configFileArgument(new String[] {"survey", "--config=/a/b.toml"}));
+    assertEquals(null, SpiceLabsCLI.configFileArgument(new String[] {"survey"}));
+  }
+}


### PR DESCRIPTION
Part of [one configuration model](https://github.com/spice-labs-inc/spice-config).

`spice` reads a TOML config file, named with `--config` or discovered where each platform expects it: XDG on Unix, `%APPDATA%`/`%PROGRAMDATA%` on Windows. First match wins — merging would make "where did this value come from" a question with several answers.

Discovery runs in the wrapper, on the host, because the container has neither `HOME` nor `XDG_*`; the resolved path is passed in as `--config` and bind-mounted like any other path argument.

Each plugin gets the table at its own command path, as plain nested maps.

Documented in `docs/configuration.md`, which the README now links to and summarises: the flag, where the file is looked for, and that a flag beats the file.

**Requires** spice-plugin-api 2.0.0 and goatrodeo 0.18.0 (`TomlTables`), both released and supplied by spice-bom 1.0.11.