### PR TITLE
Extend the copyright line to 2025-26

### DIFF
--- a/scripts/update-path-manifest.sh
+++ b/scripts/update-path-manifest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Spice Labs, Inc. & Contributors
+# Copyright 2025-26 Spice Labs, Inc. & Contributors
 #
 # Regenerates the two spliced regions in the wrapper scripts:
 #

--- a/shared/path-manifest.bash
+++ b/shared/path-manifest.bash
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Spice Labs, Inc. & Contributors
+# Copyright 2025-26 Spice Labs, Inc. & Contributors
 #
 # ─────────────────────────────────────────────────────────────────────────────
 # Path-manifest driven argument walking.

--- a/shared/path-manifest.ps1
+++ b/shared/path-manifest.ps1
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Spice Labs, Inc. & Contributors
+# Copyright 2025-26 Spice Labs, Inc. & Contributors
 #
 # ─────────────────────────────────────────────────────────────────────────────
 # Path-manifest driven argument walking — PowerShell mirror of

--- a/spice
+++ b/spice
@@ -58,7 +58,7 @@ fi
 
 # ── BEGIN SHARED path-manifest.bash ──
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Spice Labs, Inc. & Contributors
+# Copyright 2025-26 Spice Labs, Inc. & Contributors
 #
 # ─────────────────────────────────────────────────────────────────────────────
 # Path-manifest driven argument walking.

--- a/spice.ps1
+++ b/spice.ps1
@@ -85,7 +85,7 @@ function Convert-ToDockerPath($path) {
 
 # ── BEGIN SHARED path-manifest.ps1 ──
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Spice Labs, Inc. & Contributors
+# Copyright 2025-26 Spice Labs, Inc. & Contributors
 #
 # ─────────────────────────────────────────────────────────────────────────────
 # Path-manifest driven argument walking — PowerShell mirror of

--- a/src/main/java/io/spicelabs/cli/AnalyzeProgressPublisher.java
+++ b/src/main/java/io/spicelabs/cli/AnalyzeProgressPublisher.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 

--- a/src/main/java/io/spicelabs/cli/ArgParser.java
+++ b/src/main/java/io/spicelabs/cli/ArgParser.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/io/spicelabs/cli/DefaultSpiceContext.java
+++ b/src/main/java/io/spicelabs/cli/DefaultSpiceContext.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/io/spicelabs/cli/GeneratePowershellCompletion.java
+++ b/src/main/java/io/spicelabs/cli/GeneratePowershellCompletion.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/io/spicelabs/cli/JdkVersionDetector.java
+++ b/src/main/java/io/spicelabs/cli/JdkVersionDetector.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 

--- a/src/main/java/io/spicelabs/cli/JfrEventExtractor.java
+++ b/src/main/java/io/spicelabs/cli/JfrEventExtractor.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 

--- a/src/main/java/io/spicelabs/cli/JfrProgressCallback.java
+++ b/src/main/java/io/spicelabs/cli/JfrProgressCallback.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 

--- a/src/main/java/io/spicelabs/cli/LogLevelParser.java
+++ b/src/main/java/io/spicelabs/cli/LogLevelParser.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/io/spicelabs/cli/PassCommand.java
+++ b/src/main/java/io/spicelabs/cli/PassCommand.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/io/spicelabs/cli/PassDecodeCommand.java
+++ b/src/main/java/io/spicelabs/cli/PassDecodeCommand.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/io/spicelabs/cli/PathManifest.java
+++ b/src/main/java/io/spicelabs/cli/PathManifest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/io/spicelabs/cli/PathManifestCommand.java
+++ b/src/main/java/io/spicelabs/cli/PathManifestCommand.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/io/spicelabs/cli/PathTranslator.java
+++ b/src/main/java/io/spicelabs/cli/PathTranslator.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/io/spicelabs/cli/PluginLoader.java
+++ b/src/main/java/io/spicelabs/cli/PluginLoader.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/io/spicelabs/cli/RuntimeCollect.java
+++ b/src/main/java/io/spicelabs/cli/RuntimeCollect.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 

--- a/src/main/java/io/spicelabs/cli/SpiceLabsCLI.java
+++ b/src/main/java/io/spicelabs/cli/SpiceLabsCLI.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/io/spicelabs/cli/SpicePassDecoder.java
+++ b/src/main/java/io/spicelabs/cli/SpicePassDecoder.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/io/spicelabs/cli/SurveyCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyCommand.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyInventoryCommand.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/io/spicelabs/cli/SurveyRegistration.java
+++ b/src/main/java/io/spicelabs/cli/SurveyRegistration.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 

--- a/src/main/java/io/spicelabs/cli/SurveyRuntimeCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyRuntimeCommand.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 

--- a/src/test/java/io/spicelabs/cli/AnalyzeProgressPublisherTest.java
+++ b/src/test/java/io/spicelabs/cli/AnalyzeProgressPublisherTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 

--- a/src/test/java/io/spicelabs/cli/AnchorHashesTest.java
+++ b/src/test/java/io/spicelabs/cli/AnchorHashesTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 

--- a/src/test/java/io/spicelabs/cli/GenerateCompletionTest.java
+++ b/src/test/java/io/spicelabs/cli/GenerateCompletionTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/test/java/io/spicelabs/cli/JdkVersionDetectorTest.java
+++ b/src/test/java/io/spicelabs/cli/JdkVersionDetectorTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 

--- a/src/test/java/io/spicelabs/cli/JfrEventExtractorTest.java
+++ b/src/test/java/io/spicelabs/cli/JfrEventExtractorTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 

--- a/src/test/java/io/spicelabs/cli/SpicePassDecoderTest.java
+++ b/src/test/java/io/spicelabs/cli/SpicePassDecoderTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 

--- a/src/test/java/io/spicelabs/cli/SurveyInventoryCommandTest.java
+++ b/src/test/java/io/spicelabs/cli/SurveyInventoryCommandTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 

--- a/src/test/java/io/spicelabs/cli/SurveyRegistrationTest.java
+++ b/src/test/java/io/spicelabs/cli/SurveyRegistrationTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 

--- a/src/test/java/io/spicelabs/cli/SurveyRuntimeCommandTest.java
+++ b/src/test/java/io/spicelabs/cli/SurveyRuntimeCommandTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright 2025 Spice Labs, Inc. & Contributors */
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
 
 package io.spicelabs.cli;
 


### PR DESCRIPTION
@dpletter noticed that I copied a "Copyright 2025" line in a PR without updating the year. Rather than fix just that one, this PR updates all occurrences.

The Apache appendix in `LICENSE` reads `Copyright 2026 Spice Labs, Inc.` — a different form, with no `& Contributors` hasn't been changed.