### PR TITLE
Name the two survey options for what they do

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ spice pass decode
 | `--threads` | Number of threads to use | half of available CPU cores |
 | `--max-records` | Max records to process per batch | `5000` |
 | `--chunk-size` | Target chunk size in MB for uploads | `64` |
-| `--goat-rodeo-args` | Additional GoatRodeo args in key=value format | _(none)_ |
-| `--ginger-args` | Additional Ginger args in key=value format | _(none)_ |
+| `--analysis-args` | Additional analysis args in key=value format | _(none)_ |
+| `--upload-args` | Additional upload args in key=value format | _(none)_ |
 
 ### Runtime Survey
 

--- a/spice
+++ b/spice
@@ -551,8 +551,8 @@ O spice/survey/inventory --max-records value
 O spice/survey/inventory --chunk-size value
 O spice/survey/inventory --log-level value
 O spice/survey/inventory --log-file value hostonly
-O spice/survey/inventory --goat-rodeo-args value
-O spice/survey/inventory --ginger-args value
+O spice/survey/inventory --analysis-args value
+O spice/survey/inventory --upload-args value
 O spice/survey/inventory -h flag
 O spice/survey/inventory --help flag
 O spice/survey/inventory -V flag

--- a/spice.ps1
+++ b/spice.ps1
@@ -514,8 +514,8 @@ O spice/survey/inventory --max-records value
 O spice/survey/inventory --chunk-size value
 O spice/survey/inventory --log-level value
 O spice/survey/inventory --log-file value hostonly
-O spice/survey/inventory --goat-rodeo-args value
-O spice/survey/inventory --ginger-args value
+O spice/survey/inventory --analysis-args value
+O spice/survey/inventory --upload-args value
 O spice/survey/inventory -h flag
 O spice/survey/inventory --help flag
 O spice/survey/inventory -V flag

--- a/src/main/java/io/spicelabs/cli/GeneratePowershellCompletion.java
+++ b/src/main/java/io/spicelabs/cli/GeneratePowershellCompletion.java
@@ -67,7 +67,7 @@ public class GeneratePowershellCompletion implements Callable<Integer> {
       $SpiceCompletions = @{
         survey = @{
           __sub     = @('inventory', 'runtime')
-          inventory = @('--output', '--no-upload', '--upload-only', '--threads', '--max-records', '--chunk-size', '--log-level', '--tag-json', '--goat-rodeo-args', '--ginger-args', '--help')
+          inventory = @('--output', '--no-upload', '--upload-only', '--threads', '--max-records', '--chunk-size', '--log-level', '--tag-json', '--analysis-args', '--upload-args', '--help')
           runtime   = @('--jfr', '--no-upload', '--native-only', '--keep-recording', '--anchor', '--output', '--log-level', '--help')
         }
         pass = @{

--- a/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
@@ -111,15 +111,15 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
   String logFile;
 
   @Option(
-      names = "--goat-rodeo-args",
-      description = "Additional GoatRodeo args in key=value format",
+      names = "--analysis-args",
+      description = "Additional analysis args in key=value format",
       split = ","
   )
   List<String> goatRodeoArgsRaw;
 
   @Option(
-      names = "--ginger-args",
-      description = "Additional Ginger args in key=value format",
+      names = "--upload-args",
+      description = "Additional upload args in key=value format",
       split = ","
   )
   List<String> gingerArgsRaw;
@@ -276,7 +276,7 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
 
   protected void doSurvey(SurveyRegistration.Context survey, AnalyzeProgressPublisher analyzeProgress)
       throws Exception {
-    log.info("📦 Surveying artifacts with GoatRodeo...");
+    log.info("📦 Surveying artifacts...");
 
     String originalScalaLevel = System.getProperty("scala.logging.level");
     String originalSlf4jLevel = System.getProperty("org.slf4j.simpleLogger.defaultLogLevel");
@@ -477,7 +477,7 @@ public class SurveyInventoryCommand implements java.util.concurrent.Callable<Int
     return spicePass != null && !spicePass.isBlank();
   }
 
-  /** Encrypt-only runs (via --ginger-args) never contact a server, so we skip survey registration. */
+  /** Encrypt-only runs (via --upload-args) never contact a server, so we skip survey registration. */
   boolean isEncryptOnly() {
     return gingerArgs.containsKey("--encrypt-only")
         && !"false".equalsIgnoreCase(gingerArgs.get("--encrypt-only"));

--- a/src/test/java/io/spicelabs/cli/SpiceLabsCLITest.java
+++ b/src/test/java/io/spicelabs/cli/SpiceLabsCLITest.java
@@ -408,7 +408,7 @@ class SpiceLabsCLITest {
     int rc = cmd.execute("survey", "inventory",
         "test-subject", inputDir.toString(),
         "--no-upload", "--output", outputDir.toString(),
-        "--goat-rodeo-args=maxRecords=10,tempDir=/tmp/test");
+        "--analysis-args=maxRecords=10,tempDir=/tmp/test");
 
     assertEquals(0, rc);
   }


### PR DESCRIPTION
Part of [one configuration model](https://github.com/spice-labs-inc/spice-config). This trivially renames `--goat-rodeo` to `--analysis`, and gets the ball rolling on several related changes.

`--goat-rodeo-args` and `--ginger-args` named internal components in `spice`'s own command line; they become `--analysis-args` and `--upload-args`. The per-run log line naming the analysis engine drops the name too. Note that these will be generalized through configuration options as a later step.

Which component performs a step is not something a user needs to know, and a flag named after one is wrong the moment it is replaced.

**Breaking change:** the old aliases are not kept. A hidden alias would leave the internal name discoverable in scripts and error messages.

Both are string options, so the wrappers' embedded path manifests are regenerated.

Unstacked from the configuration series so it can merge on its own: it is a pure rename of options that already exist, and it depends on nothing above it. **Depends on:** #247 (stacked). Docs follow in spice-labs-inc/internal-docs#650.