### PR TITLE
Specify dependency versions directly, dropping spice-bom

### DIFF
--- a/.github/actions/maven-settings/action.yml
+++ b/.github/actions/maven-settings/action.yml
@@ -93,11 +93,6 @@ runs:
                   <url>https://maven.pkg.github.com/spice-labs-inc/ginger-j</url>
                 </repository>
                 <repository>
-                  <id>github-spice-labs-bom</id>
-                  <url>https://maven.pkg.github.com/spice-labs-inc/spice-bom</url>
-                  <snapshots><enabled>true</enabled></snapshots>
-                </repository>
-                <repository>
                   <id>github-spice-labs-plugin-api</id>
                   <url>https://maven.pkg.github.com/spice-labs-inc/spice-plugin-api</url>
                   <snapshots><enabled>true</enabled></snapshots>
@@ -115,11 +110,6 @@ runs:
                 <repository>
                   <id>github-spice-labs-ginger</id>
                   <url>https://maven.pkg.github.com/spice-labs-inc/ginger-j</url>
-                </repository>
-                <repository>
-                  <id>github-spice-labs-bom</id>
-                  <url>https://maven.pkg.github.com/spice-labs-inc/spice-bom</url>
-                  <snapshots><enabled>true</enabled></snapshots>
                 </repository>
                 <repository>
                   <id>github-spice-labs-plugin-api</id>
@@ -141,11 +131,6 @@ runs:
                   <url>https://maven.pkg.github.com/spice-labs-inc/ginger-j</url>
                 </repository>
                 <repository>
-                  <id>github-spice-labs-bom</id>
-                  <url>https://maven.pkg.github.com/spice-labs-inc/spice-bom</url>
-                  <snapshots><enabled>true</enabled></snapshots>
-                </repository>
-                <repository>
                   <id>github-spice-labs-plugin-api</id>
                   <url>https://maven.pkg.github.com/spice-labs-inc/spice-plugin-api</url>
                   <snapshots><enabled>true</enabled></snapshots>
@@ -164,7 +149,7 @@ runs:
                   <id>github-spice-labs-ginger</id>
                   <url>https://maven.pkg.github.com/spice-labs-inc/ginger-j</url>
                 </repository>
-                <!-- spice-bom + spice-plugin-api resolve from Maven Central by default;
+                <!-- spice-plugin-api resolves from Maven Central by default;
                      CI builds that need GHP (e.g. before Central propagation) activate
                      the `github` or `maven-central` profile instead. -->
               </repositories>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,6 @@ jobs:
                 <repositories>
                   <repository><id>github-spice-labs-goatrodeo</id><url>https://maven.pkg.github.com/spice-labs-inc/goatrodeo</url></repository>
                   <repository><id>github-spice-labs-ginger</id><url>https://maven.pkg.github.com/spice-labs-inc/ginger-j</url></repository>
-                  <repository><id>github-spice-labs-bom</id><url>https://maven.pkg.github.com/spice-labs-inc/spice-bom</url><snapshots><enabled>true</enabled></snapshots></repository>
                   <repository><id>github-spice-labs-plugin-api</id><url>https://maven.pkg.github.com/spice-labs-inc/spice-plugin-api</url><snapshots><enabled>true</enabled></snapshots></repository>
                 </repositories>
               </profile>

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # does not.
 COPY pom.xml ./
 
-# Pre-fetch all resolvable dependencies. spice-bom + spice-plugin-api resolve
-# from GitHub Packages (spice-labs-inc/spice-bom, spice-labs-inc/spice-plugin-api),
+# Pre-fetch all resolvable dependencies. spice-plugin-api, goatrodeo and
+# ginger-j resolve from GitHub Packages (one repo each under spice-labs-inc),
 # which needs auth even for public reads. Write a settings.xml from GH_TOKEN so
 # the resolve can reach them; the || true lets the bulk of the Maven cache
 # (picocli, slf4j, logback, junit, okhttp, etc.) be fetched regardless.
@@ -56,7 +56,6 @@ RUN mkdir -p ~/.m2 && cat > ~/.m2/settings.xml <<SXML
       <repositories>
         <repository><id>github-spice-labs-goatrodeo</id><url>https://maven.pkg.github.com/spice-labs-inc/goatrodeo</url></repository>
         <repository><id>github-spice-labs-ginger</id><url>https://maven.pkg.github.com/spice-labs-inc/ginger-j</url></repository>
-        <repository><id>github-spice-labs-bom</id><url>https://maven.pkg.github.com/spice-labs-inc/spice-bom</url><snapshots><enabled>true</enabled></snapshots></repository>
         <repository><id>github-spice-labs-plugin-api</id><url>https://maven.pkg.github.com/spice-labs-inc/spice-plugin-api</url><snapshots><enabled>true</enabled></snapshots></repository>
         <repository><id>github-spice-labs-ancho</id><url>https://maven.pkg.github.com/spice-labs-inc/ancho</url></repository>
       </repositories>
@@ -96,7 +95,6 @@ RUN mkdir -p ~/.m2 && cat > ~/.m2/settings.xml <<SXML
       <repositories>
         <repository><id>github-spice-labs-goatrodeo</id><url>https://maven.pkg.github.com/spice-labs-inc/goatrodeo</url></repository>
         <repository><id>github-spice-labs-ginger</id><url>https://maven.pkg.github.com/spice-labs-inc/ginger-j</url></repository>
-        <repository><id>github-spice-labs-bom</id><url>https://maven.pkg.github.com/spice-labs-inc/spice-bom</url><snapshots><enabled>true</enabled></snapshots></repository>
         <repository><id>github-spice-labs-plugin-api</id><url>https://maven.pkg.github.com/spice-labs-inc/spice-plugin-api</url><snapshots><enabled>true</enabled></snapshots></repository>
         <repository><id>github-spice-labs-ancho</id><url>https://maven.pkg.github.com/spice-labs-inc/ancho</url></repository>
       </repositories>
@@ -107,8 +105,8 @@ RUN mkdir -p ~/.m2 && cat > ~/.m2/settings.xml <<SXML
 SXML
 
 # spice-plugin-api is published from spice-labs-inc/spice-plugin-api and
-# resolved remotely via the settings.xml above (a transitive dependency of
-# the spice-bom the CLI imports).
+# resolved remotely via the settings.xml above; its version is pinned
+# directly in pom.xml.
 
 # The fat JAR + ancho agent are assembled by the shade + dependency-plugin
 # bindings in pom.xml. `package` produces:
@@ -131,7 +129,7 @@ RUN if [ -n "${VERSION}" ]; then mvn -B -ntp versions:set -DnewVersion="${VERSIO
 FROM deps AS test
 WORKDIR /workspace
 COPY . .
-# spice-bom + spice-plugin-api are resolved remotely (see builder settings.xml).
+# spice-plugin-api is resolved remotely (see builder settings.xml).
 ENTRYPOINT ["mvn", "-B", "-ntp"]
 CMD ["verify"]
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -98,10 +98,10 @@ into a top-level **`dist/`** directory:
 - **any runtime dependencies the CLI does not already provide.** Declare the libraries the CLI
   already ships — `goatrodeo`, `ginger-j`, the Scala library, SLF4J/Logback, picocli and
   `spice-plugin-api` — as **`provided`** so they are available at compile time but excluded from
-  `dist/`; a single copy of each then lives on the runtime classpath. Import the shared BOM,
-  `io.spicelabs:spice-bom` (`<type>pom</type>`, `<scope>import</scope>`), and declare those
-  dependencies **without versions** so the whole ecosystem — the CLI and every plugin — converges
-  on one governed set of versions.
+  `dist/`; a single copy of each then lives on the runtime classpath. Give each an explicit
+  version matching the one the CLI ships: the CLI's `pom.xml` `<properties>` block is the
+  reference. (These were previously versioned by importing `io.spicelabs:spice-bom`; that BOM
+  is being retired in favour of explicit versions per module.)
 
 See [`sample/hello-plugin/pom.xml`](../sample/hello-plugin/pom.xml) for the smallest possible
 build, and `allspice`'s `spicePlugin` module for one that bundles real dependencies.
@@ -142,7 +142,7 @@ install time, so completion always reflects whatever plugins that image ships.
 |---|---|
 | SPI artifact | `io.spicelabs:spice-plugin-api` (`provided`) |
 | Provider registration | `META-INF/services/io.spicelabs.cli.spi.SpiceCommandPlugin` |
-| Shared runtime libs | declare CLI-provided libs (`goatrodeo`, `ginger-j`, …) as `provided`, versions from the imported `io.spicelabs:spice-bom` — do not re-bundle |
+| Shared runtime libs | declare CLI-provided libs (`goatrodeo`, `ginger-j`, …) as `provided` with explicit versions matching the CLI's `pom.xml` — do not re-bundle |
 | Plugin output | a top-level `dist/` directory of jars |
 | Inclusion | `ln -s /path/to/plugin spice/plugins/<name>` → build collects `<name>/dist/*.jar` |
 | Runtime | `-cp "spice-labs-cli.jar:plugins/*"` |

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -30,8 +30,8 @@ java -cp "spice-labs-cli.jar:plugins/*" io.spicelabs.cli.SpiceLabsCLI ...
 so each plugin jar keeps its own `META-INF/services/...SpiceCommandPlugin` and is
 discovered. Plugins should depend on `io.spicelabs:spice-plugin-api` and on any
 CLI-bundled libraries (goatrodeo, ginger-j, …) as **provided** scope, so those are not
-duplicated here — version convergence is governed by the shared `io.spicelabs:spice-bom`
-(spice-labs-inc/spice-bom).
+duplicated here. Declare each with an explicit version matching the one the CLI ships —
+see the `<properties>` block in the CLI's `pom.xml`.
 
 ## Public vs internal builds
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,21 +48,29 @@
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
 
-        <!-- The BOM (io.spicelabs:spice-bom) is the single fixed dependency
-             specification; it is imported below and supplies the versions for the
-             runtime classpath + coordinates. It lives in its own repo
-             (spice-labs-inc/spice-bom) and is resolved from GitHub Packages.
-             spice-plugin-api's version comes from here too, so the SPI the CLI
-             compiles against and the one it ships cannot drift apart. ancho is
-             versioned here (NOT in the BOM): it is injected
-             via -javaagent, never on the CLI's own classpath.
+        <!-- Dependency versions. Previously supplied by the imported spice-bom;
+             inlined here from spice-bom 1.0.11, the BOM this build already used,
+             so no version changes. ancho is not among them: it is injected via
+             -javaagent and never on the CLI's own classpath. -->
+        <commons-lang3.version>3.19.0</commons-lang3.version>
+        <coordinates.version>1.1.0</coordinates.version>
+        <ginger-j.version>0.4.0</ginger-j.version>
+        <goatrodeo.version>0.18.0</goatrodeo.version>
+        <java-jwt.version>4.4.0</java-jwt.version>
+        <logback.version>1.5.18</logback.version>
+        <picocli.version>4.7.6</picocli.version>
+        <slf4j.version>2.0.17</slf4j.version>
+        <spice-plugin-api.version>2.0.0</spice-plugin-api.version>
 
-             1.0.11 is the BOM that carries goatrodeo 0.18.0, which supplies TomlTables:
-             the one place a TOML table is converted to and from the plain maps the plugin
-             SPI carries. Pinning the goatrodeo version here instead would put a SNAPSHOT
-             in the fat jar and make the same commit build against different bytes, so the
-             version comes from the BOM like every other. -->
-        <spice-bom.version>1.0.11</spice-bom.version>
+        <!-- Transitive convergence pins (see the dependencyManagement block below).
+             spice-bom constrained these even though nothing here declares them
+             directly; goatrodeo and ginger-j pull them in. -->
+        <saffron.version>0.2.3</saffron.version>
+        <bouncycastle.version>1.84</bouncycastle.version>
+        <jackson.version>2.18.9</jackson.version>
+        <snakeyaml.version>2.3</snakeyaml.version>
+        <xz.version>1.12</xz.version>
+        <byte-buddy.version>1.18.12</byte-buddy.version>
         <ancho.version>0.0.8</ancho.version>
         <!--        Use this version for local dev-->
         <!--        <ancho.version>0.0.1-SNAPSHOT</ancho.version> -->
@@ -71,16 +79,61 @@
         <mockito.version>5.3.1</mockito.version>
     </properties>
 
+    <!-- Transitive convergence pins. spice-bom's dependencyManagement applied to the
+         whole resolved graph, not just the dependencies declared below, so dropping
+         the import would silently move these. Pinned to the values spice-bom 1.0.11
+         produced, so the fat jar's contents do not change. -->
     <dependencyManagement>
         <dependencies>
-            <!-- Single fixed dependency specification. Supplies versions for
-                 everything below. -->
             <dependency>
                 <groupId>io.spicelabs</groupId>
-                <artifactId>spice-bom</artifactId>
-                <version>${spice-bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
+                <artifactId>saffron</artifactId>
+                <version>${saffron.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpg-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.tukaani</groupId>
+                <artifactId>xz</artifactId>
+                <version>${xz.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${byte-buddy.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -97,38 +150,47 @@
         <dependency>
             <groupId>io.spicelabs</groupId>
             <artifactId>spice-plugin-api</artifactId>
+            <version>${spice-plugin-api.version}</version>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
+            <version>${picocli.version}</version>
         </dependency>
         <dependency>
             <groupId>io.spicelabs</groupId>
             <artifactId>goatrodeo_3</artifactId>
+            <version>${goatrodeo.version}</version>
         </dependency>
         <dependency>
             <groupId>io.spicelabs</groupId>
             <artifactId>ginger-j</artifactId>
+            <version>${ginger-j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
+            <version>${java-jwt.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>io.spicelabs</groupId>
             <artifactId>coordinates</artifactId>
+            <version>${coordinates.version}</version>
         </dependency>
         <!-- JFR agent for runtime surveys — extracted to temp at runtime, not shaded.
              Kept separate (not on the CLI runtime classpath): it is injected into the
@@ -375,11 +437,6 @@
                 <repository>
                     <id>github-spice-labs-ginger</id>
                     <url>https://maven.pkg.github.com/spice-labs-inc/ginger-j</url>
-                </repository>
-                <repository>
-                    <id>github-spice-labs-bom</id>
-                    <url>https://maven.pkg.github.com/spice-labs-inc/spice-bom</url>
-                    <snapshots><enabled>true</enabled></snapshots>
                 </repository>
                 <repository>
                     <id>github-spice-labs-plugin-api</id>

--- a/sample/hello-plugin/README.md
+++ b/sample/hello-plugin/README.md
@@ -19,8 +19,8 @@ From the `spice` repo root:
 
 ```bash
 # 1. Build the plugin (needs spice-plugin-api resolved from GitHub Packages,
-#    or in ~/.m2). The sample pom imports spice-bom, which depends on
-#    spice-plugin-api transitively.
+#    or in ~/.m2). The sample pom declares spice-plugin-api and picocli
+#    directly, with explicit versions.
 mvn -f sample/hello-plugin package          # → sample/hello-plugin/dist/hello-plugin.jar
 
 # 2. Symlink it into plugins/ (any name; the build looks in <name>/dist/).

--- a/sample/hello-plugin/pom.xml
+++ b/sample/hello-plugin/pom.xml
@@ -15,34 +15,25 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- The shared BOM supplies the versions for spice-plugin-api, picocli and the rest
-             of the CLI runtime classpath, so plugins never hard-code them. -->
-        <spice-bom.version>1.0.3</spice-bom.version>
+        <!-- Versions for the CLI runtime classpath a plugin compiles against.
+             Previously supplied by the imported spice-bom; inlined from 1.0.11. -->
+        <picocli.version>4.7.6</picocli.version>
+        <spice-plugin-api.version>2.0.0</spice-plugin-api.version>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.spicelabs</groupId>
-                <artifactId>spice-bom</artifactId>
-                <version>${spice-bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <!-- Both are provided by the spice CLI at runtime, so they are compile-only here
-             (versions from the imported spice-bom) and are NOT bundled into dist/. -->
+             (versions in the <properties> block above) and are NOT bundled into dist/. -->
         <dependency>
             <groupId>io.spicelabs</groupId>
             <artifactId>spice-plugin-api</artifactId>
+            <version>${spice-plugin-api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
+            <version>${picocli.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
tl;dr This inlines the contents of `spice-bom`, and removes it as a dependency.

Full LLM description:
The CLI already imported **spice-bom 1.0.11**, so the nine versions it supplied are inlined unchanged. `sample/hello-plugin` was on 1.0.3.

## The part that matters: transitive constraints

`dependencyManagement` applies to the entire resolved graph, not just the dependencies a pom declares. Removing the import therefore loosens versions on ten artifacts nothing here declares directly — they arrive through goatrodeo and ginger-j. Without pins:

| Artifact | With BOM | After naive removal | |
|---|---|---|---|
| `io.spicelabs:saffron` | 0.2.3 | 0.3.1 | ↑ |
| `org.bouncycastle:bcprov-jdk18on` | 1.84 | 1.85.2 | ↑ |
| `org.bouncycastle:bcutil/bcpkix/bcpg-jdk18on` | 1.84 | 1.85 | ↑ |
| `com.fasterxml.jackson.core:jackson-databind` | 2.18.9 | 2.19.2 | ↑ |
| `com.fasterxml.jackson.datatype:jackson-datatype-jsr310` | 2.18.9 | 2.19.2 | ↑ |
| `org.yaml:snakeyaml` | 2.3 | **2.2** | ↓ |
| `org.tukaani:xz` | 1.12 | **1.9** | ↓ |
| `net.bytebuddy:byte-buddy` | 1.18.12 | 1.18.11 | ↓ |

A `dependencyManagement` block pins all ten to the values spice-bom 1.0.11 produced, so this PR is a no-op on what actually ships.

**Worth a decision, though:** the BOM was holding BouncyCastle at 1.84 and saffron at 0.2.3 while goatrodeo 0.18.0 asks for 1.85/1.85.2 and 0.3.1. I have preserved the pin-down because that is what the repo does today and what "use the latest BOM versions" asks for — but with the BOM gone, letting them float up to what goatrodeo wants may be what you actually want, especially given the BouncyCastle bump work in flight. Deleting the four `bouncycastle` and one `saffron` entries from the new block is all that would take.

## Verification

Both poms resolved into the same clean local repository:

```
origin/main pom (imports spice-bom)  -> 78 artifacts
this branch  (inlined)               -> 78 artifacts
diff                                 -> NONE, graphs identical
mvn compile                          -> success, 0 errors
```

## sample/hello-plugin did not build on main

Unrelated to the transitive story, and worth knowing: the sample plugin declared `spice-plugin-api` **without a version**, relying on the BOM. But spice-bom 1.0.3 carries `spice-plugin-api` as an ordinary `<dependency>`, not a managed one, so it never supplied a version. `mvn package` on `origin/main` fails outright:

```
[ERROR] dependencies.dependency.version for io.spicelabs:spice-plugin-api:jar is missing. @ line 38
```

Giving it an explicit `2.0.0` fixes it; `mvn package` now succeeds and produces `dist/hello-plugin.jar`.

## Also cleaned up

The spice-bom GitHub Packages repository is now unused, so it goes from `pom.xml`, `Dockerfile` (two copies), `build.yml` and `.github/actions/maven-settings/action.yml` (three copies), along with the comments naming it.

`docs/PLUGINS.md`, `plugins/README.md` and the hello-plugin README told plugin authors to import the BOM and declare dependencies *without* versions. They now point at the CLI`s `<properties>` block as the reference for which versions to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)