### PR TITLE
Resolve every setting in one place, and say when two disagree

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ any other path argument.
 A flag always beats the file. See **[docs/configuration.md](docs/configuration.md)** for the
 settings themselves, how they group, and the full precedence order.
 
+To see what a run will actually use, and where each value came from:
+
+```bash
+spice config explain survey inventory
+```
+
+Every key is printed with its origin — the file and table it came from, the environment
+variable, or the flag — which is how to answer "why is it doing that?" without guessing.
+
 ## ⚙️ Options
 
 ### Global

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -29,6 +29,7 @@ public interface SpiceCommandPlugin {
   String id();                          // stable id, for ordering and diagnostics
   default int apiVersion() { return SpiceContext.API_VERSION; }
   default String parent() { return ""; } // parent command to mount under, or "" for top-level
+  default java.util.List<String> configurationGroups() { return List.of(); } // see below
   default String powershellCompletion() { return ""; } // see "Tab completion" below
 }
 
@@ -47,6 +48,24 @@ behaves consistently (version reporting, `SPICE_PASS` resolution, configuration)
 `spice` mounts a plugin only when its `apiVersion()` **equals** `API_VERSION` exactly. A
 mismatch is a plugin that does not appear, logged as such — not a build failure — so rebuild
 plugins against the `spice-plugin-api` the CLI ships.
+
+## Reading configuration
+
+`context.configuration()` hands over the config-file groups this plugin claimed through
+`configurationGroups()`, already resolved. Defaults, the shared `[group]`, the command-scoped
+`[command.group]`, environment variables and flags have all been applied by the time a plugin
+sees them, so it reads one settled value per key instead of re-implementing precedence — and
+gets the same answer the built-in commands get from the same file.
+
+Values arrive as plain nested `java.*` maps, so the SPI stays dependency-free and a plugin
+needs no TOML parser of its own.
+
+Claim the groups you read. A group that no plugin and no built-in command claims is reported
+as a probable typo, which only works if claims are honest — an unclaimed group is
+indistinguishable from a misspelt one.
+
+See [configuration.md](configuration.md) for the layering rules, and `spice config explain`
+for the resolved values with an origin per key.
 
 ## Reading the Spice Pass
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,42 +43,133 @@ The Java-side discovery in `ConfigFile` exists for `java -jar` runs that bypass 
 Inside the container it finds nothing, which is the correct outcome and needs no container
 detection.
 
-## The shape of the file
+## Groups
 
-A command's settings live at its command path; a component the command embeds gets a
-sub-table named after it.
+Settings live in **groups**, named for the job rather than for whoever does it — `analysis`,
+`upload`, `crypto`, `pipeline`, `repositories`.
 
 ```toml
-[survey.inventory]
-threads = 8
-
-# The analysis engine's own schema, carried by spice without being understood
-[survey.inventory.analysis]
-max_records = 100000
-mime_filter = ["+application/java-archive"]
-
-# A plugin's own schema, likewise
-[registry]
-
-[[registry.repositories]]
-id = "nexus"
-
-[registry.analysis]
+# Shared: every command that claims `analysis` sees this
+[analysis]
 threads = 16
+max_records = 100000
+
+[upload]
+target_chunk_size = 64        # also: encrypt_only, skip_key, comment, bundle_format_version
+
+[crypto]
+max_classes = 50000
+
+# Scoped: only `spice registry` sees this
+[registry.analysis]
+threads = 4
 ```
 
-**`spice` does not understand the tables it carries.** That is the point: it is what keeps
-this CLI free of every plugin's schema. The previous attempt at cross-program configuration
-failed exactly there — an allowlist of another program's flags, maintained here, that drifted
-until it permitted flags that program does not have.
+A group is **shared**. `[analysis] threads = 16` written once governs `spice survey
+inventory` and `spice registry` alike, so you configure the job and not each component that
+performs part of it. A same-named table under a command's path overrides for that command
+alone.
 
-Plugins receive their table through `SpiceContext.configuration()` (SPI 3), already parsed and
-sliced to their own command path. A plugin never sees the file and never learns where its
-table sits.
+A command reads a group only if it **claims** it, and it receives nothing else. That is what
+makes sharing safe: a command cannot read settings meant for another, and a table nobody
+claims can be reported as a probable typo rather than silently doing nothing.
+
+```
+WARN ⚠️  No command reads [anaylsis] — check the spelling, or the plugin may not be installed
+```
+
+A group is usually a table of settings. Some name a list of things — `[[repositories]]` — and
+have no keys to layer, so a later source replaces such a group whole or leaves it alone.
+
+**A group may not share a name with a command.** At the root of the file a table is either a
+group or a command's scope, so `[registry.analysis]` can only mean "the analysis group, for
+the registry command" if nothing called `registry` is also a group.
+
+**`spice` does not understand the groups it carries.** That is the point: it is what keeps
+this CLI free of every component's schema. The previous attempt at cross-program
+configuration failed exactly there — an allowlist of another program's flags, maintained
+here, that drifted until it permitted flags that program does not have.
+
+Plugins receive their claimed groups through `SpiceContext.configuration()` (SPI 4), already
+resolved. A plugin never sees the file and never learns where its tables sit.
+
+## One setting, three names
+
+| Form | Shape | Example |
+| --- | --- | --- |
+| Config key | `snake_case` in a group | `[analysis] max_records` |
+| Flag | its kebab-case form | `--max-records` |
+| Environment | `SPICE_<GROUP>_<KEY>` | `SPICE_ANALYSIS_MAX_RECORDS` |
+
+No exceptions, so there is no table of them to remember. The one variation: when a command
+claims two groups that both define `threads`, the flag is qualified as `--analysis-threads` —
+still derived, not remembered.
+
+Flags are *bindings onto group keys*, not values of their own. `--threads` and `[analysis]
+threads` are one setting reached two ways, rather than two settings that have to be kept in
+agreement.
+
+Run a component standalone and only the prefix changes:
+
+| Component | Prefix |
+| --- | --- |
+| `spice` | `SPICE_` |
+| `goatrodeo` | `GOATRODEO_` |
+| `allspice` | `ALLSPICE_` |
+| `sassafras` | `SASSAFRAS_` |
+
+The environment is matched against *claimed group names* rather than parsed, so the wrapper's
+own variables — `SPICE_IMAGE`, `SPICE_CACHE_DIR`, `SPICE_PATH_MANIFEST`, `SPICE_PASS` — can
+never be mistaken for settings. They are read on the host before any JVM exists and are not
+part of any configuration. No group may be named `image`, `cache`, `path` or `pass`.
 
 ## Precedence
 
-    defaults  <  config file  <  environment  <  command line
+    defaults  <  [group]  <  [command.group]  <  environment  <  command line
+
+Resolution does not depend on the order sources are supplied in: a value may only be
+displaced by one from a strictly later layer.
+
+**There is no fifth channel.** System properties are not a configuration input anywhere in
+`spice` or its components. Setting one to steer a third-party library is an *output*, written
+once from a resolved configuration and never read back.
+
+## Disagreements are reported
+
+One place decides which source wins, so one place can say so:
+
+```
+INFO ⚙️  analysis.threads = 8 (SPICE_ANALYSIS_THREADS) overrides 16 ([analysis] in ~/.config/spice/config.toml)
+```
+
+Overriding a *default* is deliberately not reported: that happens for every setting on every
+run, and the noise would bury the cases where two deliberate choices conflict.
+
+`spice config explain` prints the whole resolved configuration with an origin per key —
+which is also how to answer "why is it doing that?":
+
+```
+$ spice config explain survey inventory
+# /home/u/.config/spice/config.toml
+
+[analysis]
+  max_records = 100000    [analysis] in /home/u/.config/spice/config.toml
+  threads     = 4         [survey.inventory.analysis] in /home/u/.config/spice/config.toml
+```
+
+Standalone components print the same thing with `--explain-config` (`allspice
+explain-config`).
+
+A value that came from the environment shows quoted — `threads = "8"` — because the
+environment has no types and the value really is text until the component that knows the
+schema coerces it.
+
+## Where the rules live
+
+Naming, layering, precedence and provenance are implemented once, in
+[`spice-config`](https://github.com/spice-labs-inc/spice-config), and shared by every
+component. Rules copied into several codebases are rules that will disagree, and these
+already have.
 
 ## What the config file cannot set
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,12 +91,21 @@
         <!-- Version from the BOM, like everything else here. Note that the SPI's pom
              version is not what decides compatibility: SpiceContext.API_VERSION is, and
              `spice` mounts a plugin only when that plugin's apiVersion() equals its own
-             exactly. A pom version can therefore move without the contract moving, or
-             the reverse, so a plugin built against a different API_VERSION fails to mount
-             at runtime rather than failing to compile. -->
+             exactly (passClaims() carries the pass's claims; configuration() carries the
+             groups a plugin claimed). A pom version can therefore move without the
+             contract moving, or the reverse, so a plugin built against a different
+             API_VERSION fails to mount at runtime rather than failing to compile. -->
         <dependency>
             <groupId>io.spicelabs</groupId>
             <artifactId>spice-plugin-api</artifactId>
+        </dependency>
+        <!-- The naming, layering and precedence rules, in the one implementation every
+             component shares. A released artifact on Maven Central, so unlike goatrodeo
+             below it needs no repository declaration and no credentials. -->
+        <dependency>
+            <groupId>io.spicelabs</groupId>
+            <artifactId>spice-config</artifactId>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>

--- a/spice
+++ b/spice
@@ -591,6 +591,18 @@ O spice/generate-completion -V flag
 O spice/generate-completion --version flag
 C spice/generate-powershell-completion
 C spice/path-manifest
+C spice/config
+O spice/config -h flag
+O spice/config --help flag
+O spice/config -V flag
+O spice/config --version flag
+C spice/config/explain
+O spice/config/explain --group value
+O spice/config/explain -h flag
+O spice/config/explain --help flag
+O spice/config/explain -V flag
+O spice/config/explain --version flag
+P spice/config/explain 0 value
 SPICE_EMBEDDED_MANIFEST
 }
 # ── END GENERATED PATH MANIFEST ──

--- a/spice.ps1
+++ b/spice.ps1
@@ -554,6 +554,18 @@ O spice/generate-completion -V flag
 O spice/generate-completion --version flag
 C spice/generate-powershell-completion
 C spice/path-manifest
+C spice/config
+O spice/config -h flag
+O spice/config --help flag
+O spice/config -V flag
+O spice/config --version flag
+C spice/config/explain
+O spice/config/explain --group value
+O spice/config/explain -h flag
+O spice/config/explain --help flag
+O spice/config/explain -V flag
+O spice/config/explain --version flag
+P spice/config/explain 0 value
 '@
 # ── END GENERATED PATH MANIFEST ──
 

--- a/src/main/java/io/spicelabs/cli/ConfigCommand.java
+++ b/src/main/java/io/spicelabs/cli/ConfigCommand.java
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.cli;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import io.spicelabs.config.Resolution;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/** Questions about the configuration itself, rather than about artifacts. */
+@Command(
+    name = "config",
+    mixinStandardHelpOptions = true,
+    description = "Inspect the configuration this run would use",
+    subcommands = {ConfigCommand.Explain.class})
+public class ConfigCommand implements Runnable {
+
+  @Override
+  public void run() {
+    new picocli.CommandLine(this).usage(System.out);
+  }
+
+  /**
+   * Print every setting a command would run with, and where each value came from.
+   *
+   * <p>The question this answers — "why is it doing that?" — previously had no answer at
+   * all. A value could come from a shared group, a command-scoped group, an environment
+   * variable or a flag, and nothing recorded which. Overrides are reported as they happen
+   * during a run; this shows the whole resolved picture without running anything.
+   */
+  @Command(
+      name = "explain",
+      mixinStandardHelpOptions = true,
+      description = "Show every setting and where its value came from")
+  static class Explain implements Callable<Integer> {
+
+    @Parameters(
+        arity = "0..*",
+        paramLabel = "COMMAND",
+        description =
+            "The command to explain, e.g. `survey inventory` or `registry`. "
+                + "Defaults to every command's settings.")
+    List<String> commandPath = new ArrayList<>();
+
+    @Option(
+        names = "--group",
+        paramLabel = "GROUP",
+        description = "Restrict to one configuration group, e.g. analysis")
+    String group;
+
+    @Override
+    public Integer call() {
+      RunConfiguration configuration = RunConfiguration.current();
+
+      configuration
+          .file()
+          .ifPresentOrElse(
+              path -> System.out.println("# " + path + "\n"),
+              () ->
+                  System.out.println(
+                      "# No configuration file; showing defaults and the environment\n"));
+
+      List<String> groups = group == null ? knownGroups() : List.of(group);
+      Resolution resolved = configuration.explain(commandPath, groups);
+      String explained = resolved.explain();
+      System.out.print(explained.isEmpty() ? "# Nothing set\n" : explained);
+
+      configuration.warnAboutUnclaimedGroups(knownGroups(), knownCommands());
+      return 0;
+    }
+
+    /**
+     * Every group any command reads.
+     *
+     * <p>Built-in claims are listed by the commands themselves; a plugin's claims come from
+     * the plugin. Both are needed here, because explaining a configuration means explaining
+     * all of it — and because a group in the file that appears in neither list is exactly
+     * the typo worth reporting.
+     */
+    private static List<String> knownGroups() {
+      List<String> groups = new ArrayList<>(SurveyInventoryCommand.GROUPS);
+      for (String group : PluginLoader.claimedGroups()) {
+        if (!groups.contains(group)) {
+          groups.add(group);
+        }
+      }
+      return groups;
+    }
+
+    private static List<String> knownCommands() {
+      List<String> commands = new ArrayList<>(List.of("survey", "pass", "config"));
+      commands.addAll(PluginLoader.mountedCommands());
+      return commands;
+    }
+  }
+}

--- a/src/main/java/io/spicelabs/cli/PluginContext.java
+++ b/src/main/java/io/spicelabs/cli/PluginContext.java
@@ -15,7 +15,7 @@ limitations under the License. */
 
 package io.spicelabs.cli;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -23,26 +23,40 @@ import io.spicelabs.cli.spi.SpicePassClaims;
 import io.spicelabs.cli.spi.SpiceContext;
 
 /**
- * The {@link SpiceContext} handed to one plugin: the shared run context, plus that plugin's
- * own slice of the configuration file.
+ * The {@link SpiceContext} handed to one plugin: the shared run context, plus the
+ * configuration groups that plugin claimed.
  *
- * <p><strong>Why the command path is bound after construction.</strong> A plugin's table lives
- * at its command path, but {@code spice} does not know that path until
- * {@link io.spicelabs.cli.spi.SpiceCommandPlugin#command} has returned and picocli has been
- * asked for the command's name — and {@code command()} needs a context. The ordering works
- * because a plugin reads its configuration when its command *executes*, not when it is built,
- * so {@link PluginLoader} binds the path immediately after mounting and well before anything
- * runs. Until then {@link #configuration()} is empty rather than wrong.
+ * <p>A plugin gets exactly the groups it named in
+ * {@link io.spicelabs.cli.spi.SpiceCommandPlugin#configurationGroups()}, already resolved:
+ * the shared {@code [group]} table, overlaid by the command-scoped {@code [<path>.group]}
+ * table, overlaid by the environment. It never sees the file, never learns where its tables
+ * sit, and cannot reach a group it did not claim — which is what makes sharing a group
+ * between commands safe.
+ *
+ * <p><strong>Why the command path is bound after construction.</strong> A plugin's
+ * command-scoped tables live at its command path, but {@code spice} does not know that path
+ * until {@link io.spicelabs.cli.spi.SpiceCommandPlugin#command} has returned and picocli has
+ * been asked for the command's name — and {@code command()} needs a context. The ordering
+ * works because a plugin reads its configuration when its command *executes*, not when it is
+ * built, so {@link PluginLoader} binds the path immediately after mounting and well before
+ * anything runs. Until then {@link #configuration()} is empty rather than wrong.
  */
 final class PluginContext implements SpiceContext {
 
   private final SpiceContext shared;
   private final RunConfiguration runConfiguration;
+  private final List<String> groups;
   private volatile String[] commandPath;
 
-  PluginContext(SpiceContext shared, RunConfiguration runConfiguration) {
+  PluginContext(SpiceContext shared, RunConfiguration runConfiguration, List<String> groups) {
     this.shared = shared;
     this.runConfiguration = runConfiguration;
+    this.groups = List.copyOf(groups);
+  }
+
+  /** The groups this plugin claimed, for the whole-file typo check. */
+  List<String> claimedGroups() {
+    return groups;
   }
 
   /**
@@ -72,20 +86,21 @@ final class PluginContext implements SpiceContext {
   @Override
   public Map<String, Object> configuration() {
     String[] path = commandPath;
-    return path == null ? Map.of() : runConfiguration.tableFor(path);
+    if (path == null || groups.isEmpty()) {
+      return Map.of();
+    }
+    return runConfiguration.claimedGroups(List.of(path), groups);
   }
 
   /**
    * Deliberately says nothing about the pass or the configuration.
    *
-   * <p>A plugin context carries the Spice Pass and the plugin's own configuration table, either
-   * of which a caller might reasonably print while working out why a plugin did something. Naming
-   * the command path is enough to tell two contexts apart.
+   * <p>A plugin context carries the Spice Pass and the groups a plugin claimed, either of which a
+   * caller might reasonably print while working out why a plugin did something. Naming the groups
+   * is enough to tell two contexts apart.
    */
   @Override
   public String toString() {
-    return "PluginContext[commandPath="
-        + Arrays.toString(commandPath)
-        + ", spicePass=<redacted>, configuration=<redacted>]";
+    return "PluginContext[groups=" + groups + ", spicePass=<redacted>, configuration=<redacted>]";
   }
 }

--- a/src/main/java/io/spicelabs/cli/PluginLoader.java
+++ b/src/main/java/io/spicelabs/cli/PluginLoader.java
@@ -15,7 +15,10 @@ limitations under the License. */
 
 package io.spicelabs.cli;
 
+import java.util.List;
 import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,7 +82,7 @@ public final class PluginLoader {
         // cannot reach settings meant for another command. The command path is not known
         // until the command has been built and named, so it is bound just below — before
         // anything executes, which is when a plugin reads its configuration.
-        java.util.List<String> claimed = safeGroups(plugin, id);
+        List<String> claimed = safeGroups(plugin, id);
         CLAIMED_GROUPS.addAll(claimed);
         PluginContext pluginContext = new PluginContext(context, runConfiguration, claimed);
         Object command = plugin.command(pluginContext);
@@ -144,20 +147,20 @@ public final class PluginLoader {
    * {@code spice config explain} needs both to tell a misspelt group from one belonging to
    * a plugin that is simply not installed here.
    */
-  private static final java.util.Set<String> CLAIMED_GROUPS =
-      java.util.concurrent.ConcurrentHashMap.newKeySet();
+  private static final Set<String> CLAIMED_GROUPS =
+      ConcurrentHashMap.newKeySet();
 
-  private static final java.util.Set<String> MOUNTED_COMMANDS =
-      java.util.concurrent.ConcurrentHashMap.newKeySet();
+  private static final Set<String> MOUNTED_COMMANDS =
+      ConcurrentHashMap.newKeySet();
 
   /** Groups claimed by the plugins mounted in this run. */
-  static java.util.List<String> claimedGroups() {
-    return java.util.List.copyOf(CLAIMED_GROUPS);
+  static List<String> claimedGroups() {
+    return List.copyOf(CLAIMED_GROUPS);
   }
 
   /** Top-level command names contributed by plugins in this run. */
-  static java.util.List<String> mountedCommands() {
-    return java.util.List.copyOf(MOUNTED_COMMANDS);
+  static List<String> mountedCommands() {
+    return List.copyOf(MOUNTED_COMMANDS);
   }
 
   /**
@@ -168,16 +171,16 @@ public final class PluginLoader {
    * Claiming nothing is the safe failure — the plugin gets no settings, instead of another
    * command's.
    */
-  private static java.util.List<String> safeGroups(SpiceCommandPlugin plugin, String id) {
+  private static List<String> safeGroups(SpiceCommandPlugin plugin, String id) {
     try {
-      java.util.List<String> groups = plugin.configurationGroups();
+      List<String> groups = plugin.configurationGroups();
       if (groups != null) {
         return groups;
       }
     } catch (Throwable e) {
       log.warn("Plugin '{}' could not name its configuration groups: {}", id, e.toString());
     }
-    return java.util.List.of();
+    return List.of();
   }
 
   private static String safeId(SpiceCommandPlugin plugin) {

--- a/src/main/java/io/spicelabs/cli/PluginLoader.java
+++ b/src/main/java/io/spicelabs/cli/PluginLoader.java
@@ -75,10 +75,13 @@ public final class PluginLoader {
           continue;
         }
 
-        // Each plugin gets its own context so it sees only its own table. The command
-        // path is not known until the command has been built and named, so it is bound
-        // just below — before anything executes, which is when a plugin reads it.
-        PluginContext pluginContext = new PluginContext(context, runConfiguration);
+        // Each plugin gets its own context, carrying only the groups it claimed, so it
+        // cannot reach settings meant for another command. The command path is not known
+        // until the command has been built and named, so it is bound just below — before
+        // anything executes, which is when a plugin reads its configuration.
+        java.util.List<String> claimed = safeGroups(plugin, id);
+        CLAIMED_GROUPS.addAll(claimed);
+        PluginContext pluginContext = new PluginContext(context, runConfiguration, claimed);
         Object command = plugin.command(pluginContext);
         if (command == null) {
           log.warn("Skipping plugin '{}': command() returned null", id);
@@ -101,6 +104,7 @@ public final class PluginLoader {
           }
           parentCmd.addSubcommand(name, sub);
           pluginContext.bindCommandPath(parent, name);
+          MOUNTED_COMMANDS.add(parent);
           log.debug("Registered plugin '{}' as '{} {}'", id, parent, name);
           continue;
         }
@@ -111,6 +115,7 @@ public final class PluginLoader {
 
         cmd.addSubcommand(name, sub);
         pluginContext.bindCommandPath(name);
+        MOUNTED_COMMANDS.add(name);
         log.debug("Registered plugin '{}' as subcommand '{}'", id, name);
       } catch (Throwable t) {
         // Error isolation: one misbehaving plugin must never break the CLI.
@@ -129,6 +134,50 @@ public final class PluginLoader {
       return new CommandLine((CommandSpec) command);
     }
     return new CommandLine(command);
+  }
+
+  /**
+   * Every group claimed by a mounted plugin, and every command a plugin mounted.
+   *
+   * <p>Recorded as plugins are registered because the alternative — asking the plugins
+   * again later — would re-run third-party code to answer a question already answered.
+   * {@code spice config explain} needs both to tell a misspelt group from one belonging to
+   * a plugin that is simply not installed here.
+   */
+  private static final java.util.Set<String> CLAIMED_GROUPS =
+      java.util.concurrent.ConcurrentHashMap.newKeySet();
+
+  private static final java.util.Set<String> MOUNTED_COMMANDS =
+      java.util.concurrent.ConcurrentHashMap.newKeySet();
+
+  /** Groups claimed by the plugins mounted in this run. */
+  static java.util.List<String> claimedGroups() {
+    return java.util.List.copyOf(CLAIMED_GROUPS);
+  }
+
+  /** Top-level command names contributed by plugins in this run. */
+  static java.util.List<String> mountedCommands() {
+    return java.util.List.copyOf(MOUNTED_COMMANDS);
+  }
+
+  /**
+   * The groups a plugin claims, or none if it cannot say.
+   *
+   * <p>Defensive in the same way as {@link #safeId}: a plugin is third-party code, and a
+   * throwing accessor should cost that plugin its configuration rather than the whole run.
+   * Claiming nothing is the safe failure — the plugin gets no settings, instead of another
+   * command's.
+   */
+  private static java.util.List<String> safeGroups(SpiceCommandPlugin plugin, String id) {
+    try {
+      java.util.List<String> groups = plugin.configurationGroups();
+      if (groups != null) {
+        return groups;
+      }
+    } catch (Throwable e) {
+      log.warn("Plugin '{}' could not name its configuration groups: {}", id, e.toString());
+    }
+    return java.util.List.of();
   }
 
   private static String safeId(SpiceCommandPlugin plugin) {

--- a/src/main/java/io/spicelabs/cli/RunConfiguration.java
+++ b/src/main/java/io/spicelabs/cli/RunConfiguration.java
@@ -17,45 +17,58 @@ package io.spicelabs.cli;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tomlj.Toml;
 import org.tomlj.TomlParseResult;
-import org.tomlj.TomlTable;
 
+import io.spicelabs.config.Groups;
+import io.spicelabs.config.Resolution;
+import io.spicelabs.config.Resolver;
 import io.spicelabs.goatrodeo.util.TomlTables;
 
 /**
- * The run's configuration file, parsed once.
+ * The run's configuration file, parsed once, and resolved per command.
  *
- * <p>A command's settings live at its own command path — {@code spice survey inventory} reads
- * {@code [survey.inventory]}, the {@code registry} plugin reads {@code [registry]} — and a
- * component a command embeds gets a sub-table named after it. {@code spice} hands each plugin
- * only the table at its own path, so a plugin never sees the file, never learns where its
- * table sits, and never parses TOML that is not its own.
+ * <p>Settings live in <em>groups</em> named for the job rather than for whoever does it —
+ * {@code [analysis]}, {@code [upload]}, {@code [pipeline]}. A group is shared: a value
+ * written once at the top level reaches every command that claims that group, so a user
+ * configures the job and not each component that performs part of it. A same-named table
+ * under a command's path overrides for that command alone, so {@code [registry.analysis]}
+ * beats {@code [analysis]} for {@code spice registry} and nothing else.
  *
- * <p>{@code spice} does not understand the tables it carries. That is the point: it is what
- * keeps this command free of every plugin's schema. The previous attempt at cross-program
- * configuration failed exactly there — an allowlist of another program's flags, maintained
- * here, that drifted until it permitted flags that program does not have.
+ * <p>Which group means what is still none of {@code spice}'s business. That is the property
+ * that keeps this command free of every component's schema, and the previous attempt at
+ * cross-program configuration failed exactly there — an allowlist of another program's
+ * flags, maintained here, that drifted until it permitted flags that program does not have.
  *
- * <p>Tables cross the plugin SPI as plain nested maps of {@code java.*} values, so
- * {@code spice-plugin-api} stays dependency-free. {@link TomlTables#toPlainMap} does that
- * conversion; {@link TomlTable#toMap()} is not usable for it because it is shallow and would
- * leave nested tables as tomlj objects.
+ * <p>What is {@code spice}'s business is deciding which source wins, and saying so. The
+ * layering, the environment-variable naming and the override reporting all live in
+ * {@code spice-config}, in one implementation shared with every component, because rules
+ * copied into three codebases are rules that will disagree.
  */
 final class RunConfiguration {
 
+  private static final Logger log = LoggerFactory.getLogger(RunConfiguration.class);
+
+  /** The environment-variable prefix for settings when running as {@code spice}. */
+  static final String ENVIRONMENT_PREFIX = "SPICE";
+
   /** A run with no configuration file. */
-  static final RunConfiguration EMPTY = new RunConfiguration(null, null);
+  static final RunConfiguration EMPTY = new RunConfiguration(null, Map.of());
 
   private static volatile RunConfiguration current = EMPTY;
 
   private final Path file;
-  private final TomlTable root;
+  private final Map<String, Object> root;
 
-  private RunConfiguration(Path file, TomlTable root) {
+  private RunConfiguration(Path file, Map<String, Object> root) {
     this.file = file;
     this.root = root;
   }
@@ -83,7 +96,7 @@ final class RunConfiguration {
     if (!parsed.errors().isEmpty()) {
       throw new IllegalArgumentException("Invalid config file " + path + ": " + parsed.errors().get(0));
     }
-    RunConfiguration loaded = new RunConfiguration(path, parsed);
+    RunConfiguration loaded = new RunConfiguration(path, TomlTables.toPlainMap(parsed));
     current = loaded;
     return loaded;
   }
@@ -94,7 +107,7 @@ final class RunConfiguration {
    * <p>A process-wide accessor for a process-wide fact, matching
    * {@link DefaultSpiceContext#current()}. Built-in commands need it and picocli constructs
    * them itself, so there is nowhere to hand it in. Plugins do not use this — they are given
-   * their own table through {@link PluginContext}, which is what keeps them from reading
+   * their claimed groups through {@link PluginContext}, which is what keeps them from reading
    * each other's settings.
    */
   static RunConfiguration current() {
@@ -106,21 +119,67 @@ final class RunConfiguration {
     return Optional.ofNullable(file);
   }
 
+  /** The parsed file, for whole-file checks such as {@link Groups#unclaimed}. */
+  Map<String, Object> root() {
+    return root;
+  }
+
   /**
-   * The table at the given command path, as plain {@code java.*} values.
+   * Resolve the groups a command claims.
    *
-   * @param commandPath the command's path, e.g. {@code ["survey", "inventory"]} or
-   *     {@code ["registry"]}
-   * @return the table, or an empty map when there is no config file or no such table
+   * <p>The shared table, then the command-scoped one, then the environment. Command-line
+   * flags are added by the caller afterwards, because only the command knows which of its
+   * options map to which setting.
+   *
+   * @param commandPath the command's path, e.g. {@code ["registry"]} or
+   *     {@code ["survey", "inventory"]}
+   * @param groups the groups that command claims
    */
-  Map<String, Object> tableFor(String... commandPath) {
-    TomlTable table = root;
-    for (String segment : commandPath) {
-      if (table == null) {
-        return Map.of();
-      }
-      table = table.getTable(segment);
+  Resolver resolverFor(List<String> commandPath, Collection<String> groups) {
+    Resolver resolver =
+        new Resolver(ENVIRONMENT_PREFIX, Set.copyOf(groups), message -> log.info("⚙️  {}", message));
+    if (file != null) {
+      resolver.withFile(file, root, commandPath);
     }
-    return table == null ? Map.of() : TomlTables.toPlainMap(table);
+    return resolver.withEnvironment(System.getenv());
+  }
+
+  /**
+   * The resolved values for a command's claimed groups, keyed by group name.
+   *
+   * <p>What crosses the plugin SPI, and what a built-in command hands to the component that
+   * owns the group. A group of settings arrives as a map; a group that names a list of
+   * things — an array of repositories — arrives as that list, since it has no keys to layer.
+   */
+  Map<String, Object> claimedGroups(List<String> commandPath, Collection<String> groups) {
+    Resolution resolved = resolverFor(commandPath, groups).resolve();
+    Map<String, Object> claimed = new java.util.LinkedHashMap<>(resolved.groups());
+    for (String group : groups) {
+      resolved.value(group).ifPresent(whole -> claimed.put(group, whole));
+    }
+    return claimed;
+  }
+
+  /** As {@link #claimedGroups}, but only the groups that are tables of settings. */
+  Map<String, Map<String, Object>> groupsFor(List<String> commandPath, Collection<String> groups) {
+    return resolverFor(commandPath, groups).resolve().groups();
+  }
+
+  /**
+   * Warn about top-level tables no command reads.
+   *
+   * <p>A misspelt group is otherwise perfectly silent: the file parses, the run proceeds, and
+   * the setting does nothing at all. Warned rather than refused, because an unknown table may
+   * belong to a plugin that is not installed in this run, and a shared config file should
+   * stay usable across machines with different plugins.
+   */
+  void warnAboutUnclaimedGroups(Collection<String> claimed, Collection<String> commands) {
+    Groups.describeUnclaimed(Groups.unclaimed(root, claimed, commands))
+        .ifPresent(message -> log.warn("⚠️  {}", message));
+  }
+
+  /** Everything resolved for a command, with provenance, for {@code spice config explain}. */
+  Resolution explain(List<String> commandPath, Collection<String> groups) {
+    return resolverFor(commandPath, groups).resolve();
   }
 }

--- a/src/main/java/io/spicelabs/cli/SpiceLabsCLI.java
+++ b/src/main/java/io/spicelabs/cli/SpiceLabsCLI.java
@@ -47,6 +47,8 @@ import picocli.CommandLine.Command;
         // Tells the host wrapper which arguments are paths to bind-mount, derived from
         // the live command model (plugins included) rather than a hardcoded list.
         PathManifestCommand.class,
+        // Answers "why is it doing that?": every setting, and where its value came from.
+        ConfigCommand.class,
     },
     footer = {
         "",

--- a/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
@@ -23,8 +23,13 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+
+import io.spicelabs.config.Names;
+import io.spicelabs.config.Resolution;
+import io.spicelabs.config.Setting;
 import java.util.Map;
 import java.util.Optional;
 
@@ -101,7 +106,7 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
   Integer threads;
 
   @Option(names = "--max-records", description = "Max records to process per batch (default: 5000)")
-  int maxRecords = 5000;
+  Integer maxRecords;
 
   @Option(names = "--chunk-size", description = "Target chunk size in MB for uploads (default: 64)")
   Integer chunkSizeMB;
@@ -187,12 +192,6 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
       validateTagJson(tagJson);
     }
 
-    if (threads == null) {
-      int availableCores = Runtime.getRuntime().availableProcessors();
-      threads = Math.max(1, Math.round(availableCores / 2.0f));
-      log.info("Using {} threads (half of {} available CPU cores)", threads, availableCores);
-    }
-
     // Resolve output directory
     if (output == null) {
       String userHome = System.getProperty("user.home");
@@ -276,6 +275,47 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
     return survey;
   }
 
+  /**
+   * The configuration groups this command reads.
+   *
+   * <p>Named for the job rather than the component: {@code analysis} is the same group
+   * {@code spice registry} claims, so {@code [analysis] threads = 16} written once in the
+   * config file governs both. Declared here for the same reason a plugin declares its
+   * claims — it is what lets a table nobody reads be reported as a probable typo.
+   */
+  static final List<String> GROUPS = List.of("analysis", "upload", "logging");
+
+  /** Where this command's command-scoped overrides live: {@code [survey.inventory.*]}. */
+  static final List<String> COMMAND_PATH = List.of("survey", "inventory");
+
+  /**
+   * Decide every setting for this run.
+   *
+   * <p>Defaults, then the shared group, then the command-scoped group, then the
+   * environment, then the flags — and any disagreement between two of those is reported as
+   * it is resolved, because this is the only place they meet.
+   *
+   * <p>The flags are <em>bindings onto group keys</em>, not values of their own. That is the
+   * point of the whole exercise: before this, {@code --threads} and
+   * {@code [survey.inventory.analysis] threads} were separate routes to the same engine
+   * setting, and nothing reconciled them.
+   */
+  Resolution resolveSettings() {
+    int cores = Runtime.getRuntime().availableProcessors();
+    long halfTheCores = Math.max(1, Math.round(cores / 2.0f));
+    return RunConfiguration.current()
+        .resolverFor(COMMAND_PATH, GROUPS)
+        .withDefaults(Map.of(
+            "analysis", Map.of("threads", halfTheCores, "max_records", 5000L),
+            "upload", Map.of("target_chunk_size", 64L),
+            "logging", Map.of("level", "INFO")))
+        .withFlag("analysis", "threads", threads, "--threads")
+        .withFlag("analysis", "max_records", maxRecords, "--max-records")
+        .withFlag("upload", "target_chunk_size", chunkSizeMB, "--chunk-size")
+        .withFlag("logging", "level", logLevel, "--log-level")
+        .resolve();
+  }
+
   protected void doSurvey(SurveyRegistration.Context survey, AnalyzeProgressPublisher analyzeProgress)
       throws Exception {
     log.info("📦 Surveying artifacts...");
@@ -306,28 +346,31 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
         payloadDir = singleFileDir;
       }
 
-      String level = (logLevel == null) ? "INFO" : logLevel.toUpperCase();
+      // Every setting this command's components read, from every source, decided in one
+      // place. `--threads` and `--max-records` are bindings onto [analysis] keys rather
+      // than values of their own, so there is one `threads` and not one per route.
+      Resolution settings = resolveSettings();
+
+      String level = settings.setting("logging", "level").map(Setting::asString)
+          .map(String::toUpperCase).orElse("INFO");
       System.setProperty("scala.logging.level", level);
       System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", level);
 
       GoatRodeoBuilder builder = GoatRodeo.builder()
           .withPayload(payloadDir.toString())
           .withOutput(surveyOutput.toString())
-          .withThreads(threads)
-          .withMaxRecords(maxRecords)
           .withStaticMetadata(true)
           .withFsFilePaths(true)
           .withTag(subject)
           .withTempDir(tmpDir.toString())
           .withExtraArgs(goatRodeoArgs);
 
-      // Settings from the config file's [survey.inventory.analysis] table. Applied before
-      // the flags below so an explicit flag still wins, and handed over without spice
-      // knowing what is in it — the analysis engine owns that schema.
-      Map<String, Object> analysis =
-          RunConfiguration.current().tableFor("survey", "inventory", "analysis");
+      // The [analysis] group, handed over without spice knowing what is in it — the
+      // analysis engine owns that schema and rejects a key it does not have, which is why
+      // this command carries no list of the engine's settings.
+      Map<String, Object> analysis = settings.group("analysis");
       if (!analysis.isEmpty()) {
-        builder.withConfiguration(analysis, "survey.inventory.analysis");
+        builder.withConfiguration(analysis, "analysis");
       }
 
       if (tagJson != null && !tagJson.isBlank()) {
@@ -388,16 +431,28 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
       AnalyzeProgressPublisher analyzeProgress) throws Exception {
     log.info("📦 Uploading ADGs...");
 
+    // `--upload-args` takes raw uploader flags: the escape hatch for something this
+    // schema does not model yet. It goes through `extraArgs`, which the uploader applies
+    // *inside* run(), after everything set here — so it wins, as an escape hatch must.
     Map<String, String> gingerArgsMap = new HashMap<>(gingerArgs);
-    if (chunkSizeMB != null && chunkSizeMB > 0) {
-      gingerArgsMap.put("--target-chunk-size", chunkSizeMB.toString());
-      log.info("Using target chunk size: {}MB", chunkSizeMB);
-    }
 
     Ginger ginger = Ginger.builder()
         .jwt(spicePass)
         .adgDir(gingerInputDir.orElse(input))
         .extraArgs(gingerArgsMap);
+
+    // The [upload] group, applied through the uploader's typed setters rather than as
+    // flag strings. Two reasons, and the second is the important one.
+    //
+    // The uploader models these settings properly — `targetChunkSizeMB(Integer)`, not
+    // `--target-chunk-size=64` — so going through the typed API is checked at compile
+    // time and cannot depend on a key name deriving a flag that happens to exist.
+    //
+    // And `extraArgs` is applied inside the uploader's run() and assigns its `jwt` and
+    // `uuid` fields, so anything reaching it overrides the Spice Pass. Forwarding a
+    // config-file group there wholesale would have let `[upload] jwt = "…"` replace the
+    // credential the platform issued — the one thing configuration must never do.
+    applyUploadSettings(ginger, resolveSettings());
 
     if (survey != null) {
       ginger.parentId(survey.parentId())
@@ -536,14 +591,54 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
     System.setProperty("scala.logging.level", levelStr);
   }
 
+  /**
+   * The settings a user may write in {@code [upload]}, and where each one goes.
+   *
+   * <p>A closed list, deliberately. The uploader accepts other arguments — the pass, the
+   * ADG directory, the output path — but those are the run's own, decided by this command
+   * from the pass and the command line, and a config file has no business supplying them.
+   * Anything else in the group is an error naming the key, rather than a flag quietly
+   * forwarded to a program that will warn about it in a log nobody reads.
+   */
+  void applyUploadSettings(Ginger ginger, Resolution settings) {
+    List<String> unknown = new ArrayList<>();
+    settings
+        .group("upload")
+        .forEach(
+            (key, value) -> {
+              Setting setting = settings.setting("upload", key).orElseThrow();
+              switch (key) {
+                case "target_chunk_size" -> ginger.targetChunkSizeMB((int) setting.asLong());
+                case "encrypt_only" -> ginger.encryptOnly(setting.asBoolean());
+                case "skip_key" -> ginger.skipKey(setting.asBoolean());
+                case "comment" -> ginger.comment(setting.asString());
+                case "bundle_format_version" -> ginger.bundleFormatVersion((int) setting.asLong());
+                default -> unknown.add(key);
+              }
+            });
+    if (!unknown.isEmpty()) {
+      throw new IllegalArgumentException(
+          "[upload] has no setting called " + String.join(", ", unknown));
+    }
+  }
+
   private static boolean hasSpicePass(String spicePass) {
     return spicePass != null && !spicePass.isBlank();
   }
 
   /** Encrypt-only runs (via --upload-args) never contact a server, so we skip survey registration. */
   boolean isEncryptOnly() {
-    return gingerArgs.containsKey("--encrypt-only")
-        && !"false".equalsIgnoreCase(gingerArgs.get("--encrypt-only"));
+    // Both ways of saying it: `[upload] encrypt_only = true` and the raw
+    // `--upload-args=--encrypt-only`. A run that never contacts a server must skip
+    // registration however that was said, and the raw flag wins for the same reason it
+    // wins everywhere else.
+    if (gingerArgs.containsKey("--encrypt-only")) {
+      return !"false".equalsIgnoreCase(gingerArgs.get("--encrypt-only"));
+    }
+    return resolveSettings()
+        .setting("upload", "encrypt_only")
+        .map(Setting::asBoolean)
+        .orElse(false);
   }
 
   static void deleteRecursively(Path path) {

--- a/src/test/java/io/spicelabs/cli/ConfigFileTest.java
+++ b/src/test/java/io/spicelabs/cli/ConfigFileTest.java
@@ -4,6 +4,7 @@
 package io.spicelabs.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -60,31 +61,70 @@ class ConfigFileTest {
   }
 
   @Test
-  void aTableIsSlicedByCommandPath(@TempDir Path dir) throws Exception {
+  void aSharedGroupReachesEveryCommandThatClaimsIt(@TempDir Path dir) throws Exception {
+    // The behaviour the whole model exists for: `threads` is written once and both
+    // commands run with it, neither naming a file of its own.
     Path config = Files.writeString(dir.resolve("config.toml"), """
-        [survey.inventory]
-        threads = 4
-
-        [survey.inventory.analysis]
-        max_records = 42
-
-        [registry]
-        anything = "the plugin's own schema"
+        [analysis]
+        threads = 16
         """);
     RunConfiguration run = RunConfiguration.load(config);
 
-    assertEquals(4L, run.tableFor("survey", "inventory").get("threads"));
-    assertEquals(42L, run.tableFor("survey", "inventory", "analysis").get("max_records"));
     assertEquals(
-        "the plugin's own schema", run.tableFor("registry").get("anything"));
+        16L,
+        run.groupsFor(List.of("survey", "inventory"), List.of("analysis")).get("analysis").get("threads"));
+    assertEquals(
+        16L,
+        run.groupsFor(List.of("registry"), List.of("analysis")).get("analysis").get("threads"));
   }
 
   @Test
-  void anAbsentTableIsEmptyRatherThanNull(@TempDir Path dir) throws Exception {
-    Path config = Files.writeString(dir.resolve("config.toml"), "[registry]\nx = 1\n");
+  void aCommandScopedGroupOverridesTheSharedOne(@TempDir Path dir) throws Exception {
+    Path config = Files.writeString(dir.resolve("config.toml"), """
+        [analysis]
+        threads = 16
+        max_records = 42
+
+        [registry.analysis]
+        threads = 4
+        """);
     RunConfiguration run = RunConfiguration.load(config);
-    assertEquals(Map.of(), run.tableFor("survey", "inventory"));
-    assertEquals(Map.of(), run.tableFor("nothing", "here"));
+
+    Map<String, Object> registry =
+        run.groupsFor(List.of("registry"), List.of("analysis")).get("analysis");
+    assertEquals(4L, registry.get("threads"), "the command's own value wins");
+    assertEquals(42L, registry.get("max_records"), "and the rest of the shared group still applies");
+
+    assertEquals(
+        16L,
+        run.groupsFor(List.of("survey", "inventory"), List.of("analysis")).get("analysis").get("threads"),
+        "another command is unaffected");
+  }
+
+  @Test
+  void aCommandCannotReadAGroupItDidNotClaim(@TempDir Path dir) throws Exception {
+    Path config = Files.writeString(dir.resolve("config.toml"), """
+        [analysis]
+        threads = 16
+
+        [upload]
+        chunk_size_mb = 128
+        """);
+    RunConfiguration run = RunConfiguration.load(config);
+
+    Map<String, Map<String, Object>> groups =
+        run.groupsFor(List.of("registry"), List.of("analysis"));
+
+    assertEquals(Map.of("threads", 16L), groups.get("analysis"));
+    assertNull(groups.get("upload"), "a group it did not claim is not there at all");
+  }
+
+  @Test
+  void anAbsentGroupIsEmptyRatherThanNull(@TempDir Path dir) throws Exception {
+    Path config = Files.writeString(dir.resolve("config.toml"), "[analysis]\nthreads = 1\n");
+    RunConfiguration run = RunConfiguration.load(config);
+
+    assertEquals(Map.of(), run.groupsFor(List.of("registry"), List.of("upload")));
   }
 
   @Test
@@ -97,9 +137,9 @@ class ConfigFileTest {
         [registry.analysis]
         threads = 3
         """);
-    Object nested = RunConfiguration.load(config).tableFor("registry").get("analysis");
-    assertTrue(nested instanceof Map, "expected a plain Map, got: " + nested.getClass());
-    assertEquals(3L, ((Map<?, ?>) nested).get("threads"));
+    Object root = RunConfiguration.load(config).root().get("registry");
+    assertTrue(root instanceof Map, "expected a plain Map, got: " + root.getClass());
+    assertTrue(((Map<?, ?>) root).get("analysis") instanceof Map, "and so is the nested table");
   }
 
   @Test

--- a/src/test/java/io/spicelabs/cli/PluginConfigurationTest.java
+++ b/src/test/java/io/spicelabs/cli/PluginConfigurationTest.java
@@ -1,0 +1,194 @@
+package io.spicelabs.cli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.spicelabs.cli.spi.SpiceCommandPlugin;
+import io.spicelabs.cli.spi.SpiceContext;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/**
+ * What a plugin can and cannot see.
+ *
+ * <p>Sharing a group between commands is only safe if a command's reach is declared, so
+ * these are the tests that make claiming mean something: a plugin gets the groups it named,
+ * resolved, and gets nothing else — not another command's settings, and not a group it
+ * forgot to ask for.
+ */
+class PluginConfigurationTest {
+
+  /** A plugin that claims one group, and hands back what it was given. */
+  static class ClaimingPlugin implements SpiceCommandPlugin {
+    private final List<String> groups;
+    SpiceContext context;
+
+    ClaimingPlugin(String... groups) {
+      this.groups = List.of(groups);
+    }
+
+    @Override
+    public String id() {
+      return "claiming-plugin";
+    }
+
+    @Override
+    public List<String> configurationGroups() {
+      return groups;
+    }
+
+    @Override
+    public Object command(SpiceContext context) {
+      this.context = context;
+      return new Noop();
+    }
+
+    @Command(name = "claiming")
+    static class Noop implements Callable<Integer> {
+      @Override
+      public Integer call() {
+        return 0;
+      }
+    }
+  }
+
+  private static RunConfiguration configuration(Path dir, String toml) throws Exception {
+    return RunConfiguration.load(Files.writeString(dir.resolve("config.toml"), toml));
+  }
+
+  private static SpiceContext mount(RunConfiguration run, SpiceCommandPlugin plugin) {
+    CommandLine cmd = new CommandLine(new SpiceLabsCLI());
+    PluginLoader.registerPlugins(cmd, sharedContext(), run, List.of(plugin));
+    return ((ClaimingPlugin) plugin).context;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> group(SpiceContext context, String name) {
+    return (Map<String, Object>) context.configuration().get(name);
+  }
+
+  private static SpiceContext sharedContext() {
+    return new SpiceContext() {
+      @Override
+      public String version() {
+        return "test";
+      }
+
+      @Override
+      public Optional<String> spicePass() {
+        return Optional.empty();
+      }
+    };
+  }
+
+  @Test
+  void aPluginGetsTheGroupsItClaimed(@TempDir Path dir) throws Exception {
+    RunConfiguration run =
+        configuration(
+            dir,
+            """
+            [analysis]
+            threads = 16
+
+            [upload]
+            chunk_size_mb = 128
+            """);
+    ClaimingPlugin plugin = new ClaimingPlugin("analysis");
+
+    Map<String, Object> configuration = mount(run, plugin).configuration();
+
+    assertEquals(Map.of("threads", 16L), configuration.get("analysis"));
+    assertNull(configuration.get("upload"), "a group it did not claim is not delivered");
+  }
+
+  @Test
+  void aPluginClaimingNothingGetsNothing(@TempDir Path dir) throws Exception {
+    RunConfiguration run = configuration(dir, "[analysis]\nthreads = 16\n");
+    ClaimingPlugin plugin = new ClaimingPlugin();
+
+    assertEquals(Map.of(), mount(run, plugin).configuration());
+  }
+
+  @Test
+  void aPluginSeesItsOwnCommandScopedOverride(@TempDir Path dir) throws Exception {
+    RunConfiguration run =
+        configuration(
+            dir,
+            """
+            [analysis]
+            threads = 16
+
+            [claiming.analysis]
+            threads = 2
+            """);
+    ClaimingPlugin plugin = new ClaimingPlugin("analysis");
+
+    assertEquals(2L, group(mount(run, plugin), "analysis").get("threads"));
+  }
+
+  @Test
+  void aPluginDoesNotSeeAnotherCommandsOverride(@TempDir Path dir) throws Exception {
+    RunConfiguration run =
+        configuration(
+            dir,
+            """
+            [analysis]
+            threads = 16
+
+            [registry.analysis]
+            threads = 2
+            """);
+    ClaimingPlugin plugin = new ClaimingPlugin("analysis");
+
+    assertEquals(16L, group(mount(run, plugin), "analysis").get("threads"));
+  }
+
+  @Test
+  void aPluginThatCannotNameItsGroupsStillMounts(@TempDir Path dir) throws Exception {
+    // Third-party code: a throwing accessor costs that plugin its configuration, never the
+    // run. Claiming nothing is the safe failure — no settings beats another command's.
+    RunConfiguration run = configuration(dir, "[analysis]\nthreads = 16\n");
+    SpiceCommandPlugin plugin =
+        new ClaimingPlugin("analysis") {
+          @Override
+          public List<String> configurationGroups() {
+            throw new IllegalStateException("no idea");
+          }
+        };
+
+    CommandLine cmd = new CommandLine(new SpiceLabsCLI());
+    PluginLoader.registerPlugins(cmd, sharedContext(), run, List.of(plugin));
+
+    assertTrue(cmd.getSubcommands().containsKey("claiming"), "the plugin still mounts");
+    assertEquals(Map.of(), ((ClaimingPlugin) plugin).context.configuration());
+  }
+
+  @Test
+  void aGroupNoCommandReadsIsReported(@TempDir Path dir) throws Exception {
+    RunConfiguration run =
+        configuration(
+            dir,
+            """
+            [analysis]
+            threads = 16
+
+            [anaylsis]
+            threads = 16
+            """);
+
+    List<String> unknown =
+        io.spicelabs.config.Groups.unclaimed(
+            run.root(), List.of("analysis", "upload"), List.of("survey", "registry"));
+
+    assertEquals(List.of("anaylsis"), unknown);
+  }
+}

--- a/src/test/java/io/spicelabs/cli/SurveyInventoryCommandTest.java
+++ b/src/test/java/io/spicelabs/cli/SurveyInventoryCommandTest.java
@@ -5,6 +5,7 @@ package io.spicelabs.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
@@ -14,6 +15,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+
+import io.spicelabs.ginger.Ginger;
 
 /**
  * Guards the encrypt-only gate: encrypt-only runs never contact a server, so the command
@@ -98,5 +101,43 @@ class SurveyInventoryCommandTest {
     SurveyInventoryCommand cmd = new SurveyInventoryCommand();
     cmd.gingerArgs = Map.of("--encrypt-only", "false");
     assertFalse(cmd.isEncryptOnly());
+  }
+
+  @Test
+  void anUnknownUploadSettingIsAnError() {
+    // The group is a closed list applied through the uploader's typed setters. Anything
+    // else names itself, rather than being forwarded as a flag the uploader would warn
+    // about in a log nobody reads.
+    SurveyInventoryCommand command = new SurveyInventoryCommand();
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> command.applyUploadSettings(
+                Ginger.builder(),
+                io.spicelabs.config.Resolution.of(
+                    Map.of("upload", Map.of("chunk_size_mb", 64L)),
+                    io.spicelabs.config.Origin.defaultValue())));
+
+    assertTrue(thrown.getMessage().contains("chunk_size_mb"), thrown.getMessage());
+  }
+
+  @Test
+  void theSpicePassCannotBeSetFromConfiguration() {
+    // The uploader applies extraArgs inside run(), where they assign its jwt and uuid
+    // fields — so anything reaching extraArgs overrides the credential the platform
+    // issued. `jwt` is not a setting, and saying so is the check that keeps it that way.
+    SurveyInventoryCommand command = new SurveyInventoryCommand();
+    for (String credential : java.util.List.of("jwt", "uuid")) {
+      IllegalArgumentException thrown =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> command.applyUploadSettings(
+                  Ginger.builder(),
+                  io.spicelabs.config.Resolution.of(
+                      Map.of("upload", Map.of(credential, "forged")),
+                      io.spicelabs.config.Origin.defaultValue())),
+              credential + " must not be settable in [upload]");
+      assertTrue(thrown.getMessage().contains(credential), thrown.getMessage());
+    }
   }
 }


### PR DESCRIPTION
Part of [one configuration model](https://github.com/spice-labs-inc/spice-config).

`--threads` and `[survey.inventory.analysis] threads` were separate routes to the same engine setting. The flag was applied to the builder first and the config table second, so the file silently beat the flag — the opposite of what the comment beside it claimed. It could not have worked either way: `int maxRecords = 5000` and a `threads = halfTheCores` assignment before use meant both flags always looked as though they had been given.

Settings now live in shared groups, flags are bindings onto group keys, and defaults are a layer:

    defaults < [group] < [command.group] < environment < flag

Overrides between two things a person wrote are logged; `spice config explain` prints the lot with an origin per key. A group nobody claims is reported as a probable typo.

The `[upload]` group is a closed list applied through the uploader's typed setters, not forwarded as flag strings: the uploader applies `extraArgs` inside its own `run()`, where they assign its `jwt` field, so a forwarded group would have let `[upload] jwt = "…"` replace the Spice Pass.

`docs/PLUGINS.md` now documents `configuration()` and `configurationGroups()`, which had no prose at all; the README documents `spice config explain`.

Requires spice-plugin-api 2.0.0, released and supplied by spice-bom 1.0.11.