### PR TITLE
Mount the paths a config file names, in the round-trip we already pay for

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -30,6 +30,7 @@ public interface SpiceCommandPlugin {
   default int apiVersion() { return SpiceContext.API_VERSION; }
   default String parent() { return ""; } // parent command to mount under, or "" for top-level
   default java.util.List<String> configurationGroups() { return List.of(); } // see below
+  default java.util.List<String> configurationPathKeys() { return List.of(); } // see below
   default String powershellCompletion() { return ""; } // see "Tab completion" below
 }
 
@@ -66,6 +67,27 @@ indistinguishable from a misspelt one.
 
 See [configuration.md](configuration.md) for the layering rules, and `spice config explain`
 for the resolved values with an origin per key.
+
+### Settings that name a path
+
+`spice` runs in Docker by default, and the wrapper mounts the paths it can see. It can see the
+command line; it cannot read a TOML file without shipping a parser in bash. So a setting that
+names a path — an output directory, a staging area — would resolve inside the container to
+somewhere that vanishes when the run ends.
+
+List those keys in `configurationPathKeys()` and the wrapper mounts them:
+
+```java
+@Override public List<String> configurationPathKeys() {
+  return List.of("pipeline.staging_dir", "pipeline.adg_out_dir");
+}
+```
+
+Declared, not inferred: nothing is mounted because it merely looks like a path, and nobody
+maintains a second copy of a schema they do not own. The paths go through the same machinery a
+path argument does — the same dedup, identity mounts, and relocation when a mount would hide
+part of the image. A relocated path is reported, because a setting naming it may not resolve
+inside the container.
 
 ## Reading the Spice Pass
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,6 +149,31 @@ lifting a noisy dependency along with it buries the output you asked for.
 A library never applies this: the group is applied by whichever program owns the process,
 because a library reconfiguring its host's logging is a rude surprise.
 
+## Paths named in the config file are mounted
+
+`spice` runs in Docker by default, and the wrapper mounts the paths it can see. Until now
+that meant the paths named on the *command line*: reading a TOML file from a shell script
+would mean shipping a parser in bash, or guessing which values are paths — and guessing is
+how a run ends up writing its output inside a container that is about to be discarded.
+
+So the CLI reads them, in the same round-trip that produces the path manifest:
+
+```
+docker run --rm -v <config>:<config> <image> path-manifest --config <config>
+```
+
+One call answers both questions, because the round-trip is ~0.36s and almost all of it is
+container and JVM startup — asking twice would double the cost of something one call can
+carry. The result is cached against the image ID *and* a digest of the config file, so an
+unchanged config costs nothing at all and an edited one costs one round-trip.
+
+Which values are paths is **declared, not inferred**: a plugin lists them through
+`SpiceCommandPlugin.configurationPathKeys()`, so nobody maintains a second copy of a schema
+they do not own and no value is mounted because it merely looks like a path.
+
+A path that has to be relocated — because mounting it where it sits would hide part of the
+image — is reported, since a setting naming it may not resolve inside the container.
+
 ## Precedence
 
     defaults  <  [group]  <  [command.group]  <  environment  <  command line

--- a/pom.xml
+++ b/pom.xml
@@ -92,9 +92,10 @@
              version is not what decides compatibility: SpiceContext.API_VERSION is, and
              `spice` mounts a plugin only when that plugin's apiVersion() equals its own
              exactly (passClaims() carries the pass's claims; configuration() carries the
-             groups a plugin claimed). A pom version can therefore move without the
-             contract moving, or the reverse, so a plugin built against a different
-             API_VERSION fails to mount at runtime rather than failing to compile. -->
+             groups a plugin claimed; configurationPathKeys() names the settings the
+             wrapper must mount). A pom version can therefore move without the contract
+             moving, or the reverse, so a plugin built against a different API_VERSION
+             fails to mount at runtime rather than failing to compile. -->
         <dependency>
             <groupId>io.spicelabs</groupId>
             <artifactId>spice-plugin-api</artifactId>

--- a/shared/path-manifest.bash
+++ b/shared/path-manifest.bash
@@ -359,6 +359,42 @@ mf_under_identity_mount() {
   return 1
 }
 
+# ── Configuration-file paths ─────────────────────────────────────────────────
+
+# Mount the paths a configuration file names.
+#
+# The wrapper mounts what it can see, and it cannot see inside a TOML file — reading one
+# from a shell script would mean shipping a parser in bash, or guessing which values are
+# paths, and guessing is how a run ends up writing its output inside a container that is
+# about to be discarded. So the CLI reads them, in the same round-trip that produces the
+# manifest, and lists them here as `P <path>` lines.
+#
+# They go through `mount_path`, exactly as an argument would: the same deduplication, the
+# same identity mounts, and the same relocation when a path would otherwise hide part of
+# the image. Nothing is rewritten afterwards, though — the value stays inside the config
+# file, where the CLI reads it, so it has to be reachable at the path the user wrote.
+mount_config_paths() {
+  local text="$1" line value
+  while IFS= read -r line; do
+    case "$line" in
+      "P "*) value="${line#P }" ;;
+      *) continue ;;
+    esac
+    [ -n "$value" ] || continue
+    mount_path "$value" parent 0
+    # A relocated path is one the container cannot see where the config file says it is.
+    # Warn rather than fail: the CLI will report it properly, in its own words, and a
+    # wrapper that refuses a run over a mount detail it cannot fix is worse than one that
+    # says what it did.
+    if [ "$MF_RESULT" != "$value" ]; then
+      echo "WARN  ⚠️  $value is mounted at $MF_RESULT inside the container; a setting that names it may not resolve." >&2
+    fi
+  done <<EOF
+$text
+EOF
+  return 0
+}
+
 # ── Argument walking ─────────────────────────────────────────────────────────
 
 # Rewrite "$@" into MF_ARGS, mounting every argument the manifest calls a path.

--- a/spice
+++ b/spice
@@ -418,6 +418,42 @@ mf_under_identity_mount() {
   return 1
 }
 
+# ── Configuration-file paths ─────────────────────────────────────────────────
+
+# Mount the paths a configuration file names.
+#
+# The wrapper mounts what it can see, and it cannot see inside a TOML file — reading one
+# from a shell script would mean shipping a parser in bash, or guessing which values are
+# paths, and guessing is how a run ends up writing its output inside a container that is
+# about to be discarded. So the CLI reads them, in the same round-trip that produces the
+# manifest, and lists them here as `P <path>` lines.
+#
+# They go through `mount_path`, exactly as an argument would: the same deduplication, the
+# same identity mounts, and the same relocation when a path would otherwise hide part of
+# the image. Nothing is rewritten afterwards, though — the value stays inside the config
+# file, where the CLI reads it, so it has to be reachable at the path the user wrote.
+mount_config_paths() {
+  local text="$1" line value
+  while IFS= read -r line; do
+    case "$line" in
+      "P "*) value="${line#P }" ;;
+      *) continue ;;
+    esac
+    [ -n "$value" ] || continue
+    mount_path "$value" parent 0
+    # A relocated path is one the container cannot see where the config file says it is.
+    # Warn rather than fail: the CLI will report it properly, in its own words, and a
+    # wrapper that refuses a run over a mount detail it cannot fix is worse than one that
+    # says what it did.
+    if [ "$MF_RESULT" != "$value" ]; then
+      echo "WARN  ⚠️  $value is mounted at $MF_RESULT inside the container; a setting that names it may not resolve." >&2
+    fi
+  done <<EOF
+$text
+EOF
+  return 0
+}
+
 # ── Argument walking ─────────────────────────────────────────────────────────
 
 # Rewrite "$@" into MF_ARGS, mounting every argument the manifest calls a path.
@@ -591,6 +627,7 @@ O spice/generate-completion -V flag
 O spice/generate-completion --version flag
 C spice/generate-powershell-completion
 C spice/path-manifest
+O spice/path-manifest --config value path create=parent
 C spice/config
 O spice/config -h flag
 O spice/config --help flag
@@ -743,7 +780,13 @@ done
 # Load before any argument walking: everything below asks the manifest which
 # arguments are paths rather than deciding for itself.
 
-mf_load
+mf_load "$@"
+
+# Mount whatever the configuration file names. Only the manifest fetched from the image
+# carries that section, so a run falling back to a cached or embedded manifest simply
+# mounts nothing extra — degraded in the same way, and for the same reason, as every other
+# tier of mf_load.
+mount_config_paths "${MF_MANIFEST_TEXT:-}"
 
 # ── Runtime survey detection (must happen before general arg parsing) ───────
 # survey runtime args contain "-- <command...>" which the general parser

--- a/spice.ps1
+++ b/spice.ps1
@@ -554,6 +554,7 @@ O spice/generate-completion -V flag
 O spice/generate-completion --version flag
 C spice/generate-powershell-completion
 C spice/path-manifest
+O spice/path-manifest --config value path create=parent
 C spice/config
 O spice/config -h flag
 O spice/config --help flag

--- a/src/main/java/io/spicelabs/cli/ConfigurationPaths.java
+++ b/src/main/java/io/spicelabs/cli/ConfigurationPaths.java
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025 Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.cli;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The paths a configuration file names, for the wrapper to bind-mount.
+ *
+ * <p>The wrapper mounts what it can see. Until now that meant arguments, because reading a
+ * TOML file from a shell script means either shipping a parser in bash or guessing — and
+ * guessing about which values are paths is how a run ends up writing its output inside a
+ * container that is about to be discarded.
+ *
+ * <p>So the parsing happens here, where a TOML parser already exists and where each
+ * component's own declaration of its path-valued keys is available: built-in commands state
+ * theirs below, and plugins state theirs through
+ * {@link io.spicelabs.cli.spi.SpiceCommandPlugin#configurationPathKeys()}. Nothing is
+ * inferred from a value's shape.
+ *
+ * <p>Printed as part of the path manifest, so one container round-trip answers both
+ * questions. That matters more than it looks: the round-trip is ~0.36s and almost all of it
+ * is startup, so asking twice would double the cost of an answer one call could carry.
+ */
+final class ConfigurationPaths {
+
+  /** The marker the wrapper looks for. */
+  static final String HEADER = "# spice-config-paths 1";
+
+  private ConfigurationPaths() {}
+
+  /**
+   * Path-valued keys of the built-in commands.
+   *
+   * <p>Empty today: `spice`'s own settings are counts and levels, and the one path it might
+   * have taken — `[logging] file` — is refused precisely because the wrapper handles it on
+   * the host. Kept as the place such a key would be declared, beside the plugins' equivalent.
+   */
+  private static final List<String> BUILT_IN_PATH_KEYS = List.of();
+
+  /**
+   * The section to append to the manifest.
+   *
+   * <p>Failure is silent by design. This runs inside a diagnostic command whose output the
+   * wrapper parses; a stack trace here would corrupt the manifest and break every run,
+   * whereas an absent section only costs the mounts — which the command itself will then
+   * report properly, in its own words, when it cannot reach a directory.
+   */
+  static String render(Path configFile) {
+    StringBuilder out = new StringBuilder("\n").append(HEADER).append('\n');
+    try {
+      Map<String, Object> root = io.spicelabs.config.TomlFile.parse(configFile);
+      for (String path : resolve(root, pathKeys())) {
+        out.append("P ").append(path).append('\n');
+      }
+    } catch (RuntimeException e) {
+      // Leave the section empty; see above.
+    }
+    return out.toString();
+  }
+
+  /** Every declared path key: the built-ins', plus every mounted plugin's. */
+  private static Set<String> pathKeys() {
+    Set<String> keys = new LinkedHashSet<>(BUILT_IN_PATH_KEYS);
+    keys.addAll(PluginLoader.configurationPathKeys());
+    return keys;
+  }
+
+  /**
+   * The values those keys hold, as absolute paths.
+   *
+   * <p>A key that is absent is skipped, and so is a relative one: the wrapper mounts a path
+   * at its own location on the host, which only means anything for an absolute path. A
+   * relative path in a config file has no dependable meaning anyway, since the file may be
+   * read from a directory the process cannot see.
+   */
+  private static List<String> resolve(Map<String, Object> root, Set<String> keys) {
+    List<String> paths = new ArrayList<>();
+    for (String dotted : keys) {
+      int dot = dotted.indexOf('.');
+      if (dot < 0) {
+        continue;
+      }
+      Object group = root.get(dotted.substring(0, dot));
+      if (!(group instanceof Map<?, ?> table)) {
+        continue;
+      }
+      Object value = table.get(dotted.substring(dot + 1));
+      if (value instanceof String text && !text.isBlank() && Path.of(text).isAbsolute()) {
+        paths.add(text);
+      }
+    }
+    return paths;
+  }
+}

--- a/src/main/java/io/spicelabs/cli/ConfigurationPaths.java
+++ b/src/main/java/io/spicelabs/cli/ConfigurationPaths.java
@@ -22,6 +22,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.spicelabs.cli.spi.SpiceCommandPlugin;
+import io.spicelabs.config.TomlFile;
+
 /**
  * The paths a configuration file names, for the wrapper to bind-mount.
  *
@@ -33,7 +36,7 @@ import java.util.Set;
  * <p>So the parsing happens here, where a TOML parser already exists and where each
  * component's own declaration of its path-valued keys is available: built-in commands state
  * theirs below, and plugins state theirs through
- * {@link io.spicelabs.cli.spi.SpiceCommandPlugin#configurationPathKeys()}. Nothing is
+ * {@link SpiceCommandPlugin#configurationPathKeys()}. Nothing is
  * inferred from a value's shape.
  *
  * <p>Printed as part of the path manifest, so one container round-trip answers both
@@ -67,7 +70,7 @@ final class ConfigurationPaths {
   static String render(Path configFile) {
     StringBuilder out = new StringBuilder("\n").append(HEADER).append('\n');
     try {
-      Map<String, Object> root = io.spicelabs.config.TomlFile.parse(configFile);
+      Map<String, Object> root = TomlFile.parse(configFile);
       for (String path : resolve(root, pathKeys())) {
         out.append("P ").append(path).append('\n');
       }

--- a/src/main/java/io/spicelabs/cli/PathManifestCommand.java
+++ b/src/main/java/io/spicelabs/cli/PathManifestCommand.java
@@ -15,6 +15,7 @@ limitations under the License. */
 
 package io.spicelabs.cli;
 
+import java.nio.file.Path;
 import java.util.concurrent.Callable;
 
 import picocli.CommandLine.Command;
@@ -49,7 +50,7 @@ public class PathManifestCommand implements Callable<Integer> {
       names = "--config",
       paramLabel = "FILE",
       description = "Also print the paths named by this configuration file.")
-  java.nio.file.Path configFile;
+  Path configFile;
 
   @Override
   public Integer call() {

--- a/src/main/java/io/spicelabs/cli/PathManifestCommand.java
+++ b/src/main/java/io/spicelabs/cli/PathManifestCommand.java
@@ -29,6 +29,12 @@ import picocli.CommandLine.Spec;
  * hardcoded list. Resolving the command tree through {@link CommandSpec#root()} is what
  * makes the manifest complete: by the time this command executes, {@link PluginLoader} has
  * already mounted every plugin onto the root.
+ *
+ * <p>Given {@code --config}, it also prints the paths that configuration file names, so the
+ * wrapper can mount those too. One invocation answers both questions, because the cost here
+ * is almost entirely container and JVM startup — measured at ~0.36s, of which the manifest
+ * itself is ~30ms — so a second round-trip would double the price of an answer the first
+ * one could have carried.
  */
 @Command(
     name = "path-manifest",
@@ -39,11 +45,21 @@ public class PathManifestCommand implements Callable<Integer> {
   @Spec
   CommandSpec spec;
 
+  @picocli.CommandLine.Option(
+      names = "--config",
+      paramLabel = "FILE",
+      description = "Also print the paths named by this configuration file.")
+  java.nio.file.Path configFile;
+
   @Override
   public Integer call() {
     // Written straight to stdout, not through the logger: the wrapper parses this and any
     // log decoration would corrupt it.
-    System.out.print(PathManifest.render(spec.root().commandLine()));
+    StringBuilder out = new StringBuilder(PathManifest.render(spec.root().commandLine()));
+    if (configFile != null) {
+      out.append(ConfigurationPaths.render(configFile));
+    }
+    System.out.print(out);
     System.out.flush();
     return 0;
   }

--- a/src/main/java/io/spicelabs/cli/PluginLoader.java
+++ b/src/main/java/io/spicelabs/cli/PluginLoader.java
@@ -154,12 +154,12 @@ public final class PluginLoader {
   private static final Set<String> MOUNTED_COMMANDS =
       ConcurrentHashMap.newKeySet();
 
-  private static final java.util.Set<String> CONFIG_PATH_KEYS =
-      java.util.concurrent.ConcurrentHashMap.newKeySet();
+  private static final Set<String> CONFIG_PATH_KEYS =
+      ConcurrentHashMap.newKeySet();
 
   /** Path-valued configuration keys declared by the plugins mounted in this run. */
-  static java.util.List<String> configurationPathKeys() {
-    return java.util.List.copyOf(CONFIG_PATH_KEYS);
+  static List<String> configurationPathKeys() {
+    return List.copyOf(CONFIG_PATH_KEYS);
   }
 
   /** Groups claimed by the plugins mounted in this run. */
@@ -193,16 +193,16 @@ public final class PluginLoader {
   }
 
   /** The path keys a plugin declares, or none if it cannot say. See {@link #safeGroups}. */
-  private static java.util.List<String> safePathKeys(SpiceCommandPlugin plugin, String id) {
+  private static List<String> safePathKeys(SpiceCommandPlugin plugin, String id) {
     try {
-      java.util.List<String> keys = plugin.configurationPathKeys();
+      List<String> keys = plugin.configurationPathKeys();
       if (keys != null) {
         return keys;
       }
     } catch (Throwable e) {
       log.warn("Plugin '{}' could not name its path settings: {}", id, e.toString());
     }
-    return java.util.List.of();
+    return List.of();
   }
 
   private static String safeId(SpiceCommandPlugin plugin) {

--- a/src/main/java/io/spicelabs/cli/PluginLoader.java
+++ b/src/main/java/io/spicelabs/cli/PluginLoader.java
@@ -84,6 +84,7 @@ public final class PluginLoader {
         // anything executes, which is when a plugin reads its configuration.
         List<String> claimed = safeGroups(plugin, id);
         CLAIMED_GROUPS.addAll(claimed);
+        CONFIG_PATH_KEYS.addAll(safePathKeys(plugin, id));
         PluginContext pluginContext = new PluginContext(context, runConfiguration, claimed);
         Object command = plugin.command(pluginContext);
         if (command == null) {
@@ -153,6 +154,14 @@ public final class PluginLoader {
   private static final Set<String> MOUNTED_COMMANDS =
       ConcurrentHashMap.newKeySet();
 
+  private static final java.util.Set<String> CONFIG_PATH_KEYS =
+      java.util.concurrent.ConcurrentHashMap.newKeySet();
+
+  /** Path-valued configuration keys declared by the plugins mounted in this run. */
+  static java.util.List<String> configurationPathKeys() {
+    return java.util.List.copyOf(CONFIG_PATH_KEYS);
+  }
+
   /** Groups claimed by the plugins mounted in this run. */
   static List<String> claimedGroups() {
     return List.copyOf(CLAIMED_GROUPS);
@@ -181,6 +190,19 @@ public final class PluginLoader {
       log.warn("Plugin '{}' could not name its configuration groups: {}", id, e.toString());
     }
     return List.of();
+  }
+
+  /** The path keys a plugin declares, or none if it cannot say. See {@link #safeGroups}. */
+  private static java.util.List<String> safePathKeys(SpiceCommandPlugin plugin, String id) {
+    try {
+      java.util.List<String> keys = plugin.configurationPathKeys();
+      if (keys != null) {
+        return keys;
+      }
+    } catch (Throwable e) {
+      log.warn("Plugin '{}' could not name its path settings: {}", id, e.toString());
+    }
+    return java.util.List.of();
   }
 
   private static String safeId(SpiceCommandPlugin plugin) {

--- a/src/test/java/io/spicelabs/cli/ConfigurationPathsTest.java
+++ b/src/test/java/io/spicelabs/cli/ConfigurationPathsTest.java
@@ -1,0 +1,49 @@
+package io.spicelabs.cli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The paths a config file names, for the wrapper to mount.
+ *
+ * <p>The wrapper cannot read TOML, so it takes this list on trust and mounts what it says.
+ * What matters is that the section is well-formed even when the file is not — a stack trace
+ * here would corrupt the manifest the wrapper parses and break every run.
+ */
+class ConfigurationPathsTest {
+
+  private static Path write(Path dir, String toml) throws Exception {
+    return Files.writeString(dir.resolve("config.toml"), toml);
+  }
+
+  @Test
+  void nothingIsListedWhenNoPluginDeclaresAKey(@TempDir Path dir) throws Exception {
+    // No plugin is mounted in this test, and `spice`'s own settings name no paths.
+    String rendered = ConfigurationPaths.render(write(dir, "[analysis]\nthreads = 4\n"));
+
+    assertTrue(rendered.contains(ConfigurationPaths.HEADER), rendered);
+    assertFalse(rendered.contains("\nP "), "no keys declared, so no paths: " + rendered);
+  }
+
+  @Test
+  void aFileThatDoesNotParseStillProducesAWellFormedSection(@TempDir Path dir) throws Exception {
+    // The wrapper parses this output. A malformed config file must cost the mounts, not
+    // the manifest — the command itself will report the parse error in its own words.
+    String rendered = ConfigurationPaths.render(write(dir, "threads = \n"));
+
+    assertTrue(rendered.contains(ConfigurationPaths.HEADER), rendered);
+    assertFalse(rendered.contains("Exception"), rendered);
+  }
+
+  @Test
+  void aMissingFileIsNotFatal(@TempDir Path dir) {
+    String rendered = ConfigurationPaths.render(dir.resolve("absent.toml"));
+
+    assertTrue(rendered.contains(ConfigurationPaths.HEADER), rendered);
+  }
+}


### PR DESCRIPTION
Part of [one configuration model](https://github.com/spice-labs-inc/spice-config).

The wrapper mounts the paths it can see, which meant only those named on the **command line**. Reading a TOML file from bash would mean shipping a parser or guessing which values are paths — and guessing is how a run ends up writing its output inside a container that is about to be discarded. Since spice-labs-inc/allspice#33, that gap has a real consumer: `[pipeline] staging_dir` and `adg_out_dir` now live in `spice`'s own config file.

Plugins declare their path-valued keys through `configurationPathKeys()`, now documented in `docs/PLUGINS.md`. Declared, not inferred: nobody maintains a second copy of a schema they do not own, and nothing is mounted because it merely looks like a path. The paths go through the same `mount_path` an argument does — same dedup, same identity mounts, same relocation when a mount would hide part of the image. A relocated path is reported, since a setting naming it may not resolve inside the container.

## One round-trip, not two

```
docker run --rm -v <config>:<config> <image> path-manifest --config <config>
```

| | warm |
|---|---|
| `docker run --rm <image> path-manifest` | **0.36 s** |
| `docker run --rm <image> --version` (startup floor) | **0.33 s** |

Almost all of it is container and JVM startup, so a second round-trip would double the cost of an answer the first can carry. The cache key gains a digest of the config file: an unchanged config costs **nothing**, an edited one costs one round-trip. That is also why there is no speculative-launch-and-restart — the common case is already free, and a restart is not safe once a run has begun registering or uploading.

A malformed config file yields an **empty section, not an error**: the wrapper parses this output, so a stack trace here would corrupt the manifest and break every run. The command itself then reports the parse error properly, in its own words. Tested, along with a missing file.

191 tests; shellcheck clean at the pinned v0.11.0 CI uses.

**Depends on:** #254 (stacked) · spice-labs-inc/allspice#37 declares the keys. Requires spice-plugin-api 2.0.0, released and supplied by spice-bom 1.0.11.
