### PR TITLE
Make `--log-file` do what it said it did

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,11 +128,15 @@ part of any configuration. No group may be named `image`, `cache`, `path` or `pa
 ```toml
 [logging]
 level = "debug"          # error, warn, info, debug, trace
-file = "/tmp/spice.log"  # in addition to the console
 ```
 
-`--log-level` and `--log-file` set the same two keys, and so does
-`SPICE_LOGGING_LEVEL`. Every Spice tool reads this group, with the same keys and the same
+`--log-level` sets the same key, and so does `SPICE_LOGGING_LEVEL`.
+
+**`file` is not settable here.** `--log-file` is the wrapper's: it tees the whole run to
+that path on the *host*, which catches output from subprocesses a logging appender inside
+the container would never see. The wrapper mounts the paths it can see on the command line
+and deliberately does not parse TOML, so a path written in this file would be written
+inside the container and lost when it exits. Writing one is an error that says so. Every Spice tool reads this group, with the same keys and the same
 precedence, so a level means one thing wherever it is set and two runs' logs can be read
 side by side.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,6 +123,28 @@ own variables — `SPICE_IMAGE`, `SPICE_CACHE_DIR`, `SPICE_PATH_MANIFEST`, `SPIC
 never be mistaken for settings. They are read on the host before any JVM exists and are not
 part of any configuration. No group may be named `image`, `cache`, `path` or `pass`.
 
+## Logging is a group like any other
+
+```toml
+[logging]
+level = "debug"          # error, warn, info, debug, trace
+file = "/tmp/spice.log"  # in addition to the console
+```
+
+`--log-level` and `--log-file` set the same two keys, and so does
+`SPICE_LOGGING_LEVEL`. Every Spice tool reads this group, with the same keys and the same
+precedence, so a level means one thing wherever it is set and two runs' logs can be read
+side by side.
+
+Standalone components differ only in the prefix: `GOATRODEO_LOGGING_LEVEL`,
+`ALLSPICE_LOGGING_LEVEL`, `SASSAFRAS_LOGGING_LEVEL`, `GINGER_LOGGING_LEVEL`.
+
+Each tool moves only its own loggers. A level says how much *that* program should say, and
+lifting a noisy dependency along with it buries the output you asked for.
+
+A library never applies this: the group is applied by whichever program owns the process,
+because a library reconfiguring its host's logging is a rude surprise.
+
 ## Precedence
 
     defaults  <  [group]  <  [command.group]  <  environment  <  command line

--- a/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
@@ -556,7 +556,7 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
     }
   }
 
-  private void configureLogging() {
+  void configureLogging() {
     Resolution settings = resolveSettings();
     Level level = Level.toLevel(Logging.level(settings), Level.INFO);
     String levelStr = level.toString();
@@ -592,15 +592,49 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
       log.info("Logging level set to {}", level);
     }
 
-    // A file, if one was asked for — shared wiring, so the format matches every other
-    // Spice tool's and two logs can be read side by side. `--log-file` was declared and
-    // never applied before this: the description promised a file and nothing wrote one.
+    // A log file, if one was asked for.
+    //
+    // `--log-file` belongs to the wrapper, which tees the whole run to it on the *host*
+    // and strips the flag before the container ever sees it — so this only fires for a
+    // direct `java -jar` run, where there is no wrapper to do it. The two therefore
+    // cannot both write: whichever is running is the only one that sees the flag.
+    //
+    // A path from the *config file* is refused, in `rejectConfiguredLogFile`, because the
+    // wrapper cannot see inside a TOML table to mount it.
+    rejectConfiguredLogFile();
     LogbackLogging.apply(settings, Logger.ROOT_LOGGER_NAME);
 
     // An *output*, not an input: the Scala components read this property, and it is
     // written once here from the resolved level rather than being a channel anyone
     // configures through.
     System.setProperty("scala.logging.level", levelStr);
+  }
+
+  /**
+   * Refuse {@code [logging] file} written in a configuration file.
+   *
+   * <p>The wrapper mounts the paths it can see on the command line — that is what the path
+   * manifest is for — and it deliberately does not parse TOML, so a path written in a config
+   * file is invisible to it. Under Docker such a file would be written inside the container
+   * and lost when it exits, which is the silent-configuration failure this whole arrangement
+   * exists to prevent.
+   *
+   * <p>Refused rather than warned: a log nobody can read is not a partial success, and the
+   * flag that does work is one word away.
+   */
+  private void rejectConfiguredLogFile() {
+    boolean fromConfigFile =
+        RunConfiguration.current()
+            .root()
+            .containsKey(Logging.GROUP)
+            && RunConfiguration.current().root().get(Logging.GROUP) instanceof Map<?, ?> group
+            && group.containsKey("file");
+    if (fromConfigFile) {
+      throw new IllegalArgumentException(
+          "[logging] file cannot be set in a configuration file — the wrapper mounts only the "
+              + "paths named on the command line, so a file named here would be written inside "
+              + "the container and lost. Use --log-file instead.");
+    }
   }
 
   /**

--- a/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import io.spicelabs.config.LogbackLogging;
+import io.spicelabs.config.Logging;
 import io.spicelabs.config.Names;
 import io.spicelabs.config.Resolution;
 import io.spicelabs.config.Setting;
@@ -313,6 +315,7 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
         .withFlag("analysis", "max_records", maxRecords, "--max-records")
         .withFlag("upload", "target_chunk_size", chunkSizeMB, "--chunk-size")
         .withFlag("logging", "level", logLevel, "--log-level")
+        .withFlag("logging", "file", logFile, "--log-file")
         .resolve();
   }
 
@@ -554,7 +557,8 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
   }
 
   private void configureLogging() {
-    Level level = LogLevelParser.parse(logLevel);
+    Resolution settings = resolveSettings();
+    Level level = Level.toLevel(Logging.level(settings), Level.INFO);
     String levelStr = level.toString();
 
     ch.qos.logback.classic.Logger rootLogger =
@@ -588,6 +592,14 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
       log.info("Logging level set to {}", level);
     }
 
+    // A file, if one was asked for — shared wiring, so the format matches every other
+    // Spice tool's and two logs can be read side by side. `--log-file` was declared and
+    // never applied before this: the description promised a file and nothing wrote one.
+    LogbackLogging.apply(settings, Logger.ROOT_LOGGER_NAME);
+
+    // An *output*, not an input: the Scala components read this property, and it is
+    // written once here from the resolved level rather than being a channel anyone
+    // configures through.
     System.setProperty("scala.logging.level", levelStr);
   }
 

--- a/src/test/java/io/spicelabs/cli/SurveyInventoryCommandTest.java
+++ b/src/test/java/io/spicelabs/cli/SurveyInventoryCommandTest.java
@@ -140,4 +140,28 @@ class SurveyInventoryCommandTest {
       assertTrue(thrown.getMessage().contains(credential), thrown.getMessage());
     }
   }
+
+  @Test
+  void theLogFileFlagBindsOntoTheLoggingGroup() {
+    // It was declared and never applied: the description promised "output appended to both
+    // console and file" and nothing wrote one.
+    SurveyInventoryCommand command = new SurveyInventoryCommand();
+    command.logFile = "/tmp/spice-test.log";
+    command.logLevel = "debug";
+
+    io.spicelabs.config.Resolution settings = command.resolveSettings();
+
+    assertEquals(
+        "/tmp/spice-test.log",
+        io.spicelabs.config.Logging.file(settings).orElseThrow());
+    assertEquals("DEBUG", io.spicelabs.config.Logging.level(settings));
+  }
+
+  @Test
+  void theLoggingGroupSuppliesTheLevelWhenNoFlagDoes() {
+    // So `[logging] level` and SPICE_LOGGING_LEVEL work, not only the flag.
+    SurveyInventoryCommand command = new SurveyInventoryCommand();
+
+    assertEquals("INFO", io.spicelabs.config.Logging.level(command.resolveSettings()));
+  }
 }

--- a/src/test/java/io/spicelabs/cli/SurveyInventoryCommandTest.java
+++ b/src/test/java/io/spicelabs/cli/SurveyInventoryCommandTest.java
@@ -142,6 +142,27 @@ class SurveyInventoryCommandTest {
   }
 
   @Test
+  void aLogFileInAConfigFileIsRefused(@org.junit.jupiter.api.io.TempDir java.nio.file.Path dir)
+      throws Exception {
+    // The wrapper mounts what it can see on the command line and does not parse TOML, so a
+    // path written here would be written inside the container and lost. `--log-file` works.
+    java.nio.file.Path config =
+        java.nio.file.Files.writeString(
+            dir.resolve("config.toml"), "[logging]\nfile = \"/tmp/spice.log\"\n");
+    RunConfiguration.load(config);
+    try {
+      SurveyInventoryCommand command = new SurveyInventoryCommand();
+
+      IllegalArgumentException thrown =
+          assertThrows(IllegalArgumentException.class, command::configureLogging);
+
+      assertTrue(thrown.getMessage().contains("--log-file"), thrown.getMessage());
+    } finally {
+      RunConfiguration.load(null);
+    }
+  }
+
+  @Test
   void theLogFileFlagBindsOntoTheLoggingGroup() {
     // It was declared and never applied: the description promised "output appended to both
     // console and file" and nothing wrote one.


### PR DESCRIPTION
Part of [one configuration model](https://github.com/spice-labs-inc/spice-config).

`--log-file` was declared, described as *"output appended to both console and file"*, and never applied — nothing wrote a file. It binds onto `[logging] file` now, applied through the wiring shared with every other Spice tool, so the format matches and two runs' logs can be read side by side.

The level comes from the resolved group too, so `[logging] level` and `SPICE_LOGGING_LEVEL` work and not only the flag.

`scala.logging.level` stays, but as an **output**: written once from the resolved level rather than being a channel anyone configures through.

**Depends on:** #253