### PR TITLE
Remove `syft` from the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,7 @@ WORKDIR /opt/spice-labs-cli
 # builds default to "unknown").
 ENV SPICE_VERSION=${VERSION}
 
-COPY --from=anchore/syft:v1.30.0 /syft /usr/bin/syft
+COPY --from=anchore/syft:v1.51.0 /syft /usr/bin/syft
 COPY --from=builder /workspace/target/*-fat.jar ./spice-labs-cli.jar
 COPY --from=builder /workspace/target/ancho.jar ./ancho.jar
 # Plugin jars (empty in a public build); placed on the classpath alongside the CLI.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #              image (see .github/workflows/build.yml).
 #   builder  — compiles spice-labs-cli + assembles the fat JAR + stages ancho.
 #              Built FROM deps so the Maven cache is already warm.
-#   spice    — runtime image: JRE + fat JAR + syft + JFR config + wrapper scripts.
+#   spice    — runtime image: JRE + fat JAR + JFR config + wrapper scripts.
 #   test     — deps + runs `mvn verify`. Used by CI so tests run against the
 #              exact dependency image that produced the runtime JAR.
 #
@@ -23,9 +23,8 @@ WORKDIR /workspace
 
 ENV MAVEN_CONFIG="-B -ntp"
 
-# Install Maven + the OS deps the runtime image will need later (syft is added
-# in the runtime stage via a COPY --from). git is required by the
-# git-commit-id-maven-plugin at build time.
+# Install Maven + the OS deps the runtime image will need later. git is
+# required by the git-commit-id-maven-plugin at build time.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl git maven \
         bash coreutils findutils \
@@ -138,8 +137,7 @@ CMD ["verify"]
 
 # ---- runtime ----------------------------------------------------------------
 # Slim runtime: JRE only, no JDK, no Maven. The fat JAR is the only artifact;
-# syft is layered in for SBOM generation; the JFR config and wrapper scripts
-# mirror what the install/release flow ships.
+# the JFR config and wrapper scripts mirror what the install/release flow ships.
 FROM eclipse-temurin:21-jre AS spice
 ARG VERSION="unknown"
 WORKDIR /opt/spice-labs-cli
@@ -148,7 +146,6 @@ WORKDIR /opt/spice-labs-cli
 # builds default to "unknown").
 ENV SPICE_VERSION=${VERSION}
 
-COPY --from=anchore/syft:v1.51.0 /syft /usr/bin/syft
 COPY --from=builder /workspace/target/*-fat.jar ./spice-labs-cli.jar
 COPY --from=builder /workspace/target/ancho.jar ./ancho.jar
 # Plugin jars (empty in a public build); placed on the classpath alongside the CLI.


### PR DESCRIPTION
### Summary

I upgraded `syft` to avoid a transitive vulnerability, but later realized it isn't needed except in images that include Allspice. The upgrade will move to the Enterprise image build.

### Changes

- **Upgrade syft to version 0.51.0, to avoid x/crypto vulnerabilities** (superceded)
- **Remove `syft` (saving 80MB in the image) since it's not needed except with Allspice**
