### PR TITLE
Park non-successive releases in the Central Portal for manual confirmation

### DIFF
--- a/.github/scripts/check-release-tag.py
+++ b/.github/scripts/check-release-tag.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Validate a release tag and decide whether it may auto-publish to Maven Central.
+
+Two tiers, because the two failure modes deserve different treatment:
+
+  Shape      A tag that is not `v<major>.<minor>.<patch>` is a typo, not a
+             judgement call -- there is no version anyone would confirm. Exit
+             non-zero so nothing is deployed anywhere.
+
+  Succession A tag that is well-formed but skips ahead of the previous release
+             (`v1.0.2` -> `v1.0.9`, or the classic `v0.10.6` -> `v0.10.61`) may
+             still be deliberate. Rather than block it, emit
+             auto_publish=false. publish.yml passes that to the Central
+             publishing plugin, so the deployment uploads and validates but
+             parks in the Central Portal until a human publishes or drops it.
+
+The asymmetry is deliberate: a Maven Central version can never be deleted or
+overwritten, so it is the one channel where a wrong number is permanent.
+
+Writes GitHub Actions `name=value` output lines to stdout.
+
+Usage: check-release-tag.py <tag> <tags-file>
+"""
+
+import re
+import sys
+
+SEMVER = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+
+def parse(tag):
+    m = SEMVER.match(tag)
+    return tuple(int(g) for g in m.groups()) if m else None
+
+
+def successors(version):
+    """The three versions that may legitimately follow `version`."""
+    major, minor, patch = version
+    return [(major, minor, patch + 1), (major, minor + 1, 0), (major + 1, 0, 0)]
+
+
+def fmt(version):
+    return "v%d.%d.%d" % version
+
+
+def main(argv):
+    if len(argv) != 3:
+        print(__doc__.strip().splitlines()[-1], file=sys.stderr)
+        return 2
+
+    tag, tags_file = argv[1], argv[2]
+
+    current = parse(tag)
+    if current is None:
+        print(
+            "::error title=Malformed release tag::"
+            "'%s' is not of the form v<major>.<minor>.<patch>. "
+            "Nothing has been deployed. Delete this release and its tag, "
+            "then cut the correct version." % tag,
+            file=sys.stderr,
+        )
+        return 1
+
+    with open(tags_file) as handle:
+        released = {v for v in (parse(t.strip()) for t in handle) if v}
+    released.discard(current)
+
+    # The predecessor is the highest release below this one. Releases above it
+    # are ignored so that a maintenance line still works: v1.0.13 follows
+    # v1.0.12 even once v2.0.0 exists.
+    earlier = sorted(v for v in released if v < current)
+    previous = earlier[-1] if earlier else None
+
+    expected = successors(previous) if previous else []
+
+    if not released:
+        # Genuinely the first release: nothing to be a successor to.
+        ok = True
+    elif previous is None:
+        # Well-formed, but below every existing release -- a backwards release.
+        # Not a typo we can rule on, so it goes to the Portal like any other
+        # non-successor rather than publishing unattended.
+        ok = False
+    else:
+        ok = current in expected
+
+    # `version` and `VERSION` are both emitted: the two spellings are already in
+    # use across the Spice Labs publish workflows (ginger-j/saffron/annatto read
+    # `version`, spice-bom/spice-labs-cli read `VERSION`), and emitting both lets
+    # this script drop into every repo unchanged.
+    out = [
+        ("version", tag[1:]),
+        ("VERSION", tag[1:]),
+        ("successor_ok", "true" if ok else "false"),
+        ("auto_publish", "true" if ok else "false"),
+        ("previous", fmt(previous) if previous else ""),
+        ("expected", ", ".join(fmt(v) for v in expected)),
+    ]
+    for name, value in out:
+        print("%s=%s" % (name, value))
+
+    if not released:
+        print(
+            "::notice::%s is the first release; no predecessor to check against."
+            % tag,
+            file=sys.stderr,
+        )
+    elif previous is None:
+        print(
+            "::warning title=Release tag goes backwards::"
+            "%s is lower than every existing release (earliest is %s). The "
+            "Maven Central deployment will wait in the Central Portal for "
+            "manual confirmation." % (tag, fmt(min(released))),
+            file=sys.stderr,
+        )
+    elif ok:
+        print(
+            "::notice::%s is a natural successor to %s." % (tag, fmt(previous)),
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "::warning title=Release tag is not a natural successor::"
+            "%s does not follow %s (expected one of %s). The Maven Central "
+            "deployment will wait in the Central Portal for manual confirmation."
+            % (tag, fmt(previous), ", ".join(fmt(v) for v in expected)),
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,9 @@ jobs:
       id-token: write
     outputs:
       version: ${{ steps.validate.outputs.VERSION }}
+      successor-ok: ${{ steps.validate.outputs.successor_ok }}
+      previous: ${{ steps.validate.outputs.previous }}
+      expected: ${{ steps.validate.outputs.expected }}
       thread-ts: ${{ steps.release-notification.outputs.thread-ts }}
       channel-id: ${{ steps.release-notification.outputs.channel-id }}
     steps:
@@ -45,21 +48,20 @@ jobs:
         with:
           lfs: true
           ref: ${{ github.event.release.tag_name }}
+          # Full history and tags: the successor check compares this release
+          # tag against every previously released version.
+          fetch-depth: 0
 
-      - name: Validate and extract version from tag
+      - name: Validate the release tag
         id: validate
         env:
           # tag_name is "vX.Y.Z" (no refs/tags/ prefix) for the release event.
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          if [[ "${TAG_NAME}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-            VERSION="${BASH_REMATCH[1]}"
-            echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-          else
-            echo "Tag does not match semantic version pattern v*.*.* (got: ${TAG_NAME})" >&2
-            exit 1
-          fi
+          git tag --list > /tmp/all-tags.txt
+          python3 .github/scripts/check-release-tag.py \
+            "${TAG_NAME}" /tmp/all-tags.txt >> "$GITHUB_OUTPUT"
 
       - name: Set up JDK 21 and GitHub Maven auth
         uses: actions/setup-java@v4
@@ -96,7 +98,9 @@ jobs:
 
       - name: Build and publish all jars to Maven Central
         id: build-jars-maven-central
-        run: mvn --batch-mode clean deploy -P maven-central
+        run: |
+          mvn --batch-mode clean deploy -P maven-central \
+            -Dcentral.autoPublish=${{ steps.validate.outputs.auto_publish }}
         env:
           GH_USERNAME: ${{ secrets.GH_USERNAME_SG }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -274,9 +278,49 @@ jobs:
             ${{ env.FEDERAL_IMAGE }}:${{ github.event.release.tag_name }}
             ${{ env.FEDERAL_IMAGE }}:latest
 
+  # Its own job rather than a step inside publish_jars: failing inside
+  # publish_jars would block docker_image and the enterprise/federal images,
+  # which do not depend on Maven Central and are freely retaggable. Those should
+  # still ship while the Central deployment waits for a decision. This job
+  # exists to turn the run red -- `mvn deploy` succeeds even when the
+  # deployment is only staged, so without it the run would go green with
+  # nothing on Maven Central.
+  confirm_central_release:
+    name: Maven Central release awaiting confirmation
+    needs: [publish_jars]
+    if: always() && needs.publish_jars.outputs.successor-ok == 'false'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Flag release awaiting manual confirmation
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          PREVIOUS: ${{ needs.publish_jars.outputs.previous }}
+          EXPECTED: ${{ needs.publish_jars.outputs.expected }}
+        run: |
+          {
+            echo "## :warning: Maven Central release awaiting manual confirmation"
+            echo
+            if [ -n "${PREVIOUS}" ]; then
+              echo "\`${TAG_NAME}\` is not a natural successor to \`${PREVIOUS}\`."
+              echo "Expected one of: ${EXPECTED}."
+            else
+              echo "\`${TAG_NAME}\` is lower than every existing release."
+            fi
+            echo
+            echo "The deployment was uploaded and validated, but **has not been published**."
+            echo "It is waiting in the [Central Portal](https://central.sonatype.com/publishing/deployments):"
+            echo
+            echo "- **Publish** it if this version number is deliberate."
+            echo "- **Drop** it otherwise, then delete the \`${TAG_NAME}\` release and tag and cut the correct version."
+            echo
+            echo "GitHub Packages and the Docker images already carry \`${TAG_NAME}\`; clean those up too if you drop this."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error title=Maven Central release awaiting confirmation::${TAG_NAME} was not published automatically${PREVIOUS:+ (does not follow ${PREVIOUS})}. The deployment is parked in the Central Portal and must be published or dropped by hand."
+          exit 1
+
   notify:
     name: Notify deployment result
-    needs: [publish_jars, docker_image, build_enterprise, build_federal]
+    needs: [publish_jars, docker_image, build_enterprise, build_federal, confirm_central_release]
     if: always()
     runs-on: ubuntu-24.04
     steps:
@@ -287,10 +331,20 @@ jobs:
           JAR_STATUS="${{ needs.publish_jars.result }}"
           DOCKER_STATUS="${{ needs.docker_image.result }}"
           ENT_STATUS="${{ needs.build_enterprise.result }}"
+          SUCCESSOR_OK="${{ needs.publish_jars.outputs.successor-ok }}"
 
-          if [ "$JAR_STATUS" == "success" ] && [ "$DOCKER_STATUS" == "success" ] && [ "$ENT_STATUS" == "success" ]; then
+          # Staged, not failed: the jars are uploaded and validated but parked in
+          # the Central Portal pending a human decision. Reported as a failure
+          # because nothing is on Maven Central yet, but named distinctly so it
+          # is not mistaken for a broken build.
+          if [ "$SUCCESSOR_OK" == "false" ]; then
+            echo "overall_status=failure" >> "$GITHUB_OUTPUT"
+            echo "message=⚠️ Awaiting manual confirmation in the Maven Central Portal." >> "$GITHUB_OUTPUT"
+            echo "workflow_name=${{ github.workflow }} — AWAITING MANUAL CONFIRMATION in the Maven Central Portal" >> "$GITHUB_OUTPUT"
+          elif [ "$JAR_STATUS" == "success" ] && [ "$DOCKER_STATUS" == "success" ] && [ "$ENT_STATUS" == "success" ]; then
             echo "overall_status=success" >> "$GITHUB_OUTPUT"
             echo "message=✅ All components deployed successfully!" >> "$GITHUB_OUTPUT"
+            echo "workflow_name=${{ github.workflow }}" >> "$GITHUB_OUTPUT"
           else
             echo "overall_status=failure" >> "$GITHUB_OUTPUT"
             MESSAGE="❌ Deployment failed:"
@@ -298,6 +352,7 @@ jobs:
             [ "$DOCKER_STATUS" != "success" ] && MESSAGE="$MESSAGE ❌ Docker build/push failed." || MESSAGE="$MESSAGE ✅ Docker build/push succeeded."
             [ "$ENT_STATUS" != "success" ] && MESSAGE="$MESSAGE ❌ Enterprise image build failed." || MESSAGE="$MESSAGE ✅ Enterprise image build succeeded."
             echo "message=$MESSAGE" >> "$GITHUB_OUTPUT"
+            echo "workflow_name=${{ github.workflow }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Notify deployment result
@@ -307,6 +362,7 @@ jobs:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           username-mapping: ${{ vars.GH_SLACK_USERNAME_MAPPING }}
           github-token: ${{ github.token }}
+          workflow-name: ${{ steps.deployment-status.outputs.workflow_name }}
           environment: production
           thread-ts: ${{ needs.publish_jars.outputs.thread-ts }}
           channel-id: ${{ needs.publish_jars.outputs.channel-id }}

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,14 @@
         <junit.jupiter.version>5.13.1</junit.jupiter.version>
         <mockwebserver.version>4.12.0</mockwebserver.version>
         <mockito.version>5.3.1</mockito.version>
+            <!-- Whether a Maven Central deployment publishes itself once validated.
+             `true` is the normal path. The publish workflow overrides this to
+             `false` when the release tag is not a natural successor to the
+             previous release, which leaves the deployment sitting in the
+             Central Portal for a human to publish or drop. A published Central
+             version can never be deleted or overwritten, so that is the one
+             channel worth stopping at. -->
+        <central.autoPublish>true</central.autoPublish>
     </properties>
 
     <dependencyManagement>
@@ -436,7 +444,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
-                            <autoPublish>true</autoPublish>
+                            <autoPublish>${central.autoPublish}</autoPublish>
                             <checksums>all</checksums>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
Replicates spice-labs-inc/spice-plugin-api#8 (approved) into `spice-labs-cli`. This is the one that needed a different shape — see below.

A published Maven Central version can never be deleted or overwritten. GitHub Packages entries, GitHub Releases, Docker tags and git tags can all be undone; Central cannot. So it is the one channel where a wrong tag is permanent.

## Two tiers

| Tag | Verdict | Effect |
|---|---|---|
| natural successor | fine | publishes exactly as today |
| malformed (`v.0.0.5`, `v.0.1.11`) | typo | **run fails, nothing deploys anywhere** |
| well-formed but skips ahead | maybe deliberate | **deploys but parks in the Central Portal** |

A version skip may well be intentional, so rather than blocking it, `-Dcentral.autoPublish=false` is passed and the deployment uploads and validates as normal but waits in the Portal for someone to Publish or Drop. The Portal is the escape hatch, so the rule can be strict without needing an override flag.

`autoPublish` is now `${central.autoPublish}`, defaulting to `true`, so the normal path is byte-for-byte what it is today. Verified with `help:effective-pom` that the `-D` override reaches the plugin.

## Why a separate job here, unlike the other five

In the other repos the "this needs confirmation" failure is a step at the end of the publish job. That does not work here: `docker_image` has `needs: publish_jars`, and `build_enterprise`/`build_federal` chain off that. Failing inside `publish_jars` would mean a parked Central deployment also blocks every Docker image — and the images neither depend on Maven Central nor are irreversible, since they are just retaggable.

So the flag lives in its own `confirm_central_release` job that `needs: publish_jars` and nothing depends on. The images still build and push; the run still goes red. Job graph after this change:

```
publish_jars ─┬─> docker_image ─┬─> build_enterprise ─┐
              │                 └─> build_federal ────┤
              └─> confirm_central_release ────────────┴─> notify
```

## Historical impact

Backtested against all 102 releases, comparing each tag only against those that preceded it:

- **Would have parked: `v1.5.2`** (followed `v1.5.0`, skipping `v1.5.1`).
- **Would have hard-failed: `v.0.0.5`, `v.0.1.11`** — typo`d `v.` prefixes, exactly what tier 1 is for — plus the legacy `bom-v1.0.0` and `plugin-api-v0.1.0`, which no longer occur now that both artifacts release from their own repos.

Going forward from `v1.6.3`, a normal `v1.6.4` is unaffected.

## The green-build trap

`mvn deploy` **succeeds** when a deployment is merely staged, so without `confirm_central_release` the run would go green with nothing on Central — a version everyone believes shipped but consumers cannot resolve.

The `notify` job is also updated: it previously keyed off the three job results, so a parked release would have gone to Slack as "❌ Deployment failed: ❌ JAR publishing failed" while the jars had in fact built and uploaded fine. It now checks the staged state first and passes an explicit `workflow-name` naming the pending Portal decision.

## Notes

- The check script is identical in all six repos; it emits both `version` and `VERSION` because the workflows disagree on the spelling, which keeps this repo`s `outputs.VERSION` references untouched.
- Copied rather than shared. A `spice-labs-inc/action-check-release-tag` would beat six copies, but that needs a new org repo, so I left it as a follow-up rather than create one unasked.
- `Checkout with LFS` gains `fetch-depth: 0`; the check needs the full tag list. It keeps `ref: ${{ github.event.release.tag_name }}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)