### PR TITLE
Force Maven to re-resolve, so a cached miss cannot outlive a release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,9 @@ jobs:
             <activeProfiles><activeProfile>ci</activeProfile></activeProfiles>
           </settings>
           SXML
-              mvn -B -ntp verify
+              # -U so a resolution failure cached in the restored deps layer is
+              # retried here rather than trusted; see the Dockerfile deps stage.
+              mvn -B -ntp -U verify
             '
 
   build-image-spice:

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,12 @@ COPY pom.xml ./
 # which needs auth even for public reads. Write a settings.xml from GH_TOKEN so
 # the resolve can reach them; the || true lets the bulk of the Maven cache
 # (picocli, slf4j, logback, junit, okhttp, etc.) be fetched regardless.
+#
+# -U because this layer is pushed to a registry cache and restored by later runs.
+# Without it, a version that was missing when the layer was built stays missing:
+# Maven records the failure in the local repo and honours that record instead of
+# asking again. A dependency released after a failed build would then never
+# resolve, however many times CI was re-run.
 ARG GH_TOKEN=""
 RUN mkdir -p ~/.m2 && cat > ~/.m2/settings.xml <<SXML
 <settings>
@@ -65,7 +71,7 @@ RUN mkdir -p ~/.m2 && cat > ~/.m2/settings.xml <<SXML
   <activeProfiles><activeProfile>github</activeProfile></activeProfiles>
 </settings>
 SXML
-RUN mvn -B -ntp dependency:resolve || true
+RUN mvn -B -ntp -U dependency:resolve || true
 
 # ---- builder ----------------------------------------------------------------
 # Compiles spice-labs-cli and assembles the fat JAR. Built FROM deps so the
@@ -120,7 +126,7 @@ SXML
 # (0.0.1-SNAPSHOT).
 ARG VERSION=""
 RUN if [ -n "${VERSION}" ]; then mvn -B -ntp versions:set -DnewVersion="${VERSION}" -DgenerateBackupPoms=false; fi && \
-    mvn -B -ntp -DskipTests package
+    mvn -B -ntp -U -DskipTests package
 
 # ---- test ------------------------------------------------------------------
 # The test target reuses the deps cache and runs `mvn verify`. Used by CI


### PR DESCRIPTION
The deps stage resolves dependencies into a layer that is pushed to a registry cache and restored by later runs. When a version is missing at the moment that layer is built, Maven writes a `.lastUpdated` marker recording the failure, and then honours that record instead of asking the server again. The marker is baked into the layer, so the miss is restored on every subsequent run: **a dependency released after a failed build never resolves, however often CI is re-run.**

That is not hypothetical — it is what happened to `spice-bom` 1.0.11, which was published twenty-two seconds after the build that went looking for it. Every re-run then reported it `(absent)` while it sat in the registry:

```
Non-resolvable import POM: io.spicelabs:spice-bom:pom:1.0.11 (absent):
  ... was not found ... during a previous attempt. This failure was cached in the
  local repository and resolution is not reattempted until the update interval
  ... has elapsed or updates are forced
```

`-U` on the three invocations that matter:

| where | why |
|---|---|
| `Dockerfile` deps warm-up | writes the marker, and is what gets cached |
| `Dockerfile` `package` | image build, runs against the restored layer |
| `build.yml` `verify` | test job, same |

**Not** on the second `dependency:resolve` in `build.yml`, which runs before the `settings.xml` carrying credentials is written. It cannot resolve the private artifacts at all — that is why it is `|| true` — so forcing it to retry would buy nothing.

Editing the deps stage also changes that layer's hash, so the next run discards the poisoned cache rather than restoring it.

Split out of #251, where it was an unrelated passenger. This affects every build, so it is worth landing on `main` on its own rather than waiting for the configuration stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)