### PR TITLE
Bump ancho to 0.0.8 for probe class stamping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
              inherits it. ancho is versioned here (NOT in the BOM): it is injected
              via -javaagent, never on the CLI's own classpath. -->
         <spice-bom.version>1.0.7</spice-bom.version>
-        <ancho.version>0.0.7</ancho.version>
+        <ancho.version>0.0.8</ancho.version>
         <!--        Use this version for local dev-->
         <!--        <ancho.version>0.0.1-SNAPSHOT</ancho.version> -->
         <junit.jupiter.version>5.13.1</junit.jupiter.version>


### PR DESCRIPTION
Agent stamps probe events with declaring and caller class gitoids; runtime surveys attribute crypto to the jar it ran in. Consumer side already shipped.