### PR TITLE
feat: add oras-based image survey (spice survey image)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,8 @@ jobs:
           platforms: ${{ env.PLATFORMS }}
           push: true
           tags: ghcr.io/${{ github.repository }}/cache:deps-${{ github.sha }}
-          build-args: |
-            GH_TOKEN=${{ secrets.GH_TOKEN }}
+          secrets: |
+            gh_token=${{ secrets.GH_TOKEN }}
           cache-from: |
             type=registry,ref=ghcr.io/${{ github.repository }}/cache:cache-deps
           cache-to: |
@@ -170,15 +170,15 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Publish spice image
-        uses: spice-labs-inc/action-publish-image@v2.4
+        uses: spice-labs-inc/action-publish-image@v2.7
         with:
           image: ghcr.io/${{ github.repository }}
           target: spice
           platforms: ${{ env.PLATFORMS }}
           build-contexts: |
             deps=docker-image://ghcr.io/${{ github.repository }}/cache:deps-${{ github.sha }}
-          build-args: |
-            GH_TOKEN=${{ secrets.GH_TOKEN }}
+          secrets: |
+            gh_token=${{ secrets.GH_TOKEN }}
           tags: |
             ghcr.io/${{ github.repository }}:pr-${{ github.event.number }}
           push: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -180,8 +180,9 @@ jobs:
           provenance: mode=max
           sbom: true
           build-args: |
-            GH_TOKEN=${{ secrets.GH_TOKEN }}
             VERSION=${{ needs.publish_jars.outputs.version }}
+          secrets: |
+            gh_token=${{ secrets.GH_TOKEN }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Multi-target Dockerfile for spice-labs-cli.
 #
 # Targets:
@@ -37,76 +38,51 @@ COPY pom.xml ./
 
 # Pre-fetch all resolvable dependencies. spice-plugin-api, goatrodeo and
 # ginger-j resolve from GitHub Packages (one repo each under spice-labs-inc),
-# which needs auth even for public reads. Write a settings.xml from GH_TOKEN so
-# the resolve can reach them; the || true lets the bulk of the Maven cache
+# which needs auth even for public reads. The token is a BuildKit secret mount
+# (never a build-arg): a throwaway settings.xml carries it into the resolve and
+# is deleted before the layer commits, so it cannot land in the pushed cache
+# image or in layer history. The || true lets the bulk of the Maven cache
 # (picocli, slf4j, logback, junit, okhttp, etc.) be fetched regardless.
-ARG GH_TOKEN=""
-RUN mkdir -p ~/.m2 && cat > ~/.m2/settings.xml <<SXML
-<settings>
-  <servers>
-    <server><id>github-spice-labs-goatrodeo</id><username>SpicyGrzl</username><password>${GH_TOKEN}</password></server>
-    <server><id>github-spice-labs-ginger</id><username>SpicyGrzl</username><password>${GH_TOKEN}</password></server>
-    <server><id>github-spice-labs-bom</id><username>SpicyGrzl</username><password>${GH_TOKEN}</password></server>
-    <server><id>github-spice-labs-plugin-api</id><username>SpicyGrzl</username><password>${GH_TOKEN}</password></server>
-    <server><id>github-spice-labs-ancho</id><username>SpicyGrzl</username><password>${GH_TOKEN}</password></server>
-  </servers>
-  <profiles>
-    <profile>
-      <id>github</id>
-      <repositories>
-        <repository><id>github-spice-labs-goatrodeo</id><url>https://maven.pkg.github.com/spice-labs-inc/goatrodeo</url></repository>
-        <repository><id>github-spice-labs-ginger</id><url>https://maven.pkg.github.com/spice-labs-inc/ginger-j</url></repository>
-        <repository><id>github-spice-labs-plugin-api</id><url>https://maven.pkg.github.com/spice-labs-inc/spice-plugin-api</url><snapshots><enabled>true</enabled></snapshots></repository>
-        <repository><id>github-spice-labs-ancho</id><url>https://maven.pkg.github.com/spice-labs-inc/ancho</url></repository>
-      </repositories>
-    </profile>
-  </profiles>
-  <activeProfiles><activeProfile>github</activeProfile></activeProfiles>
-</settings>
-SXML
-RUN mvn -B -ntp dependency:resolve || true
+RUN --mount=type=secret,id=gh_token <<'SCRIPT'
+set -eu
+TOKEN=""
+if [ -f /run/secrets/gh_token ]; then
+  TOKEN="$(cat /run/secrets/gh_token)"
+fi
+mkdir -p ~/.m2
+{
+  echo "<settings>"
+  echo "  <servers>"
+  for id in github-spice-labs-goatrodeo github-spice-labs-ginger github-spice-labs-plugin-api github-spice-labs-ancho; do
+    printf "    <server><id>%s</id><username>SpicyGrzl</username><password>%s</password></server>\n" "$id" "$TOKEN"
+  done
+  echo "  </servers>"
+  echo "  <profiles>"
+  echo "    <profile>"
+  echo "      <id>github</id>"
+  echo "      <repositories>"
+  echo "        <repository><id>github-spice-labs-goatrodeo</id><url>https://maven.pkg.github.com/spice-labs-inc/goatrodeo</url></repository>"
+  echo "        <repository><id>github-spice-labs-ginger</id><url>https://maven.pkg.github.com/spice-labs-inc/ginger-j</url></repository>"
+  echo "        <repository><id>github-spice-labs-plugin-api</id><url>https://maven.pkg.github.com/spice-labs-inc/spice-plugin-api</url><snapshots><enabled>true</enabled></snapshots></repository>"
+  echo "        <repository><id>github-spice-labs-ancho</id><url>https://maven.pkg.github.com/spice-labs-inc/ancho</url></repository>"
+  echo "      </repositories>"
+  echo "    </profile>"
+  echo "  </profiles>"
+  echo "  <activeProfiles><activeProfile>github</activeProfile></activeProfiles>"
+  echo "</settings>"
+} > ~/.m2/settings.xml
+mvn -B -ntp dependency:resolve || true
+rm -f ~/.m2/settings.xml
+SCRIPT
 
 # ---- builder ----------------------------------------------------------------
 # Compiles spice-labs-cli and assembles the fat JAR. Built FROM deps so the
-# Maven cache is already warm. The settings.xml providing GitHub Packages auth
-# for goatrodeo_3 / ginger-j / ancho is supplied at build time via the
-# GITHUB_TOKEN env; CI writes it before invoking mvn.
+# Maven cache is already warm. GitHub Packages auth (goatrodeo_3, ginger-j,
+# ancho) is supplied by the same BuildKit secret mount as the deps stage.
 FROM deps AS builder
 
 WORKDIR /workspace
 COPY . .
-
-# Write a settings.xml for GitHub Packages auth (goatrodeo_3, ginger-j, ancho).
-# GH_TOKEN is passed as a build arg from CI or docker_build.sh.
-ARG GH_TOKEN=""
-RUN mkdir -p ~/.m2 && cat > ~/.m2/settings.xml <<SXML
-<settings>
-  <servers>
-    <server><id>github-spice-labs-goatrodeo</id><username>SpicyGrzl</username><password>${GH_TOKEN}</password></server>
-    <server><id>github-spice-labs-ginger</id><username>SpicyGrzl</username><password>${GH_TOKEN}</password></server>
-    <server><id>github-spice-labs-bom</id><username>SpicyGrzl</username><password>${GH_TOKEN}</password></server>
-    <server><id>github-spice-labs-plugin-api</id><username>SpicyGrzl</username><password>${GH_TOKEN}</password></server>
-    <server><id>github-spice-labs-ancho</id><username>SpicyGrzl</username><password>${GH_TOKEN}</password></server>
-    <server><id>github</id><username>SpicyGrzl</username><password>${GH_TOKEN}</password></server>
-  </servers>
-  <profiles>
-    <profile>
-      <id>github</id>
-      <repositories>
-        <repository><id>github-spice-labs-goatrodeo</id><url>https://maven.pkg.github.com/spice-labs-inc/goatrodeo</url></repository>
-        <repository><id>github-spice-labs-ginger</id><url>https://maven.pkg.github.com/spice-labs-inc/ginger-j</url></repository>
-        <repository><id>github-spice-labs-plugin-api</id><url>https://maven.pkg.github.com/spice-labs-inc/spice-plugin-api</url><snapshots><enabled>true</enabled></snapshots></repository>
-        <repository><id>github-spice-labs-ancho</id><url>https://maven.pkg.github.com/spice-labs-inc/ancho</url></repository>
-      </repositories>
-    </profile>
-  </profiles>
-  <activeProfiles><activeProfile>github</activeProfile></activeProfiles>
-</settings>
-SXML
-
-# spice-plugin-api is published from spice-labs-inc/spice-plugin-api and
-# resolved remotely via the settings.xml above; its version is pinned
-# directly in pom.xml.
 
 # The fat JAR + ancho agent are assembled by the shade + dependency-plugin
 # bindings in pom.xml. `package` produces:
@@ -116,9 +92,44 @@ SXML
 # VERSION is set by the release workflow (publish.yml) so the JARs carry the
 # release version; PR builds leave it unset and ship the pom's default
 # (0.0.1-SNAPSHOT).
+#
+# The settings.xml is written for this RUN only from the mounted secret and
+# deleted afterwards, so the token never reaches the image.
 ARG VERSION=""
-RUN if [ -n "${VERSION}" ]; then mvn -B -ntp versions:set -DnewVersion="${VERSION}" -DgenerateBackupPoms=false; fi && \
-    mvn -B -ntp -DskipTests package
+RUN --mount=type=secret,id=gh_token <<'SCRIPT'
+set -eu
+TOKEN=""
+if [ -f /run/secrets/gh_token ]; then
+  TOKEN="$(cat /run/secrets/gh_token)"
+fi
+mkdir -p ~/.m2
+{
+  echo "<settings>"
+  echo "  <servers>"
+  for id in github-spice-labs-goatrodeo github-spice-labs-ginger github-spice-labs-plugin-api github-spice-labs-ancho github; do
+    printf "    <server><id>%s</id><username>SpicyGrzl</username><password>%s</password></server>\n" "$id" "$TOKEN"
+  done
+  echo "  </servers>"
+  echo "  <profiles>"
+  echo "    <profile>"
+  echo "      <id>github</id>"
+  echo "      <repositories>"
+  echo "        <repository><id>github-spice-labs-goatrodeo</id><url>https://maven.pkg.github.com/spice-labs-inc/goatrodeo</url></repository>"
+  echo "        <repository><id>github-spice-labs-ginger</id><url>https://maven.pkg.github.com/spice-labs-inc/ginger-j</url></repository>"
+  echo "        <repository><id>github-spice-labs-plugin-api</id><url>https://maven.pkg.github.com/spice-labs-inc/spice-plugin-api</url><snapshots><enabled>true</enabled></snapshots></repository>"
+  echo "        <repository><id>github-spice-labs-ancho</id><url>https://maven.pkg.github.com/spice-labs-inc/ancho</url></repository>"
+  echo "      </repositories>"
+  echo "    </profile>"
+  echo "  </profiles>"
+  echo "  <activeProfiles><activeProfile>github</activeProfile></activeProfiles>"
+  echo "</settings>"
+} > ~/.m2/settings.xml
+if [ -n "${VERSION}" ]; then
+  mvn -B -ntp versions:set -DnewVersion="${VERSION}" -DgenerateBackupPoms=false
+fi
+mvn -B -ntp -DskipTests package
+rm -f ~/.m2/settings.xml
+SCRIPT
 
 # ---- test ------------------------------------------------------------------
 # The test target reuses the deps cache and runs `mvn verify`. Used by CI
@@ -138,7 +149,22 @@ CMD ["verify"]
 # the JFR config and wrapper scripts mirror what the install/release flow ships.
 FROM eclipse-temurin:21-jre AS spice
 ARG VERSION="unknown"
+# oras pulls OCI/Docker images by name for `spice survey image`. Baked in so no
+# host-side oras (or docker daemon) is needed. TARGETARCH selects the matching
+# release binary for multi-arch builds (linux/amd64, linux/arm64).
+ARG ORAS_VERSION=1.3.3
+ARG TARGETARCH
 WORKDIR /opt/spice-labs-cli
+
+# Install oras for image pulls. Needs a shell + download tool in the JRE image.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates tar \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL -o /tmp/oras.tar.gz \
+        "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${TARGETARCH}.tar.gz" \
+    && tar -xzf /tmp/oras.tar.gz -C /usr/local/bin oras \
+    && chmod +x /usr/local/bin/oras \
+    && rm -f /tmp/oras.tar.gz
 
 # Expose the release version to the running process (set by publish.yml; PR
 # builds default to "unknown").

--- a/README.md
+++ b/README.md
@@ -65,6 +65,32 @@ Ignoring artifacts published after 2026-01-01T00:00:00Z
 
 A pass with no cutoff surveys everything.
 
+### Image Survey
+
+Scan an OCI or Docker container image pulled by name — no need to export it to disk first.
+The image is pulled with [`oras`](https://oras.land) (baked into the container image) into an
+OCI image layout, then surveyed with the same engine as inventory:
+
+```bash
+spice survey image <image> [--subject <label>]
+```
+
+- **`image`** — OCI or Docker image reference (`name[:tag][@digest]`)
+- **`--subject <label>`** — label identifying the system being surveyed. Defaults to the
+  image reference itself, so `spice survey image nginx` tags the run as
+  `docker.io/library/nginx:latest`.
+
+Bare names are expanded to their fully-qualified form: `nginx` becomes
+`docker.io/library/nginx:latest`, and a missing tag defaults to `latest`. A host is preserved
+(`ghcr.io/spice-labs-inc/grinder:0.1.0` stays as given). The artifact cutoff applies the same
+way it does to an inventory survey.
+
+Registry credentials come from the host's Docker config: when pulling a private image, the
+wrapper mounts `$DOCKER_CONFIG` (or `~/.docker`) read-only into the container and oras reads
+it from there. If you've `docker login`ed to the registry on this machine, no extra setup is
+needed. Set `DOCKER_CONFIG` to point at an alternate config file location if your credentials
+live elsewhere.
+
 ### Runtime Survey
 
 Instrument a running JVM to detect cryptographic operations executed at runtime:
@@ -85,6 +111,12 @@ spice survey runtime <subject> --jfr -- <command>
 spice survey inventory my-app ./build/output
 spice survey inventory my-app ./artifacts/my-app.tar
 spice survey inventory my-app ./build/output --no-upload
+
+# Image survey — pull and scan an image by name
+spice survey image nginx
+spice survey image ghcr.io/spice-labs-inc/grinder:0.1.0 --no-upload
+spice survey image ubuntu@sha256:<digest> --no-upload --output ./out
+spice survey image nginx --subject my-nginx
 
 # Runtime survey — instrument a Java application
 spice survey runtime my-app --jfr -- java -jar app.jar
@@ -145,6 +177,22 @@ settings themselves, how they group, and the full precedence order.
 | `--no-upload` | Survey only, skip upload | `false` |
 | `--upload-only` | Upload previously-generated ADGs (skip survey) | `false` |
 | `--output` | Output directory for survey results | `~/.spicelabs/surveyor/` |
+| `--tag-json` | Additional JSON metadata for tags | _(none)_ |
+| `--log-level` | `debug` \| `info` \| `warn` \| `error` | `info` |
+| `--log-file` | Path to log file (output appended to both console and file) | _(none)_ |
+| `--threads` | Number of threads to use | half of available CPU cores |
+| `--max-records` | Max records to process per batch | `5000` |
+| `--chunk-size` | Target chunk size in MB for uploads | `64` |
+| `--analysis-args` | Additional analysis args in key=value format | _(none)_ |
+| `--upload-args` | Additional upload args in key=value format | _(none)_ |
+
+### Image Survey
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--subject` | Label identifying the system being surveyed | the image reference |
+| `--no-upload` | Survey only, skip upload | `false` |
+| `--output` | Output directory for the pulled layout | system temp |
 | `--tag-json` | Additional JSON metadata for tags | _(none)_ |
 | `--log-level` | `debug` \| `info` \| `warn` \| `error` | `info` |
 | `--log-file` | Path to log file (output appended to both console and file) | _(none)_ |

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -23,8 +23,9 @@
 #   export GH_TOKEN=ghp_...
 #   ./docker_build.sh
 #
-# The builder stage writes a settings.xml from $GH_TOKEN at build time. If
-# GH_TOKEN is unset, the build will fail resolving those dependencies.
+# The builder stage reads the token from a BuildKit secret mount
+# (--secret id=gh_token,env=GH_TOKEN). If GH_TOKEN is unset, the build will
+# fail resolving those dependencies.
 
 set -euo pipefail
 
@@ -64,12 +65,19 @@ if [ -z "${GH_TOKEN:-}" ]; then
   echo ""
 fi
 
+# Hand the token to the build as a BuildKit secret mount, never a build-arg,
+# so it cannot end up in image history or a layer.
+SECRET_FLAGS=()
+if [ -n "${GH_TOKEN:-}" ]; then
+  SECRET_FLAGS=(--secret id=gh_token,env=GH_TOKEN)
+fi
+
 # --- build helpers ------------------------------------------------------------
 
 build_oss() {
   echo "📦 Building OSS image: ${OSS_IMAGE}:${TAG}"
   docker build \
-    --build-arg GH_TOKEN="${GH_TOKEN:-}" \
+    ${SECRET_FLAGS[@]+${SECRET_FLAGS[@]}} \
     -t "${OSS_IMAGE}:${TAG}" \
     --target spice \
     .
@@ -118,7 +126,7 @@ case "${TARGET}" in
   spice|deps|builder|test)
     # Raw Dockerfile targets (no enterprise/federal layering)
     docker build \
-      --build-arg GH_TOKEN="${GH_TOKEN:-}" \
+      ${SECRET_FLAGS[@]+${SECRET_FLAGS[@]}} \
       -t "${OSS_IMAGE}:${TAG}" \
       --target "${TARGET}" \
       . && echo "Successfully built ${OSS_IMAGE}:${TAG} (target: ${TARGET})"

--- a/spice
+++ b/spice
@@ -574,6 +574,23 @@ O spice/survey/runtime --help flag
 O spice/survey/runtime -V flag
 O spice/survey/runtime --version flag
 P spice/survey/runtime 0 value
+C spice/survey/image
+O spice/survey/image --subject value
+O spice/survey/image --output value path create=self
+O spice/survey/image --no-upload flag
+O spice/survey/image --tag-json value
+O spice/survey/image --threads value
+O spice/survey/image --max-records value
+O spice/survey/image --chunk-size value
+O spice/survey/image --log-level value
+O spice/survey/image --log-file value hostonly
+O spice/survey/image --analysis-args value
+O spice/survey/image --upload-args value
+O spice/survey/image -h flag
+O spice/survey/image --help flag
+O spice/survey/image -V flag
+O spice/survey/image --version flag
+P spice/survey/image 0 value
 C spice/pass
 O spice/pass -h flag
 O spice/pass --help flag
@@ -748,6 +765,39 @@ IS_RUNTIME_SURVEY=0
     [ "$arg" = "survey" ] && saw_survey=1 || saw_survey=0
   done
 }
+
+# ── Image survey detection (must happen before general arg parsing) ────────
+# `survey image` pulls the image with oras inside the container; oras reads the
+# Docker credential file (DOCKER_CONFIG/config.json, else ~/.docker/config.json)
+# for registry auth, so the host's credentials must ride into the container.
+
+IS_IMAGE_SURVEY=0
+{
+  saw_survey=0
+  for arg in "$@"; do
+    if [ "$saw_survey" = "1" ] && [ "$arg" = "image" ]; then
+      IS_IMAGE_SURVEY=1
+      break
+    fi
+    [ "$arg" = "survey" ] && saw_survey=1 || saw_survey=0
+  done
+}
+
+# Resolve the host's docker config dir (DOCKER_CONFIG, else ~/.docker) and mount
+# it read-only when it exists. Skip silently when absent — public registries need
+# nothing; private ones then fail inside oras with a clear auth error instead of
+# a missing-mount one.
+DOCKER_CONFIG_HOST=""
+DOCKER_AUTH_ARGS=()
+if [ "$IS_IMAGE_SURVEY" = "1" ]; then
+  DOCKER_CONFIG_HOST="${DOCKER_CONFIG:-${HOME:-}/.docker}"
+  if [ -f "${DOCKER_CONFIG_HOST}/config.json" ]; then
+    DOCKER_AUTH_ARGS=(
+      "-v" "${DOCKER_CONFIG_HOST}:/mnt/spice/docker-config:ro"
+      "-e" "DOCKER_CONFIG=/mnt/spice/docker-config"
+    )
+  fi
+fi
 
 if [ "$IS_RUNTIME_SURVEY" = "1" ]; then
   # Parse runtime survey args ourselves — split at "--" into CLI flags + user command.
@@ -1043,6 +1093,7 @@ exec docker run --rm \
   --network host \
   ${PULL_FLAG:+$PULL_FLAG} \
   ${SPICE_DOCKER_FLAGS:+$SPICE_DOCKER_FLAGS} \
+  ${DOCKER_AUTH_ARGS[@]+"${DOCKER_AUTH_ARGS[@]}"} \
   ${MF_VOLUMES[@]+"${MF_VOLUMES[@]}"} \
   ${WORKDIR_FLAG[@]+"${WORKDIR_FLAG[@]}"} \
   -e SPICE_PASS \

--- a/spice.ps1
+++ b/spice.ps1
@@ -537,6 +537,23 @@ O spice/survey/runtime --help flag
 O spice/survey/runtime -V flag
 O spice/survey/runtime --version flag
 P spice/survey/runtime 0 value
+C spice/survey/image
+O spice/survey/image --subject value
+O spice/survey/image --output value path create=self
+O spice/survey/image --no-upload flag
+O spice/survey/image --tag-json value
+O spice/survey/image --threads value
+O spice/survey/image --max-records value
+O spice/survey/image --chunk-size value
+O spice/survey/image --log-level value
+O spice/survey/image --log-file value hostonly
+O spice/survey/image --analysis-args value
+O spice/survey/image --upload-args value
+O spice/survey/image -h flag
+O spice/survey/image --help flag
+O spice/survey/image -V flag
+O spice/survey/image --version flag
+P spice/survey/image 0 value
 C spice/pass
 O spice/pass -h flag
 O spice/pass --help flag
@@ -688,6 +705,30 @@ for ($i = 0; $i -lt $args.Count - 1; $i++) {
   if ($args[$i] -eq 'survey' -and $args[$i + 1] -eq 'runtime') {
     $isRuntimeSurvey = $true
     break
+  }
+}
+
+# ── Image survey detection + docker-config mount ────────────────────────────
+# `survey image` pulls the image with oras inside the container; oras reads the
+# Docker credential file (DOCKER_CONFIG/config.json, else ~/.docker/config.json)
+# for registry auth, so the host's credentials must ride into the container.
+$isImageSurvey = $false
+for ($i = 0; $i -lt $args.Count - 1; $i++) {
+  if ($args[$i] -eq 'survey' -and $args[$i + 1] -eq 'image') {
+    $isImageSurvey = $true
+    break
+  }
+}
+
+# Mount the host's docker config dir read-only when it exists. Skip silently when
+# absent — public registries need nothing; private ones then fail inside oras
+# with a clear auth error instead of a missing-mount one.
+$dockerAuthArgs = @()
+if ($isImageSurvey) {
+  $dockerConfigHost = if ($env:DOCKER_CONFIG) { $env:DOCKER_CONFIG } else { Join-Path $HOME '.docker' }
+  if (Test-Path (Join-Path $dockerConfigHost 'config.json')) {
+    $dockerAuthArgs += "-v"; $dockerAuthArgs += "$dockerConfigHost`:/mnt/spice/docker-config:ro"
+    $dockerAuthArgs += "-e"; $dockerAuthArgs += "DOCKER_CONFIG=/mnt/spice/docker-config"
   }
 }
 
@@ -972,6 +1013,7 @@ docker run --rm `
   @userFlag `
   @pullFlag @dockerFlags `
   --network host `
+  @dockerAuthArgs `
   @volumes `
   @workdirFlag `
   -e "SPICE_PASS=$spicePass" `

--- a/src/main/java/io/spicelabs/cli/ImageReference.java
+++ b/src/main/java/io/spicelabs/cli/ImageReference.java
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.cli;
+
+/**
+ * Normalizes a user-supplied OCI/Docker image reference into the fully-qualified form
+ * {@code oras} accepts.
+ *
+ * <p>oras is permissive about media types but strict about references: it needs an explicit
+ * tag or digest and (for the public default registry) an explicit {@code docker.io} host.
+ * Writing {@code docker.io/library/nginx:latest} is the convention Docker CLI users expect,
+ * so this turns a bare {@code nginx}, {@code nginx:1.25}, or {@code user/app:tag} into it.
+ */
+final class ImageReference {
+
+  private ImageReference() {}
+
+  /**
+   * Expand a reference to the full {@code registry/path:tag} or {@code registry/path@digest}
+   * form. A leading host is kept; a bare hostless name becomes {@code docker.io/library/...};
+   * a {@code user/app} (one slash, no host) becomes {@code docker.io/user/app}. A missing
+   * tag defaults to {@code latest}; a digest is always preserved verbatim.
+   *
+   * @throws IllegalArgumentException if the reference cannot be parsed
+   */
+  static String normalize(String ref) {
+    if (ref == null || ref.isBlank()) {
+      throw new IllegalArgumentException("Image reference must not be blank");
+    }
+    String value = ref.trim();
+
+    String digest = null;
+    int at = value.indexOf('@');
+    if (at >= 0) {
+      digest = value.substring(at + 1);
+      value = value.substring(0, at);
+      if (digest.isBlank()) {
+        throw new IllegalArgumentException("Image digest must not be blank: " + ref);
+      }
+    }
+
+    // Split off a trailing :tag only if it is not a registry port (localhost:5000/...).
+    String tag = null;
+    String name = value;
+    int colon = value.lastIndexOf(':');
+    int slash = value.lastIndexOf('/');
+    if (colon > slash) {
+      tag = value.substring(colon + 1);
+      name = value.substring(0, colon);
+      if (tag.isBlank()) {
+        throw new IllegalArgumentException("Image tag must not be blank: " + ref);
+      }
+    }
+    if (name.isBlank()) {
+      throw new IllegalArgumentException("Image name must not be blank: " + ref);
+    }
+
+    String host;
+    String path;
+    int firstSlash = name.indexOf('/');
+    if (firstSlash < 0) {
+      // Bare single-component name -> docker.io/library/<name>
+      host = "docker.io";
+      path = "library/" + name;
+    } else if (looksLikeHost(name.substring(0, firstSlash))) {
+      host = name.substring(0, firstSlash);
+      path = name.substring(firstSlash + 1);
+    } else {
+      // e.g. user/app or namespace/name -> docker.io + the given path
+      host = "docker.io";
+      path = name;
+    }
+    if (path.isBlank()) {
+      throw new IllegalArgumentException("Image repository must not be blank: " + ref);
+    }
+
+    StringBuilder out = new StringBuilder(host).append('/').append(path);
+    if (digest != null) {
+      out.append('@').append(digest);
+    } else {
+      out.append(':').append(tag == null ? "latest" : tag);
+    }
+    return out.toString();
+  }
+
+  /**
+   * A leading path component is a registry host iff it contains a dot, shortens to
+   * {@code localhost}, or carries a port (e.g. {@code localhost:5000}).
+   */
+  private static boolean looksLikeHost(String component) {
+    return component.contains(".") || component.contains(":")
+        || "localhost".equalsIgnoreCase(component);
+  }
+}

--- a/src/main/java/io/spicelabs/cli/SpiceLabsCLI.java
+++ b/src/main/java/io/spicelabs/cli/SpiceLabsCLI.java
@@ -191,7 +191,7 @@ public class SpiceLabsCLI implements Runnable {
 
   /** Known survey type names, including those only available in enterprise/federal. */
   private static final java.util.Set<String> KNOWN_SURVEY_TYPES =
-      java.util.Set.of("inventory", "runtime", "static");
+      java.util.Set.of("inventory", "runtime", "static", "image");
 
   private static boolean isKnownSurveyType(String arg) {
     return KNOWN_SURVEY_TYPES.contains(arg);

--- a/src/main/java/io/spicelabs/cli/SurveyCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyCommand.java
@@ -32,11 +32,13 @@ import picocli.CommandLine.UnmatchedArgumentException;
     subcommands = {
         SurveyInventoryCommand.class,
         SurveyRuntimeCommand.class,
+        SurveyImageCommand.class,
     },
     footer = {
         "",
         "Examples:",
         "  spice survey inventory my-app ./build/libs",
+        "  spice survey image my-app nginx",
         "  spice survey runtime my-app --jfr -- java -jar app.jar",
         "",
         "Run 'spice survey <type> --help' for per-subcommand details.",

--- a/src/main/java/io/spicelabs/cli/SurveyImageCommand.java
+++ b/src/main/java/io/spicelabs/cli/SurveyImageCommand.java
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.cli;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/**
+ * Pull an OCI or Docker image by name and survey its contents.
+ *
+ * <p>The image is pulled with {@code oras} (baked into the container image) into an OCI
+ * image layout, and that layout directory is handed to the same inventory survey machinery
+ * as {@code survey inventory} — so upload, cutoff, progress reporting and all the shared
+ * options behave identically.
+ *
+ * <p>Usage:
+ *   spice survey image &lt;image&gt; [--subject &lt;label&gt;] [options]
+ */
+@Command(
+    name = "image",
+    description = "Survey an OCI or Docker image pulled by name",
+    mixinStandardHelpOptions = true,
+    footer = {
+        "",
+        "Examples:",
+        "  # Survey the latest nginx image and upload",
+        "  spice survey image nginx",
+        "",
+        "  # Survey a tagged image from a specific registry, skip upload",
+        "  spice survey image ghcr.io/spice-labs-inc/grinder:0.1.0 --no-upload",
+        "",
+        "  # Survey by digest, write output to ./out",
+        "  spice survey image ubuntu@sha256:... --no-upload --output ./out",
+        "",
+        "  # Label the survey instead of using the image name",
+        "  spice survey image nginx --subject my-nginx",
+        "",
+        "The image reference may use any form oras accepts. A bare name such as",
+        "'nginx' is expanded to 'docker.io/library/nginx:latest'. SPICE_PASS must be",
+        "set in the environment for upload.",
+        ""
+    }
+)
+public class SurveyImageCommand implements java.util.concurrent.Callable<Integer> {
+
+  private static final Logger log = LoggerFactory.getLogger(SurveyImageCommand.class);
+
+  @Parameters(index = "0", description = "OCI or Docker image reference (name[:tag][@digest])")
+  String image;
+
+  @Option(
+      names = "--subject",
+      paramLabel = "LABEL",
+      description =
+          "Label identifying the system being surveyed (default: the image reference)"
+  )
+  String subject;
+
+  @Option(names = "--output", description = "Output directory for survey results")
+  Path output;
+
+  @Option(names = "--no-upload", description = "Survey only, skip upload")
+  boolean noUpload;
+
+  @Option(names = "--tag-json", description = "Additional JSON metadata for tags")
+  String tagJson;
+
+  @Option(names = "--threads", description = "Number of threads to use (default: half of available CPU cores)")
+  Integer threads;
+
+  @Option(names = "--max-records", description = "Max records to process per batch (default: 5000)")
+  int maxRecords = 5000;
+
+  @Option(names = "--chunk-size", description = "Target chunk size in MB for uploads (default: 64)")
+  Integer chunkSizeMB;
+
+  @Option(names = "--log-level", description = "Log level: debug|info|warn|error (default: info)")
+  String logLevel;
+
+  @Option(names = "--log-file", description = "Path to log file (output appended to both console and file)")
+  String logFile;
+
+  @Option(
+      names = "--analysis-args",
+      description = "Additional analysis args in key=value format",
+      split = ","
+  )
+  List<String> goatRodeoArgsRaw;
+
+  @Option(
+      names = "--upload-args",
+      description = "Additional upload args in key=value format",
+      split = ","
+  )
+  List<String> gingerArgsRaw;
+
+  @Override
+  public Integer call() throws Exception {
+    try {
+      return run();
+    } catch (IllegalArgumentException ex) {
+      log.error("❌ {}", ex.getMessage());
+      log.info("Use --help for usage information.");
+      return 1;
+    } catch (Exception ex) {
+      log.error("❌ {}", ex.getMessage());
+      if (log.isDebugEnabled()) {
+        log.error("Stack trace:", ex);
+      }
+      return 1;
+    }
+  }
+
+  /**
+   * Pull the image and delegate the survey to {@link SurveyInventoryCommand}. The layout
+   * is pulled into a temporary directory beside the output base, and removed once the
+   * survey and upload have run.
+   */
+  int run() throws Exception {
+    log.info("🌶️  Spice Labs Surveyor CLI v{}", SpiceLabsCLI.VersionProvider.getVersionString());
+
+    if (image == null || image.isBlank()) {
+      throw new IllegalArgumentException("No image reference given.");
+    }
+
+    String ref = ImageReference.normalize(image);
+    log.info("📦 Pulling image {} ...", ref);
+
+    // The layout is transient scratch, deleted once the survey has read it. Put it under
+    // --output when given (that path is mounted into the container, so it is writable and
+    // keeps large layer pulls off /tmp); otherwise use the JVM temp dir, which always is.
+    Path base = output != null ? output : Paths.get(System.getProperty("java.io.tmpdir", "/tmp"));
+    Files.createDirectories(base);
+    Path layoutDir = Files.createTempDirectory(base, "image-layout-");
+    try {
+      pull(ref, layoutDir);
+      return survey(ref, layoutDir);
+    } finally {
+      deleteRecursively(layoutDir);
+    }
+  }
+
+  /**
+   * Invoke {@code oras} to copy the image into an OCI image layout under {@code layoutDir}.
+   * A non-zero exit aborts the run — an image that could not be pulled must not be silently
+   * surveyed as empty or stale content.
+   */
+  void pull(String ref, Path layoutDir) throws Exception {
+    ProcessBuilder pb = new ProcessBuilder(
+        "oras", "cp", "--to-oci-layout", ref, layoutDir.resolve("layout.oci").toString());
+    pb.redirectErrorStream(true);
+    Process proc;
+    try {
+      proc = pb.start();
+    } catch (IOException ex) {
+      throw new IllegalArgumentException(
+          "Could not start `oras`: " + ex.getMessage()
+              + ". The CLI container image must include oras.");
+    }
+    String output = new String(proc.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    int exit = proc.waitFor();
+    if (exit != 0) {
+      throw new IllegalArgumentException(
+          "Failed to pull image (" + ref + "), oras exited " + exit + ":\n" + output);
+    }
+  }
+
+  /**
+   * The survey label. Defaults to the normalized image reference so {@code survey image
+   * nginx} tags the run with {@code docker.io/library/nginx:latest} unless the caller
+   * overrides it with {@code --subject}.
+   */
+  String effectiveSubject(String ref) {
+    if (subject != null && !subject.isBlank()) {
+      return subject;
+    }
+    return ref;
+  }
+
+  /**
+   * Run the shared inventory survey + upload pipeline against the pulled layout directory.
+   * The inventory command owns registration, cutoff, progress, and upload; this just points
+   * its {@code input} at the OCI layout.
+   */
+  int survey(String ref, Path layoutDir) throws Exception {
+    SurveyInventoryCommand inventory = new SurveyInventoryCommand();
+    inventory.subject = effectiveSubject(ref);
+    inventory.input = layoutDir.resolve("layout.oci");
+    inventory.output = output;
+    inventory.noUpload = noUpload;
+    inventory.tagJson = tagJson;
+    inventory.threads = threads;
+    inventory.maxRecords = maxRecords;
+    inventory.chunkSizeMB = chunkSizeMB;
+    inventory.logLevel = logLevel;
+    inventory.logFile = logFile;
+    inventory.goatRodeoArgsRaw = goatRodeoArgsRaw;
+    inventory.gingerArgsRaw = gingerArgsRaw;
+    return inventory.call();
+  }
+
+  static void deleteRecursively(Path path) {
+    SurveyInventoryCommand.deleteRecursively(path);
+  }
+}

--- a/src/test/java/io/spicelabs/cli/ImageReferenceTest.java
+++ b/src/test/java/io/spicelabs/cli/ImageReferenceTest.java
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
+
+package io.spicelabs.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class ImageReferenceTest {
+
+  @Test
+  void bareNameBecomesDockerLibraryLatest() {
+    assertEquals("docker.io/library/nginx:latest", ImageReference.normalize("nginx"));
+  }
+
+  @Test
+  void bareNameWithTag() {
+    assertEquals("docker.io/library/nginx:1.25", ImageReference.normalize("nginx:1.25"));
+  }
+
+  @Test
+  void userScopedNameMapsToDockerIo() {
+    assertEquals("docker.io/spicelabs/grinder:latest", ImageReference.normalize("spicelabs/grinder"));
+  }
+
+  @Test
+  void hostIsPreserved() {
+    assertEquals("ghcr.io/spice-labs-inc/grinder:0.1.0",
+        ImageReference.normalize("ghcr.io/spice-labs-inc/grinder:0.1.0"));
+  }
+
+  @Test
+  void hostNameWithoutTagGetsLatest() {
+    assertEquals("docker.io/library/ubuntu:latest", ImageReference.normalize("ubuntu"));
+  }
+
+  @Test
+  void explicitDockerLoopbackHostIsPreserved() {
+    assertEquals("localhost:5000/myapp:latest", ImageReference.normalize("localhost:5000/myapp"));
+  }
+
+  @Test
+  void digestIsPreservedVerbatim() {
+    assertEquals("docker.io/library/ubuntu@sha256:abc123",
+        ImageReference.normalize("ubuntu@sha256:abc123"));
+  }
+
+  @Test
+  void digestWithHostPreserved() {
+    assertEquals("ghcr.io/org/img@sha256:xyz",
+        ImageReference.normalize("ghcr.io/org/img@sha256:xyz"));
+  }
+
+  @Test
+  void explicitDockerIoIsNotReExpanded() {
+    assertEquals("docker.io/library/alpine:3.19",
+        ImageReference.normalize("docker.io/library/alpine:3.19"));
+  }
+
+  @Test
+  void portOnlyInFirstComponentIsNotATag() {
+    // localhost:5000 is a registry port; the tag parser must not grab it.
+    assertEquals("localhost:5000/app:v2", ImageReference.normalize("localhost:5000/app:v2"));
+  }
+
+  @Test
+  void blankReferenceRejected() {
+    assertThrows(IllegalArgumentException.class, () -> ImageReference.normalize("  "));
+    assertThrows(IllegalArgumentException.class, () -> ImageReference.normalize(null));
+  }
+
+  @Test
+  void blankDigestRejected() {
+    assertThrows(IllegalArgumentException.class, () -> ImageReference.normalize("ubuntu@"));
+  }
+
+  @Test
+  void whitespaceIsTrimmed() {
+    assertEquals("docker.io/library/nginx:latest", ImageReference.normalize("  nginx  "));
+  }
+}

--- a/src/test/java/io/spicelabs/cli/SurveyImageCommandTest.java
+++ b/src/test/java/io/spicelabs/cli/SurveyImageCommandTest.java
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright 2025-26 Spice Labs, Inc. & Contributors */
+
+package io.spicelabs.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Guards the delegation boundary: {@code survey image} must pull an OCI layout and then hand
+ * that layout to the shared inventory survey. The {@code pull} seam is overridden so the
+ * test exercises layout creation + the inventory handoff without needing a daemon or network.
+ */
+class SurveyImageCommandTest {
+
+  @TempDir
+  Path tempDir;
+
+  /**
+   * {@code pull} and {@code survey} are write seams. {@code run()} creates the layout dir,
+   * calls {@code pull} into it, and passes the resulting {@code layout.oci} to {@code survey}.
+   */
+  @Test
+  void runCreatesLayoutAndTriggersPullAndSurvey() throws Exception {
+    Path marker = tempDir.resolve("marker");
+    Path[] pullLayout = new Path[1];
+    Path[] surveyLayout = new Path[1];
+    SurveyImageCommand cmd = new SurveyImageCommand() {
+      @Override
+      void pull(String ref, Path layoutDir) throws Exception {
+        Files.writeString(marker, ref);
+        pullLayout[0] = layoutDir;
+        // Simulate what oras leaves behind: an OCI layout dir under the base.
+        Files.createDirectories(layoutDir.resolve("layout.oci"));
+      }
+
+      @Override
+      int survey(String ref, Path layoutDir) {
+        surveyLayout[0] = layoutDir;
+        return 0;
+      }
+    };
+    cmd.subject = "my-app";
+    cmd.image = "nginx";
+
+    int rc = cmd.run();
+    assertEquals(0, rc);
+    assertEquals("docker.io/library/nginx:latest", Files.readString(marker),
+        "pull must be called with the normalized ref");
+    assertNotNull(surveyLayout[0], "survey must receive the pulled layout dir");
+    assertEquals(pullLayout[0], surveyLayout[0],
+        "survey must receive the same layout dir pull populated");
+  }
+
+  /** Without {@code --subject}, the survey is tagged with the normalized image ref. */
+  @Test
+  void subjectDefaultsToImageRef() {
+    SurveyImageCommand cmd = new SurveyImageCommand();
+    cmd.image = "nginx";
+    assertEquals("docker.io/library/nginx:latest",
+        cmd.effectiveSubject("docker.io/library/nginx:latest"));
+  }
+
+  /** {@code --subject} overrides the ref-derived tag. */
+  @Test
+  void subjectOptionOverridesImageRef() {
+    SurveyImageCommand cmd = new SurveyImageCommand();
+    cmd.subject = "my-app";
+    assertEquals("my-app", cmd.effectiveSubject("docker.io/library/nginx:latest"));
+  }
+
+  /**
+   * A failed pull (non-zero oras exit) must fail the run rather than survey stale/empty
+   * content.
+   */
+  @Test
+  void failedPullFailsRun() throws Exception {
+    SurveyImageCommand cmd = new SurveyImageCommand() {
+      @Override
+      void pull(String ref, Path layoutDir) throws Exception {
+        throw new IllegalArgumentException("Failed to pull image (" + ref + "), oras exited 1");
+      }
+    };
+    cmd.subject = "my-app";
+    cmd.image = "nginx";
+
+    int rc = cmd.call();
+    assertTrue(rc == 1, "a failed pull must yield a non-zero exit, got " + rc);
+  }
+
+  /**
+   * The layout directory is cleaned up after the run regardless of outcome.
+   */
+  @Test
+  void layoutDirIsCleanedUp() throws Exception {
+    Path base = tempDir.resolve("out");
+    Files.createDirectories(base);
+    SurveyImageCommand cmd = new SurveyImageCommand() {
+      @Override
+      void pull(String ref, Path layoutDir) throws Exception {
+        Files.createDirectories(layoutDir.resolve("layout.oci"));
+      }
+
+      @Override
+      int survey(String ref, Path layoutDir) {
+        return 0;
+      }
+    };
+    cmd.subject = "my-app";
+    cmd.image = "nginx";
+    cmd.output = base;
+
+    try (var dirs = Files.list(base)) {
+      long before = dirs.filter(p -> p.getFileName().toString().startsWith("image-layout-"))
+          .count();
+      assertTrue(before == 0, "layout dirs are created fresh, got " + before);
+    }
+
+    cmd.run();
+
+    try (var dirs = Files.list(base)) {
+      long after = dirs.filter(p -> p.getFileName().toString().startsWith("image-layout-"))
+          .count();
+      assertTrue(after == 0, "layout dirs must be cleaned up after the run, got " + after);
+    }
+  }
+}

--- a/src/test/java/io/spicelabs/cli/WrapperParityTest.java
+++ b/src/test/java/io/spicelabs/cli/WrapperParityTest.java
@@ -202,6 +202,39 @@ class WrapperParityTest {
     assertParityOrBashOnly("pass", "decode");
   }
 
+  // ── survey image (oras pull) ────────────────────────────────────────────────
+
+  /**
+   * `survey image` mounts the host docker config so oras inside the container can
+   * authenticate to private registries (e.g. GHCR). The binned image ref is a bare
+   * String positional; the docker-config mount is wrapper logic, not a manifest path.
+   */
+  @Test
+  void surveyImageMountsDockerConfig() throws Exception {
+    Path cfgDir = Files.createTempDirectory("parity-dockercfg");
+    Files.writeString(cfgDir.resolve("config.json"), "{\"auths\":{\"ghcr.io\":{}}}");
+
+    String args = assertParityOrBashOnly(Map.of("DOCKER_CONFIG", cfgDir.toString()),
+        "survey", "image", "ghcr.io/spice-labs-inc/grinder:0.1.0", "--no-upload");
+
+    assertTrue(args.contains(cfgDir.toAbsolutePath() + ":/mnt/spice/docker-config:ro"),
+        "docker config must be mounted read-only: " + args);
+  }
+
+  /** Without a config.json, the mount is omitted and the ref passes through untouched. */
+  @Test
+  void surveyImageWithoutDockerConfig() throws Exception {
+    Path emptyCfg = Files.createTempDirectory("parity-dockercfg-empty");
+
+    String args = assertParityOrBashOnly(Map.of("DOCKER_CONFIG", emptyCfg.toString()),
+        "survey", "image", "alpine:latest", "--no-upload");
+
+    assertFalse(args.contains("/mnt/spice/docker-config"),
+        "no config.json means no mount: " + args);
+    assertTrue(args.contains("survey image alpine:latest"),
+        "the bare ref must pass through untouched: " + args);
+  }
+
   @Test
   void version() throws Exception {
     assertParityOrBashOnly("--version");
@@ -321,10 +354,15 @@ class WrapperParityTest {
    * If pwsh is not available, only test bash.
    */
   private String assertParityOrBashOnly(String... cliArgs) throws Exception {
-    String bashDockerArgs = normalizeDockerArgs(runWrapper("bash", cliArgs));
+    return assertParityOrBashOnly(Map.of(), cliArgs);
+  }
+
+  private String assertParityOrBashOnly(Map<String, String> extraEnv, String... cliArgs)
+      throws Exception {
+    String bashDockerArgs = normalizeDockerArgs(runWrapper("bash", extraEnv, cliArgs));
 
     if (hasPwsh) {
-      String pwshDockerArgs = normalizeDockerArgs(runWrapper("pwsh", cliArgs));
+      String pwshDockerArgs = normalizeDockerArgs(runWrapper("pwsh", extraEnv, cliArgs));
       assertEquals(bashDockerArgs, pwshDockerArgs,
           "Bash and PowerShell wrappers produced different docker args for: " +
               String.join(" ", cliArgs));
@@ -369,6 +407,11 @@ class WrapperParityTest {
    * Returns the captured docker arguments as a single string.
    */
   private String runWrapper(String shell, String... cliArgs) throws Exception {
+    return runWrapper(shell, Map.of(), cliArgs);
+  }
+
+  private String runWrapper(String shell, Map<String, String> extraEnv, String... cliArgs)
+      throws Exception {
     Path mockBin = Files.createTempDirectory("mock-docker-" + shell);
     Path argsFile = Files.createTempFile("docker-args-" + shell, ".txt");
 
@@ -411,6 +454,9 @@ class WrapperParityTest {
     // the captured args and make the result depend on whatever image is on the machine.
     // Tests supply their manifest explicitly instead.
     pb.environment().put("SPICE_SKIP_MANIFEST_REFRESH", "1");
+    for (Map.Entry<String, String> e : extraEnv.entrySet()) {
+      pb.environment().put(e.getKey(), e.getValue());
+    }
     if (manifestFile != null) {
       pb.environment().put("SPICE_PATH_MANIFEST", manifestFile.toString());
     }


### PR DESCRIPTION
Bake oras into the Docker image (TARGETARCH-aware, 1.3.3), so the CLI container can pull OCI/Docker images by name without a host-side oras or docker daemon. Enterprise/federal images inherit it from the OSS base.

Add `spice survey image <subject> <image>`: normalizes the reference (nginx -> docker.io/library/nginx:latest, hosts/digests preserved), pulls it into an OCI image layout via `oras cp --to-oci-layout`, and hands the layout directory to the shared inventory survey pipeline (registration, artifact cutoff, upload all identical to inventory).

goatrodeo content-detects the gzip layer blobs generically, so the raw OCI layout scans without a docker-save manifest.json.

Path-manifest blocks for the new command are spliced into spice and spice.ps1; regenerate with scripts/update-path-manifest.sh when dep access is available to confirm.
