### PR TITLE
Declare where spice-config is published

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,7 @@ jobs:
               <server><id>github-spice-labs-ginger</id><username>'"$GH_USERNAME_SG"'</username><password>'"$GH_TOKEN"'</password></server>
               <server><id>github-spice-labs-bom</id><username>'"$GH_USERNAME_SG"'</username><password>'"$GH_TOKEN"'</password></server>
               <server><id>github-spice-labs-plugin-api</id><username>'"$GH_USERNAME_SG"'</username><password>'"$GH_TOKEN"'</password></server>
+              <server><id>github-spice-labs-config</id><username>'"$GH_USERNAME_SG"'</username><password>'"$GH_TOKEN"'</password></server>
               <server><id>github</id><username>'"$GH_USERNAME_SG"'</username><password>'"$GH_TOKEN"'</password></server>
               <server><id>central</id><username>'"$MAVEN_CENTRAL_USERNAME"'</username><password>'"$MAVEN_CENTRAL_PASSWORD"'</password></server>
             </servers>
@@ -141,6 +142,7 @@ jobs:
                   <repository><id>github-spice-labs-ginger</id><url>https://maven.pkg.github.com/spice-labs-inc/ginger-j</url></repository>
                   <repository><id>github-spice-labs-bom</id><url>https://maven.pkg.github.com/spice-labs-inc/spice-bom</url><snapshots><enabled>true</enabled></snapshots></repository>
                   <repository><id>github-spice-labs-plugin-api</id><url>https://maven.pkg.github.com/spice-labs-inc/spice-plugin-api</url><snapshots><enabled>true</enabled></snapshots></repository>
+                  <repository><id>github-spice-labs-config</id><url>https://maven.pkg.github.com/spice-labs-inc/spice-config</url><snapshots><enabled>true</enabled></snapshots></repository>
                 </repositories>
               </profile>
             </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -373,6 +373,11 @@
                     <url>https://maven.pkg.github.com/spice-labs-inc/spice-plugin-api</url>
                     <snapshots><enabled>true</enabled></snapshots>
                 </repository>
+                <repository>
+                    <id>github-spice-labs-config</id>
+                    <url>https://maven.pkg.github.com/spice-labs-inc/spice-config</url>
+                    <snapshots><enabled>true</enabled></snapshots>
+                </repository>
             </repositories>
         </profile>
 


### PR DESCRIPTION
Every build depending on `io.spicelabs:spice-config` fails to resolve it:

```
Could not find artifact io.spicelabs:spice-config:jar:0.1.0-SNAPSHOT
```

The library publishes to GitHub Packages under its own repo on every push to its `main`, and those runs are green — nothing here ever looked there.

GitHub Packages needs authentication even for public reads, so the `<repository>` needs a matching `<server>` id in the settings.xml `build.yml` writes. Both are added, alongside the four io.spicelabs repositories already declared there.

On `main` rather than in the configuration series: every branch in that series needs it, and none can go green until it lands. Unblocks #250, #251, #253, #254 and #255.